### PR TITLE
docs: add OpenClaw coverage map front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Persistent mounts: `./data` → `/data`, `./config` → `/config`
 |-----|------|
 | [`docs/INDEX.md`](docs/INDEX.md) | Docs front door by audience and concern |
 | [`rune-plan.md`](rune-plan.md) | Canonical strategy, goals, stack direction |
+| [`docs/OPENCLAW-COVERAGE-MAP.md`](docs/OPENCLAW-COVERAGE-MAP.md) | Docs front door for OpenClaw parity coverage |
 | [`PARITY-INVENTORY.md`](docs/PARITY-INVENTORY.md) | OpenClaw feature parity map |
 | [`AZURE-COMPATIBILITY.md`](docs/AZURE-COMPATIBILITY.md) | Azure integration contract |
 | [`DOCKER-DEPLOYMENT.md`](docs/DOCKER-DEPLOYMENT.md) | Docker deployment model |

--- a/docs/IMPLEMENTATION-PHASES.md
+++ b/docs/IMPLEMENTATION-PHASES.md
@@ -2,6 +2,8 @@
 
 This plan sequences the rewrite so parity can be proven incrementally.
 
+For the OpenClaw-surface navigation view, see [`OPENCLAW-COVERAGE-MAP.md`](OPENCLAW-COVERAGE-MAP.md).
+
 The rule is simple:
 
 - do not build broad feature surface before the contracts are frozen

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@ Use it to find the right source of truth by audience and concern.
 | Parity execution phases | [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) | phase sequencing and acceptance criteria |
 | Live execution queue | GitHub Project 2 | what is active now |
 | Runtime orchestration rules | [`AGENT-ORCHESTRATION.md`](AGENT-ORCHESTRATION.md) | agent workflow and execution guardrails |
+| Parity docs front door | [`OPENCLAW-COVERAGE-MAP.md`](OPENCLAW-COVERAGE-MAP.md) | where to start for OpenClaw-surface coverage and parity navigation |
 | Parity contracts | [`PARITY-SPEC.md`](PARITY-SPEC.md), [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md), [`PROTOCOLS.md`](PROTOCOLS.md) | observable runtime behavior and subsystem invariants |
 | Operator deployment/runtime docs | [`DOCKER-DEPLOYMENT.md`](DOCKER-DEPLOYMENT.md), [`DATABASES.md`](DATABASES.md), [`OPERATOR-POLICY.md`](OPERATOR-POLICY.md) | deployment, storage, health, operational rules |
 | Contributor/reference docs | [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md), [`SUBSYSTEMS.md`](SUBSYSTEMS.md), [`FUNCTIONALITY-CHECKLIST.md`](FUNCTIONALITY-CHECKLIST.md) | implementation reference and verification detail |

--- a/docs/OPENCLAW-COVERAGE-MAP.md
+++ b/docs/OPENCLAW-COVERAGE-MAP.md
@@ -1,0 +1,55 @@
+# OpenClaw Coverage Map
+
+> Status: active parity-navigation document.
+>
+> Use this file to answer: "which Rune document or artifact proves coverage for this part of OpenClaw?"
+>
+> This file is a navigation map, not the exhaustive parity inventory.
+> - Use [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md) for the full surface census.
+> - Use [`PARITY-SPEC.md`](PARITY-SPEC.md) for the release rule.
+> - Use [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md) and [`PROTOCOLS.md`](PROTOCOLS.md) for subsystem invariants.
+> - Use [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) for sequencing and acceptance criteria.
+> - Use GitHub Project 2 and issue comments for live execution state.
+
+## Relationship to the planning docs
+
+| Question | Canonical source |
+|---|---|
+| What is Rune trying to become? | [`../rune-plan.md`](../rune-plan.md) |
+| What parity phases exist and what must each phase prove? | [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) |
+| What OpenClaw surfaces must be covered overall? | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md) |
+| Where do I start if I need the parity-related docs front door? | `OPENCLAW-COVERAGE-MAP.md` |
+
+## Coverage map by surface
+
+| OpenClaw surface | Primary Rune coverage doc(s) | Use when you need |
+|---|---|---|
+| CLI commands and operator workflows | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`FUNCTIONALITY-CHECKLIST.md`](FUNCTIONALITY-CHECKLIST.md) | command-family parity and evidence status |
+| Gateway / daemon / control plane | [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md), [`PROTOCOLS.md`](PROTOCOLS.md), [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) | runtime behavior and phase acceptance criteria |
+| Sessions / turns / transcripts | [`PROTOCOLS.md`](PROTOCOLS.md), [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md) | state model and behavioral invariants |
+| Tools / approvals / process execution | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md) | tool-surface coverage and gating behavior |
+| Scheduler / reminders / heartbeat | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) | automation semantics and sequencing |
+| Memory / retrieval | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md), GitHub Project 2 Phase 20 lanes | memory surface and active implementation state |
+| Channels / adapters / messaging | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`PROTOCOLS.md`](PROTOCOLS.md), crate-level channel tests | adapter behavior and inbound/outbound semantics |
+| Media / browser / OCR / TTS / STT | [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md), [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md) | adjacent parity surfaces and phase placement |
+| Config / secrets / precedence | [`PROTOCOLS.md`](PROTOCOLS.md), [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md), operator docs | runtime config behavior and operator-facing expectations |
+| Deployment / Docker / persistence | [`DOCKER-DEPLOYMENT.md`](DOCKER-DEPLOYMENT.md), [`DATABASES.md`](DATABASES.md), [`PARITY-SPEC.md`](PARITY-SPEC.md) | persistent storage model and deployment contract |
+| Admin UI / operator visibility | [`FUNCTIONALITY-CHECKLIST.md`](FUNCTIONALITY-CHECKLIST.md), relevant feature issues/PRs | visibility, diagnostics, and UI-facing evidence |
+
+## How to use this file
+
+1. Start here if you know the OpenClaw surface but not the right Rune doc.
+2. Jump to the primary coverage doc for that surface.
+3. Use GitHub Project 2 and issue comments to find the current active implementation slice.
+4. Use `FUNCTIONALITY-CHECKLIST.md` when you need the implementation/evidence view rather than the planning view.
+
+## Non-goal
+
+This file is not intended to replace:
+
+- the exhaustive parity inventory
+- the phase acceptance document
+- the live GitHub execution queue
+- the strategy/positioning docs
+
+It exists to keep those surfaces connected and discoverable.

--- a/rune-plan.md
+++ b/rune-plan.md
@@ -13,6 +13,7 @@
 |---|---|---|
 | Product strategy | `rune-plan.md` | Goals, constraints, product shape, stack direction |
 | Parity execution phases | `docs/IMPLEMENTATION-PHASES.md` | Acceptance criteria and sequencing rules |
+| OpenClaw coverage navigation | `docs/OPENCLAW-COVERAGE-MAP.md` | Front door from OpenClaw surfaces to the right parity docs |
 | Live execution state | GitHub Project 2 | Current epics, features, stories, and batch progress |
 | Runtime orchestration rules | `docs/AGENT-ORCHESTRATION.md` | Agent workflow and implementation guardrails |
 | Detailed parity contracts | `docs/PARITY-SPEC.md`, `docs/PARITY-CONTRACTS.md`, `docs/PROTOCOLS.md` | Subsystem invariants and observable behavior |


### PR DESCRIPTION
## Summary
- add the missing OpenClaw parity/docs navigation file
- wire it into the docs front door, canonical plan, and implementation phases
- keep the wider docs restructure out of scope

## What’s included
- `docs(parity): add coverage map front door`

## Validation
- local markdown link existence checks across the touched docs
- `git diff --check`

## Notes
- This PR is extracted from the active batch branch `batch/docs-repo-shape`
- It reflects honest batch-branch progress for Feature #20, not a merged artifact yet
- The earlier planning-canonicalization PR (#35) is already merged; this is the next coherent follow-up slice only
