### PR TITLE
docs: add audience-based docs scaffold

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,6 +19,20 @@ Use it to find the right source of truth by audience and concern.
 | Contributor/reference docs | [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md), [`SUBSYSTEMS.md`](SUBSYSTEMS.md), [`FUNCTIONALITY-CHECKLIST.md`](FUNCTIONALITY-CHECKLIST.md) | implementation reference and verification detail |
 | Long-form strategy / rationale | [`COMPETITIVE-RESEARCH.md`](COMPETITIVE-RESEARCH.md), [`AZURE-DATA-OPTIONS.md`](AZURE-DATA-OPTIONS.md), [`DOCS-README-PLAN-REORG.md`](DOCS-README-PLAN-REORG.md) | design rationale and planning context |
 
+## Transitional structure scaffold
+
+The approved audience-based folder layout now exists in scaffold form:
+
+- [`getting-started/`](getting-started/README.md)
+- [`operator/`](operator/README.md)
+- [`contributor/`](contributor/README.md)
+- [`reference/`](reference/README.md)
+- [`parity/`](parity/README.md)
+- [`strategy/`](strategy/README.md)
+- [`adr/`](adr/README.md)
+
+The current top-level docs remain authoritative until content is intentionally moved.
+
 ## Recommended reading paths
 
 ### If you are evaluating Rune

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+This folder is reserved for ADRs during the docs structure cleanup transition.
+
+Planned early ADRs from the reorg proposal include:
+- source-of-truth model
+- standalone-first product shape
+- Project 2 execution model
+
+Current planning context remains in:
+- [`../DOCS-README-PLAN-REORG.md`](../DOCS-README-PLAN-REORG.md)
+- [`../../rune-plan.md`](../../rune-plan.md)

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,0 +1,8 @@
+# Contributor Docs
+
+This folder is reserved for development workflow, contributor guidance, and testing-oriented docs during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../AGENT-ORCHESTRATION.md`](../AGENT-ORCHESTRATION.md)
+- [`../CRATE-LAYOUT.md`](../CRATE-LAYOUT.md)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+This folder is reserved for quickstart and install-focused docs during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../../README.md`](../../README.md)

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -1,0 +1,9 @@
+# Operator Docs
+
+This folder is reserved for deployment, configuration, runtime health, and operational guidance during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../DOCKER-DEPLOYMENT.md`](../DOCKER-DEPLOYMENT.md)
+- [`../DATABASES.md`](../DATABASES.md)
+- [`../OPERATOR-POLICY.md`](../OPERATOR-POLICY.md)

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -1,0 +1,10 @@
+# Parity Docs
+
+This folder is reserved for parity-oriented reference material during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md)
+- [`../PARITY-INVENTORY.md`](../PARITY-INVENTORY.md)
+- [`../PARITY-SPEC.md`](../PARITY-SPEC.md)
+- [`../PARITY-CONTRACTS.md`](../PARITY-CONTRACTS.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,8 @@
+# Reference Docs
+
+This folder is reserved for stable technical reference material during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../PROTOCOLS.md`](../PROTOCOLS.md)
+- [`../SUBSYSTEMS.md`](../SUBSYSTEMS.md)

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,9 @@
+# Strategy Docs
+
+This folder is reserved for long-form design rationale and supporting strategy documents during the docs structure cleanup transition.
+
+Current canonical entrypoints remain:
+- [`../INDEX.md`](../INDEX.md)
+- [`../../rune-plan.md`](../../rune-plan.md)
+- [`../COMPETITIVE-RESEARCH.md`](../COMPETITIVE-RESEARCH.md)
+- [`../AZURE-DATA-OPTIONS.md`](../AZURE-DATA-OPTIONS.md)


### PR DESCRIPTION
## Summary
- add the non-destructive audience-based docs scaffold proposed by the docs reorg plan
- add an ADR landing area without moving existing docs yet
- keep current top-level docs authoritative while making the target structure explicit and navigable

## What’s included
- `docs(structure): add audience-based doc scaffold`

## Validation
- local markdown link existence checks across the scaffold files
- `git diff --check`

## Notes
- This PR is extracted from the active batch branch `batch/docs-repo-shape`
- It reflects honest batch-branch progress for Feature #20, not a merged artifact yet
- Broader docs movement remains out of scope for this PR
