### PR TITLE
docs: add ADR execution workflow trail

### DIFF
--- a/docs/adr/ADR-0001-execution-workflow-and-speed.md
+++ b/docs/adr/ADR-0001-execution-workflow-and-speed.md
@@ -1,0 +1,96 @@
+# ADR-0001: Execution Workflow and Speed Model
+
+- **Status:** Accepted
+- **Date:** 2026-03-17
+
+## Context
+
+Rune development was slowed and destabilized by mixing incompatible execution modes:
+
+- direct local `main` development
+- PR-driven work
+- temporary side branches
+- worktrees
+- background autonomous execution
+- inconsistent merge timing
+
+This caused:
+- branch/worktree clutter
+- delayed merges even when PRs were green
+- confusion about the active source of truth
+- extra cleanup work instead of forward progress
+
+A clearer operating model is needed to keep development both fast and safe.
+
+## Decision
+
+Rune development will use the following default workflow model:
+
+### 1. Batch-branch mode is the default
+Development happens on:
+- one active coding branch
+- one active PR
+- one coherent milestone batch
+
+### 2. `main` stays stable and synced
+- `main` is the integration target
+- `main` should remain clean and synced to `origin/main`
+- implementation should not happen directly on `main` by default
+
+### 3. No worktrees by default
+- no git worktrees
+- no temp clones
+- no alternate repo copies
+
+Unless explicitly approved as an exception.
+
+### 4. Prefer larger coherent milestone PRs
+- fewer PRs
+- larger but still coherent milestone batches
+- avoid unnecessary micro-PR fragmentation
+
+### 5. Merge immediately when green
+If the active PR is green and mergeable:
+1. merge immediately
+2. sync `main`
+3. create the next batch branch
+4. continue work
+
+### 6. Parallelism is asymmetric
+Use:
+- one coding agent on the active batch branch
+- support agents for planning/review/CI/docs analysis in parallel
+
+Do not use multiple overlapping coding agents by default.
+
+## Consequences
+
+### Positive
+- cleaner repo state
+- less branch churn
+- faster progress through larger coherent batches
+- less idle waiting between merge and next work
+- lower operational ambiguity
+
+### Negative / tradeoffs
+- less fine-grained PR history than strict one-story-one-PR mode
+- parallel coding throughput is intentionally limited to reduce collisions
+- explicit planning is needed to keep milestone batches coherent
+
+## Alternatives considered
+
+### Direct `main` mode
+Rejected as default because it becomes ambiguous and messy too quickly.
+
+### Strict one-story-one-PR mode
+Rejected as default because it is cleaner but slower than desired.
+
+### Worktree-per-task parallel coding
+Rejected as default because it increases hidden state and operational confusion.
+
+## Follow-up
+
+This ADR should be reflected in:
+- execution policy docs
+- Project 2 workflow expectations
+- agent operating rules

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,10 +1,16 @@
 # Architecture Decision Records
 
-This folder is reserved for ADRs during the docs structure cleanup transition.
+This folder holds durable decisions that should not be rediscovered in chat or buried inside PR discussions.
 
-Planned early ADRs from the reorg proposal include:
+## Current ADRs
+
+- [`ADR-0001-execution-workflow-and-speed.md`](ADR-0001-execution-workflow-and-speed.md)
+
+## Planned early ADRs
+
 - source-of-truth model
 - standalone-first product shape
+- multi-database storage architecture
 - Project 2 execution model
 
 Current planning context remains in:

--- a/docs/contributor/EXECUTION-SPEED-POLICY.md
+++ b/docs/contributor/EXECUTION-SPEED-POLICY.md
@@ -1,0 +1,121 @@
+# Execution Speed Policy
+
+This document captures how Rune development should move fast **without** collapsing into repo chaos.
+
+## Core rule
+
+Speed comes from:
+- coherent milestone batches
+- immediate merges when green
+- low state ambiguity
+- parallel support work
+
+Not from:
+- multiple coding branches at once
+- dirty `main`
+- worktrees by default
+- tiny fragmented PRs for every minor sub-slice
+
+## Default operating mode
+
+### Batch-branch mode
+
+Use:
+- **one active coding branch**
+- **one active PR**
+- **one coherent milestone batch**
+
+That is the default speed/safety balance for Rune.
+
+## Branch rules
+
+- `main` stays stable and synced to `origin/main`
+- do not code on `main` by default
+- create one batch branch from clean `main`
+- keep all implementation for that milestone on the batch branch
+- merge when the batch is coherent and validated
+- delete the branch after merge
+- immediately create the next batch branch
+
+## PR sizing rule
+
+Prefer **larger coherent milestone PRs** over many tiny PRs.
+
+Good PR shape:
+- one lane
+- one milestone
+- one reviewer story
+- multiple related commits allowed
+
+Bad PR shape:
+- unrelated browser + docs + memory + channels mixed together
+- tiny one-commit PRs when the work obviously belongs in one larger milestone
+
+## Validation rule
+
+Use tiered validation:
+
+### During implementation
+- targeted tests
+- targeted lint
+- focused local validation
+
+### Before PR / merge
+- broader validation sweep appropriate to the batch
+
+### In CI
+- final gating checks
+
+Do not run the whole universe on every tiny local change if targeted validation is sufficient.
+
+## Merge rule
+
+If the active PR is:
+- green
+- mergeable
+
+then:
+1. merge immediately
+2. sync `main` immediately
+3. create the next batch immediately
+4. continue immediately
+
+Do not stop at a status checkpoint when the next safe execution step is obvious.
+
+## Parallelism rule
+
+Use:
+- **one coding agent** on the active batch branch
+- additional support agents for:
+  - issue decomposition
+  - docs analysis
+  - CI/log inspection
+  - parity-gap identification
+
+Do **not** use multiple coding agents on overlapping repo state by default.
+
+## Repository safety rule
+
+- no git worktrees by default
+- no temp clones by default
+- no alternate repo copies by default
+- use the canonical repo unless an explicit exception is approved
+
+## Interruption rule
+
+Only interrupt Hamza for:
+- real blockers
+- real milestones
+- meaningful decisions
+
+Do not generate chatter for routine intermediate state.
+
+## Cleanup rule
+
+Periodically clean:
+- merged local branches
+- stale temp branches
+- stale worktree metadata
+- stale partial branch clutter
+
+Low state complexity is a speed feature.


### PR DESCRIPTION
## Summary
- turn the ADR area into a real decision trail surface
- add ADR-0001 for the execution workflow and speed model
- add a contributor-facing execution speed policy document

## What’s included
- `docs(adr): add execution workflow decision trail`

## Validation
- scoped local markdown link existence check across the touched ADR/policy files
- `git diff --check`

## Notes
- This PR is extracted from the active batch branch `batch/docs-adr-trail`
- It reflects honest batch-branch progress for Feature #22, not a merged artifact yet
