### PR TITLE
docs: promote operator entry docs to current-use guides

### DIFF
--- a/docs/operator/CHANNELS.md
+++ b/docs/operator/CHANNELS.md
@@ -18,9 +18,15 @@ Use these docs for the current contract picture:
 - [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md)
 - [`../INDEX.md`](../INDEX.md)
 
-## What belongs here over time
+## Current operator use
 
-This file should become the stable operator entry for:
+Use this doc as the channel entrypoint for:
+- understanding where channel coverage and behavior docs live
+- navigating from adapter questions into parity and protocol references
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - channel setup/navigation
 - provider-specific channel docs
 - runtime channel expectations

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -20,9 +20,16 @@ Use these docs for the current contract picture:
 - [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) — config-related runtime/state concepts
 - [`../INDEX.md`](../INDEX.md) — docs front door
 
-## What belongs here over time
+## Current operator use
 
-This file should become the stable operator reference entry for:
+Use this doc as the configuration entrypoint for:
+- where config concerns live
+- which deeper docs cover deployment/storage/runtime config semantics
+- how config relates to provider, channel, and auth behavior
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - config file shape and precedence
 - secrets and env override guidance
 - gateway/auth/runtime configuration pointers

--- a/docs/operator/HEALTH-AND-DOCTOR.md
+++ b/docs/operator/HEALTH-AND-DOCTOR.md
@@ -19,9 +19,15 @@ Use these docs for the current contract picture:
 - [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md)
 - [`../INDEX.md`](../INDEX.md)
 
-## What belongs here over time
+## Current operator use
 
-This file should become the stable operator entry for:
+Use this doc as the health/diagnostics entrypoint for:
+- where health/status expectations live now
+- how to navigate to deployment, database, and parity contract troubleshooting references
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - health/status endpoint pointers
 - doctor command/navigation
 - common failure-mode triage

--- a/docs/operator/MEMORY.md
+++ b/docs/operator/MEMORY.md
@@ -28,9 +28,15 @@ The current operator CLI already exposes a read-only memory surface with:
 
 The runtime also enforces the curated-memory privacy boundary: `MEMORY.md` is main-session-only, while non-direct contexts use the daily/raw memory surfaces without loading curated long-term memory.
 
-## What belongs here over time
+## Current operator use
 
-This file should become the stable operator entry for:
+Use this doc as the memory entrypoint for:
+- understanding the current file-oriented memory model
+- locating the privacy-boundary and retrieval-surface references that already exist
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - memory storage conventions
 - privacy-boundary explanation
 - operator inspection/troubleshooting of memory retrieval

--- a/docs/operator/PROVIDERS.md
+++ b/docs/operator/PROVIDERS.md
@@ -18,9 +18,15 @@ Use these docs for the current contract picture:
 - [`../INDEX.md`](../INDEX.md)
 - [`../../rune-plan.md`](../../rune-plan.md)
 
-## What belongs here over time
+## Current operator use
 
-This file should become the stable operator entry for:
+Use this doc as the provider entrypoint for:
+- where provider setup and Azure-oriented expectations live
+- how to navigate from high-level provider questions into the deeper compatibility/runtime docs
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - provider kinds and configuration expectations
 - Azure-specific setup notes
 - model routing/operator mental model


### PR DESCRIPTION
## Summary
- turn the operator entry docs from future-oriented placeholders into present-tense current-use guides
- keep the operator docs useful now while preserving room for deeper future expansion
- continue the audience-hub cleanup without reopening stale workflow/planning lanes

## What changed
- `docs/operator/CONFIGURATION.md`
- `docs/operator/PROVIDERS.md`
- `docs/operator/CHANNELS.md`
- `docs/operator/HEALTH-AND-DOCTOR.md`
- `docs/operator/MEMORY.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #84