### PR TITLE
docs: promote contributor entry docs to current-use guides

### DIFF
--- a/docs/contributor/CONTRIBUTING.md
+++ b/docs/contributor/CONTRIBUTING.md
@@ -21,9 +21,15 @@ Use repo docs to understand the system.
 Use GitHub Project 2, issues, and PRs to understand active execution.
 Use ADRs for durable decisions.
 
-## What belongs here over time
+## Current contributor use
 
-This file should become the stable contributor entry for:
+Use this doc as the contributor entrypoint for:
+- understanding how docs, issues, PRs, and ADRs relate today
+- navigating to the right development, testing, and workflow references first
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - contribution expectations
 - doc/issue/PR relationship
 - review hygiene

--- a/docs/contributor/TESTING.md
+++ b/docs/contributor/TESTING.md
@@ -24,9 +24,15 @@ cargo test --workspace
 cargo clippy --workspace -- -D warnings
 ```
 
-## What belongs here over time
+## Current contributor use
 
-This file should become the stable contributor entry for:
+Use this doc as the testing entrypoint for:
+- understanding the current validation posture
+- navigating from general testing questions into parity and development references
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - test layers and expectations
 - parity-oriented acceptance pointers
 - focused vs broad validation guidance

--- a/docs/contributor/WORKFLOW.md
+++ b/docs/contributor/WORKFLOW.md
@@ -18,9 +18,16 @@ Rune currently uses a batch-branch workflow model:
 - [`../AGENT-ORCHESTRATION.md`](../AGENT-ORCHESTRATION.md)
 - [`../INDEX.md`](../INDEX.md)
 
-## What belongs here over time
+## Current contributor use
 
-This file should become the stable contributor entry for:
+Use this doc as the workflow entrypoint for:
+- the accepted batch-branch / single-PR model
+- where execution authority lives now
+- how contributor flow relates to issues, PRs, and Project 2
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - branch/PR workflow expectations
 - issue/PR/project-board relationship
 - merge discipline


### PR DESCRIPTION
## Summary
- turn the contributor entry docs from future-oriented placeholders into present-tense current-use guides
- keep the contributor docs useful now while preserving room for deeper future expansion
- continue the audience-hub cleanup without reopening stale workflow/planning lanes

## What changed
- `docs/contributor/CONTRIBUTING.md`
- `docs/contributor/TESTING.md`
- `docs/contributor/WORKFLOW.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #85