### PR TITLE
docs: promote api and cli reference entry docs

### DIFF
--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -11,9 +11,15 @@ Use these docs for the current contract picture:
 - [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) — behavioral expectations and invariants
 - [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) — where to find parity coverage by surface
 
-## What belongs here over time
+## Current reference use
 
-This file should become the stable reference entry for:
+Use this doc as the API entrypoint for:
+- understanding where the current HTTP/dashboard/control-plane contract picture lives
+- navigating from API questions into parity contracts and coverage docs
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - core HTTP route families
 - auth expectations
 - dashboard/API shape pointers

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -11,9 +11,15 @@ Use these docs for the current contract picture:
 - [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) — parity-navigation front door
 - [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) — resource/state concepts behind CLI operations
 
-## What belongs here over time
+## Current reference use
 
-This file should become the stable reference entry for:
+Use this doc as the CLI entrypoint for:
+- understanding where current command-family coverage lives
+- navigating from CLI questions into parity inventory and protocol references
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - top-level command families
 - operator mental model
 - lifecycle/status/config/doctor command pointers


### PR DESCRIPTION
## Summary
- turn the API and CLI reference entry docs from future-oriented placeholders into present-tense current-use guides
- keep the reference docs useful now while preserving room for deeper future expansion
- continue the docs cleanup without reopening stale workflow/planning lanes

## What changed
- `docs/reference/API.md`
- `docs/reference/CLI.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #86