### PR TITLE
docs: promote standalone strategy entry doc

### DIFF
--- a/docs/strategy/STANDALONE-STRATEGY.md
+++ b/docs/strategy/STANDALONE-STRATEGY.md
@@ -21,9 +21,15 @@ Use these docs for the current strategy picture:
 - [`COMPETITIVE-RESEARCH.md`](COMPETITIVE-RESEARCH.md)
 - [`../INDEX.md`](../INDEX.md)
 
-## What belongs here over time
+## Current strategy use
 
-This file should become the stable strategy entry for:
+Use this doc as the strategy entrypoint for:
+- understanding Rune's standalone-first posture today
+- navigating from high-level product-shape questions into the deeper rationale and ADR references
+
+## Coverage still expected later
+
+This file can still grow into deeper reference for:
 - standalone-first rationale
 - local-first vs server-grade positioning
 - deployment-shape tradeoffs


### PR DESCRIPTION
## Summary
- turn the standalone strategy entry doc from future-oriented placeholder language into a present-tense current-use guide
- keep the strategy docs useful now while preserving room for deeper future expansion
- continue the docs cleanup without reopening stale workflow/planning lanes

## What changed
- `docs/strategy/STANDALONE-STRATEGY.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #87