### PR TITLE
docs: clarify current-use and next-depth entry docs

### DIFF
--- a/docs/contributor/CONTRIBUTING.md
+++ b/docs/contributor/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Use this doc as the contributor entrypoint for:
 - understanding how docs, issues, PRs, and ADRs relate today
 - navigating to the right development, testing, and workflow references first
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - contribution expectations

--- a/docs/contributor/TESTING.md
+++ b/docs/contributor/TESTING.md
@@ -30,7 +30,7 @@ Use this doc as the testing entrypoint for:
 - understanding the current validation posture
 - navigating from general testing questions into parity and development references
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - test layers and expectations

--- a/docs/contributor/WORKFLOW.md
+++ b/docs/contributor/WORKFLOW.md
@@ -25,7 +25,7 @@ Use this doc as the workflow entrypoint for:
 - where execution authority lives now
 - how contributor flow relates to issues, PRs, and Project 2
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - branch/PR workflow expectations

--- a/docs/operator/CHANNELS.md
+++ b/docs/operator/CHANNELS.md
@@ -24,7 +24,7 @@ Use this doc as the channel entrypoint for:
 - understanding where channel coverage and behavior docs live
 - navigating from adapter questions into parity and protocol references
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - channel setup/navigation

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -27,7 +27,7 @@ Use this doc as the configuration entrypoint for:
 - which deeper docs cover deployment/storage/runtime config semantics
 - how config relates to provider, channel, and auth behavior
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - config file shape and precedence

--- a/docs/operator/HEALTH-AND-DOCTOR.md
+++ b/docs/operator/HEALTH-AND-DOCTOR.md
@@ -25,7 +25,7 @@ Use this doc as the health/diagnostics entrypoint for:
 - where health/status expectations live now
 - how to navigate to deployment, database, and parity contract troubleshooting references
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - health/status endpoint pointers

--- a/docs/operator/MEMORY.md
+++ b/docs/operator/MEMORY.md
@@ -34,7 +34,7 @@ Use this doc as the memory entrypoint for:
 - understanding the current file-oriented memory model
 - locating the privacy-boundary and retrieval-surface references that already exist
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - memory storage conventions

--- a/docs/operator/PROVIDERS.md
+++ b/docs/operator/PROVIDERS.md
@@ -24,7 +24,7 @@ Use this doc as the provider entrypoint for:
 - where provider setup and Azure-oriented expectations live
 - how to navigate from high-level provider questions into the deeper compatibility/runtime docs
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - provider kinds and configuration expectations

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -17,7 +17,7 @@ Use this doc as the API entrypoint for:
 - understanding where the current HTTP/dashboard/control-plane contract picture lives
 - navigating from API questions into parity contracts and coverage docs
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - core HTTP route families

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -17,7 +17,7 @@ Use this doc as the CLI entrypoint for:
 - understanding where current command-family coverage lives
 - navigating from CLI questions into parity inventory and protocol references
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - top-level command families

--- a/docs/strategy/STANDALONE-STRATEGY.md
+++ b/docs/strategy/STANDALONE-STRATEGY.md
@@ -27,7 +27,7 @@ Use this doc as the strategy entrypoint for:
 - understanding Rune's standalone-first posture today
 - navigating from high-level product-shape questions into the deeper rationale and ADR references
 
-## Coverage still expected later
+## Next depth to add
 
 This file can still grow into deeper reference for:
 - standalone-first rationale


### PR DESCRIPTION
## Summary
- normalize the remaining docs entry surfaces so they use sharper present-tense current-use language
- replace repeated placeholder-style “coverage later” phrasing with cleaner “next depth to add” guidance
- keep the docs cleanup moving as one coherent cross-surface consistency batch

## What changed
- `docs/operator/CONFIGURATION.md`
- `docs/operator/PROVIDERS.md`
- `docs/operator/CHANNELS.md`
- `docs/operator/HEALTH-AND-DOCTOR.md`
- `docs/operator/MEMORY.md`
- `docs/reference/API.md`
- `docs/reference/CLI.md`
- `docs/strategy/STANDALONE-STRATEGY.md`
- `docs/contributor/CONTRIBUTING.md`
- `docs/contributor/TESTING.md`
- `docs/contributor/WORKFLOW.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #88