### PR TITLE
docs: improve README quick-start follow-up links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ cp config.example.toml config.toml
 
 Then open `http://127.0.0.1:8787/dashboard`.
 
-For fuller development setup and service-style local operation, see [`docs/contributor/DEVELOPMENT.md`](docs/contributor/DEVELOPMENT.md).
+Next docs from there:
+- [`docs/getting-started/QUICKSTART.md`](docs/getting-started/QUICKSTART.md)
+- [`docs/getting-started/INSTALL.md`](docs/getting-started/INSTALL.md)
+- [`docs/operator/README.md`](docs/operator/README.md)
+- [`docs/contributor/DEVELOPMENT.md`](docs/contributor/DEVELOPMENT.md)
 
 ## What Rune does
 


### PR DESCRIPTION
## Summary
- improve the README quick-start handoff into the now-real getting-started and operator docs
- keep the public landing page aligned with the current docs structure
- continue the docs cleanup as a small coherent follow-up batch

## What changed
- `README.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #19
- continues post-merge README/docs cleanup after #91