### PR TITLE
docs: surface reference entry docs more clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ That means local-first is the default experience, not a throwaway dev-only mode.
 Start here:
 - [`docs/contributor/DEVELOPMENT.md`](docs/contributor/DEVELOPMENT.md)
 - [`docs/AGENT-ORCHESTRATION.md`](docs/AGENT-ORCHESTRATION.md)
+- [`docs/reference/README.md`](docs/reference/README.md)
+- [`docs/reference/ARCHITECTURE.md`](docs/reference/ARCHITECTURE.md)
 - [`docs/reference/CRATE-LAYOUT.md`](docs/reference/CRATE-LAYOUT.md)
 - [`docs/reference/SUBSYSTEMS.md`](docs/reference/SUBSYSTEMS.md)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,7 +55,9 @@ These folders are now valid first-stop entrypoints rather than placeholder-only 
 3. [`rune-plan.md`](../rune-plan.md)
 4. [`IMPLEMENTATION-PHASES.md`](IMPLEMENTATION-PHASES.md)
 5. [`PROTOCOLS.md`](parity/PROTOCOLS.md)
-6. [`reference/CRATE-LAYOUT.md`](reference/CRATE-LAYOUT.md)
+6. [`reference/README.md`](reference/README.md)
+7. [`reference/ARCHITECTURE.md`](reference/ARCHITECTURE.md)
+8. [`reference/CRATE-LAYOUT.md`](reference/CRATE-LAYOUT.md)
 
 ## Transitional note
 
@@ -66,3 +68,4 @@ Legacy planning files still exist during the docs cleanup transition:
 - [`WORKPLAN.md`](WORKPLAN.md)
 
 Treat those as provenance and historical context unless a file explicitly says otherwise.
+ provenance and historical context unless a file explicitly says otherwise.


### PR DESCRIPTION
## Summary
- update README and docs index so the reference surface is represented by its real entry docs
- make architecture/API/CLI/reference-hub entrypoints easier to discover
- continue the docs cleanup as a small coherent navigation batch

## What changed
- `README.md`
- `docs/INDEX.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #19
- advances #20
- continues post-merge docs cleanup after #91