### PR TITLE
docs: repair docs index and surface reference entries

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -68,4 +68,11 @@ Legacy planning files still exist during the docs cleanup transition:
 - [`WORKPLAN.md`](WORKPLAN.md)
 
 Treat those as provenance and historical context unless a file explicitly says otherwise.
+ transition:
+
+- [`PLAN.md`](PLAN.md)
+- [`STACK.md`](STACK.md)
+- [`WORKPLAN.md`](WORKPLAN.md)
+
+Treat those as provenance and historical context unless a file explicitly says otherwise.
  provenance and historical context unless a file explicitly says otherwise.


### PR DESCRIPTION
## Summary
- fix the docs index tail corruption
- represent the reference surface in the docs front door through its actual entry docs
- keep the docs handoff cleaner for current readers

## What changed
- `docs/INDEX.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #19
- advances #20
- continues post-merge docs cleanup after #93