### PR TITLE
docs: promote architecture entry doc to current-use guide

### DIFF
--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -51,6 +51,20 @@ Responsible for:
 - reply/reaction/media semantics
 - adapter-specific integration behavior
 
+## Current reference use
+
+Use this doc as the architecture entrypoint for:
+- understanding Rune's current runtime shape and subsystem boundaries
+- navigating from high-level architecture questions into deeper protocol, crate-layout, and subsystem references
+
+## Next depth to add
+
+This file can still grow into deeper reference for:
+- cross-cutting runtime flows and boundaries
+- storage/provider/channel relationship details
+- architecture-level invariants and tradeoffs
+- diagrams or richer deployment/control-plane context if that becomes useful
+
 ## Reference entrypoints
 
 - [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md)


### PR DESCRIPTION
## Summary
- turn the architecture reference doc into a clearer current-use entry guide
- keep the reference surface consistent with the API/CLI entry docs
- continue the docs cleanup as a small coherent follow-up batch

## What changed
- `docs/reference/ARCHITECTURE.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #94