### PR TITLE
docs: improve getting-started and parity hub guidance

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -3,7 +3,7 @@
 This folder holds the quick path for trying Rune locally without digging through operator or contributor detail first.
 
 Start here:
-- [`QUICKSTART.md`](QUICKSTART.md)
-- [`INSTALL.md`](INSTALL.md)
-- [`../INDEX.md`](../INDEX.md)
-- [`../../README.md`](../../README.md)
+- use [`QUICKSTART.md`](QUICKSTART.md) if you want the fastest local bring-up path
+- use [`INSTALL.md`](INSTALL.md) if you want the slightly fuller local setup path
+- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door
+- use [`../../README.md`](../../README.md) if you want the public project landing page first

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -3,10 +3,9 @@
 This folder is the parity hub for coverage inventory, release rules, protocol contracts, and execution sequencing.
 
 Start here:
-- [`../INDEX.md`](../INDEX.md)
-- [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md)
-- [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md)
-- [`PARITY-SPEC.md`](PARITY-SPEC.md)
-- [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md)
-- [`PROTOCOLS.md`](PROTOCOLS.md)
-- [`../IMPLEMENTATION-PHASES.md`](../IMPLEMENTATION-PHASES.md)
+- use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) if you know the OpenClaw surface but not the right Rune doc yet
+- use [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md) if you need the broad coverage census
+- use [`PARITY-SPEC.md`](PARITY-SPEC.md) if you need the release/parity rule
+- use [`PARITY-CONTRACTS.md`](PARITY-CONTRACTS.md) and [`PROTOCOLS.md`](PROTOCOLS.md) if you need subsystem/runtime behavior details
+- use [`../IMPLEMENTATION-PHASES.md`](../IMPLEMENTATION-PHASES.md) if you need sequencing and acceptance criteria
+- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door


### PR DESCRIPTION
## Summary
- make the getting-started and parity hub readmes more intent-based instead of only flat link lists
- help readers choose the right next doc based on what they need now
- continue the docs cleanup as a small coherent follow-up batch

## What changed
- `docs/getting-started/README.md`
- `docs/parity/README.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- continues post-merge docs cleanup after #94