### PR TITLE
docs: add read-next routing to secondary entry guides

### DIFF
--- a/docs/contributor/CONTRIBUTING.md
+++ b/docs/contributor/CONTRIBUTING.md
@@ -27,6 +27,12 @@ Use this doc as the contributor entrypoint for:
 - understanding how docs, issues, PRs, and ADRs relate today
 - navigating to the right development, testing, and workflow references first
 
+## Read next
+
+- use [`DEVELOPMENT.md`](DEVELOPMENT.md) for local setup and build/run flow
+- use [`TESTING.md`](TESTING.md) when you need validation guidance
+- use [`WORKFLOW.md`](WORKFLOW.md) and [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) when you need the accepted execution model and merge discipline
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/contributor/TESTING.md
+++ b/docs/contributor/TESTING.md
@@ -30,6 +30,12 @@ Use this doc as the testing entrypoint for:
 - understanding the current validation posture
 - navigating from general testing questions into parity and development references
 
+## Read next
+
+- use [`DEVELOPMENT.md`](DEVELOPMENT.md) when the testing question is really about local build/run setup
+- use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) and [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when the test question is really about runtime invariants
+- use [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) when you need focused-vs-broad validation expectations during active work
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/contributor/WORKFLOW.md
+++ b/docs/contributor/WORKFLOW.md
@@ -25,6 +25,12 @@ Use this doc as the workflow entrypoint for:
 - where execution authority lives now
 - how contributor flow relates to issues, PRs, and Project 2
 
+## Read next
+
+- use [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) when you need the speed/safety operating rules behind this workflow
+- use [`../adr/ADR-0001-execution-workflow-and-speed.md`](../adr/ADR-0001-execution-workflow-and-speed.md) and [`../adr/ADR-0004-project-2-execution-model.md`](../adr/ADR-0004-project-2-execution-model.md) when you need the durable rationale behind the current model
+- use [`../AGENT-ORCHESTRATION.md`](../AGENT-ORCHESTRATION.md) when you need deeper execution context for the repo/runtime itself
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/operator/CHANNELS.md
+++ b/docs/operator/CHANNELS.md
@@ -24,6 +24,12 @@ Use this doc as the channel entrypoint for:
 - understanding where channel coverage and behavior docs live
 - navigating from adapter questions into parity and protocol references
 
+## Read next
+
+- use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) when you need the broad parity/docs navigation view by surface
+- use [`../parity/PARITY-INVENTORY.md`](../parity/PARITY-INVENTORY.md) when you need command/surface coverage detail
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need deeper inbound/outbound runtime semantics
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -27,6 +27,12 @@ Use this doc as the configuration entrypoint for:
 - which deeper docs cover deployment/storage/runtime config semantics
 - how config relates to provider, channel, and auth behavior
 
+## Read next
+
+- use [`DEPLOYMENT.md`](DEPLOYMENT.md) and [`DATABASES.md`](DATABASES.md) when configuration questions are really about runtime/storage layout
+- use [`PROVIDERS.md`](PROVIDERS.md) and [`CHANNELS.md`](CHANNELS.md) when configuration questions are really about model or channel setup
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need deeper runtime semantics behind config behavior
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/operator/HEALTH-AND-DOCTOR.md
+++ b/docs/operator/HEALTH-AND-DOCTOR.md
@@ -25,6 +25,12 @@ Use this doc as the health/diagnostics entrypoint for:
 - where health/status expectations live now
 - how to navigate to deployment, database, and parity contract troubleshooting references
 
+## Read next
+
+- use [`DEPLOYMENT.md`](DEPLOYMENT.md) and [`DATABASES.md`](DATABASES.md) when the issue looks like runtime/storage layout or persistence health
+- use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need deeper runtime invariants behind a failing behavior
+- use [`OPERATOR-POLICY.md`](OPERATOR-POLICY.md) when the question is operational guardrails rather than runtime failure analysis
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/operator/MEMORY.md
+++ b/docs/operator/MEMORY.md
@@ -34,6 +34,12 @@ Use this doc as the memory entrypoint for:
 - understanding the current file-oriented memory model
 - locating the privacy-boundary and retrieval-surface references that already exist
 
+## Read next
+
+- use [`../parity/PARITY-INVENTORY.md`](../parity/PARITY-INVENTORY.md) when you need the memory/tool surface inventory view
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need runtime semantics behind retrieval behavior
+- use [`../FUNCTIONALITY-CHECKLIST.md`](../FUNCTIONALITY-CHECKLIST.md) when you need implementation/evidence-oriented detail
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/operator/PROVIDERS.md
+++ b/docs/operator/PROVIDERS.md
@@ -24,6 +24,12 @@ Use this doc as the provider entrypoint for:
 - where provider setup and Azure-oriented expectations live
 - how to navigate from high-level provider questions into the deeper compatibility/runtime docs
 
+## Read next
+
+- use [`../AZURE-COMPATIBILITY.md`](../AZURE-COMPATIBILITY.md) when you need provider/platform compatibility detail
+- use [`../../rune-plan.md`](../../rune-plan.md) when the question is really about strategic provider direction
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need runtime semantics behind model/provider behavior
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -17,6 +17,12 @@ Use this doc as the API entrypoint for:
 - understanding where the current HTTP/dashboard/control-plane contract picture lives
 - navigating from API questions into parity contracts and coverage docs
 
+## Read next
+
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need entity/protocol structure behind an API question
+- use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need behavioral invariants and response expectations
+- use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) when you need the broad docs/parity navigation view by surface
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -57,6 +57,12 @@ Use this doc as the architecture entrypoint for:
 - understanding Rune's current runtime shape and subsystem boundaries
 - navigating from high-level architecture questions into deeper protocol, crate-layout, and subsystem references
 
+## Read next
+
+- use [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md) and [`SUBSYSTEMS.md`](SUBSYSTEMS.md) when you need implementation-structure detail
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when the question is really about runtime semantics and invariants
+- use [`../INDEX.md`](../INDEX.md) when you need to jump back out to the wider docs front door
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -17,6 +17,12 @@ Use this doc as the CLI entrypoint for:
 - understanding where current command-family coverage lives
 - navigating from CLI questions into parity inventory and protocol references
 
+## Read next
+
+- use [`../parity/PARITY-INVENTORY.md`](../parity/PARITY-INVENTORY.md) when you need the full command/surface census
+- use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) when you need broader docs navigation by OpenClaw surface
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need the runtime/state model behind a CLI behavior
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:

--- a/docs/strategy/STANDALONE-STRATEGY.md
+++ b/docs/strategy/STANDALONE-STRATEGY.md
@@ -27,6 +27,12 @@ Use this doc as the strategy entrypoint for:
 - understanding Rune's standalone-first posture today
 - navigating from high-level product-shape questions into the deeper rationale and ADR references
 
+## Read next
+
+- use [`../../rune-plan.md`](../../rune-plan.md) when the question is really about overall product direction and delivery map
+- use [`../adr/ADR-0002-standalone-first-product-shape.md`](../adr/ADR-0002-standalone-first-product-shape.md) when you need the durable architectural rationale behind the product-shape choice
+- use [`AZURE-DATA-OPTIONS.md`](AZURE-DATA-OPTIONS.md) and [`COMPETITIVE-RESEARCH.md`](COMPETITIVE-RESEARCH.md) for adjacent strategic tradeoff context
+
 ## Next depth to add
 
 This file can still grow into deeper reference for:


### PR DESCRIPTION
## Summary
- add concrete "read next" routing to the secondary entry docs across operator/reference/contributor/strategy
- make those docs work as real navigation surfaces instead of stopping at abstract current/future framing
- land the whole cross-surface package as one coherent larger PR

## What changed
- `docs/operator/CONFIGURATION.md`
- `docs/operator/PROVIDERS.md`
- `docs/operator/CHANNELS.md`
- `docs/operator/HEALTH-AND-DOCTOR.md`
- `docs/operator/MEMORY.md`
- `docs/reference/API.md`
- `docs/reference/CLI.md`
- `docs/reference/ARCHITECTURE.md`
- `docs/contributor/CONTRIBUTING.md`
- `docs/contributor/TESTING.md`
- `docs/contributor/WORKFLOW.md`
- `docs/strategy/STANDALONE-STRATEGY.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- coherent cross-surface docs navigation milestone