### PR TITLE
docs: improve next-step routing in secondary guides

### DIFF
--- a/docs/getting-started/INSTALL.md
+++ b/docs/getting-started/INSTALL.md
@@ -49,7 +49,6 @@ After Rune starts, check:
 ## If you want more than local bring-up
 
 Use these next:
-- [`../operator/DEPLOYMENT.md`](../operator/DEPLOYMENT.md)
-- [`../operator/DATABASES.md`](../operator/DATABASES.md)
-- [`../contributor/DEVELOPMENT.md`](../contributor/DEVELOPMENT.md)
-- [`../INDEX.md`](../INDEX.md)
+- use [`../operator/DEPLOYMENT.md`](../operator/DEPLOYMENT.md) and [`../operator/DATABASES.md`](../operator/DATABASES.md) when the next question is deployment/storage shape
+- use [`../contributor/DEVELOPMENT.md`](../contributor/DEVELOPMENT.md) when the next step is active development rather than local trial use
+- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -42,7 +42,7 @@ This path is meant for a quick local bring-up of:
 
 ## Next docs
 
-- [`INSTALL.md`](INSTALL.md) — slightly fuller setup path
-- [`../operator/DEPLOYMENT.md`](../operator/DEPLOYMENT.md) — deployment model
-- [`../contributor/DEVELOPMENT.md`](../contributor/DEVELOPMENT.md) — contributor/dev workflow
-- [`../INDEX.md`](../INDEX.md) — docs front door
+- use [`INSTALL.md`](INSTALL.md) if the quick path is not enough and you want the fuller local setup path
+- use [`../operator/README.md`](../operator/README.md) if you are now thinking like an operator rather than just trying the runtime once
+- use [`../contributor/DEVELOPMENT.md`](../contributor/DEVELOPMENT.md) if you are moving from trying Rune into building or changing it
+- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -73,8 +73,6 @@ This file can still grow into deeper reference for:
 
 ## Reference entrypoints
 
-- [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md)
-- [`SUBSYSTEMS.md`](SUBSYSTEMS.md)
-- [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md)
-- [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md)
-- [`../INDEX.md`](../INDEX.md)
+- use [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md) and [`SUBSYSTEMS.md`](SUBSYSTEMS.md) when the architecture question turns into implementation-structure detail
+- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when the architecture question turns into runtime semantics or invariants
+- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door


### PR DESCRIPTION
## Summary
- improve the secondary guides so they route readers to the right next doc by intent
- continue the docs cleanup as one coherent navigation package instead of many tiny follow-ups

## What changed
- `docs/getting-started/QUICKSTART.md`
- `docs/getting-started/INSTALL.md`
- `docs/reference/ARCHITECTURE.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- coherent docs navigation follow-through batch