### PR TITLE
docs: tighten ADR and architecture follow-on guidance

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,12 +7,13 @@ Start here:
 - use [`ADR-0002-standalone-first-product-shape.md`](ADR-0002-standalone-first-product-shape.md) for the standalone-first product/deployment posture
 - use [`ADR-0003-source-of-truth-model.md`](ADR-0003-source-of-truth-model.md) for the canonical docs/planning/source-of-truth split
 - use [`ADR-0004-project-2-execution-model.md`](ADR-0004-project-2-execution-model.md) for Project 2 as the live execution control plane
+
+## Read next
+
 - use [`../contributor/EXECUTION-SPEED-POLICY.md`](../contributor/EXECUTION-SPEED-POLICY.md) if you need the contributor-facing operating policy that matches these decisions
+- use [`../../rune-plan.md`](../../rune-plan.md) when the question is really about current product/strategy direction rather than one durable decision
+- use [`../DOCS-README-PLAN-REORG.md`](../DOCS-README-PLAN-REORG.md) when you need the longer docs/planning reorganization context around these decisions
 
 ## Planned next ADRs
 
 - multi-database storage architecture
-
-Current planning context remains in:
-- [`../DOCS-README-PLAN-REORG.md`](../DOCS-README-PLAN-REORG.md)
-- [`../../rune-plan.md`](../../rune-plan.md)

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -70,9 +70,3 @@ Deeper follow-up documentation is still useful for:
 - storage/provider/channel relationship details
 - architecture-level invariants and tradeoffs
 - diagrams or richer deployment/control-plane context if that becomes useful
-
-## Reference entrypoints
-
-- use [`CRATE-LAYOUT.md`](CRATE-LAYOUT.md) and [`SUBSYSTEMS.md`](SUBSYSTEMS.md) when the architecture question turns into implementation-structure detail
-- use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when the architecture question turns into runtime semantics or invariants
-- use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door


### PR DESCRIPTION
## Summary
- tighten the follow-on guidance in the ADR and architecture entry docs
- remove overlapping architecture navigation and make the ADR hub match the broader guidance style
- land this small but coherent docs-hub follow-up as the single review surface

## What changed
- `docs/reference/ARCHITECTURE.md`
- `docs/adr/README.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- coherent docs-hub follow-up slice