### PR TITLE
docs: clarify deeper-detail sections across secondary entry docs

### DIFF
--- a/docs/contributor/CONTRIBUTING.md
+++ b/docs/contributor/CONTRIBUTING.md
@@ -33,9 +33,9 @@ Use this doc as the contributor entrypoint for:
 - use [`TESTING.md`](TESTING.md) when you need validation guidance
 - use [`WORKFLOW.md`](WORKFLOW.md) and [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) when you need the accepted execution model and merge discipline
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - contribution expectations
 - doc/issue/PR relationship
 - review hygiene

--- a/docs/contributor/TESTING.md
+++ b/docs/contributor/TESTING.md
@@ -36,9 +36,9 @@ Use this doc as the testing entrypoint for:
 - use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) and [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when the test question is really about runtime invariants
 - use [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) when you need focused-vs-broad validation expectations during active work
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - test layers and expectations
 - parity-oriented acceptance pointers
 - focused vs broad validation guidance

--- a/docs/contributor/WORKFLOW.md
+++ b/docs/contributor/WORKFLOW.md
@@ -31,9 +31,9 @@ Use this doc as the workflow entrypoint for:
 - use [`../adr/ADR-0001-execution-workflow-and-speed.md`](../adr/ADR-0001-execution-workflow-and-speed.md) and [`../adr/ADR-0004-project-2-execution-model.md`](../adr/ADR-0004-project-2-execution-model.md) when you need the durable rationale behind the current model
 - use [`../AGENT-ORCHESTRATION.md`](../AGENT-ORCHESTRATION.md) when you need deeper execution context for the repo/runtime itself
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - branch/PR workflow expectations
 - issue/PR/project-board relationship
 - merge discipline

--- a/docs/operator/CHANNELS.md
+++ b/docs/operator/CHANNELS.md
@@ -30,9 +30,9 @@ Use this doc as the channel entrypoint for:
 - use [`../parity/PARITY-INVENTORY.md`](../parity/PARITY-INVENTORY.md) when you need command/surface coverage detail
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need deeper inbound/outbound runtime semantics
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - channel setup/navigation
 - provider-specific channel docs
 - runtime channel expectations

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -33,9 +33,9 @@ Use this doc as the configuration entrypoint for:
 - use [`PROVIDERS.md`](PROVIDERS.md) and [`CHANNELS.md`](CHANNELS.md) when configuration questions are really about model or channel setup
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need deeper runtime semantics behind config behavior
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - config file shape and precedence
 - secrets and env override guidance
 - gateway/auth/runtime configuration pointers

--- a/docs/operator/HEALTH-AND-DOCTOR.md
+++ b/docs/operator/HEALTH-AND-DOCTOR.md
@@ -31,9 +31,9 @@ Use this doc as the health/diagnostics entrypoint for:
 - use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need deeper runtime invariants behind a failing behavior
 - use [`OPERATOR-POLICY.md`](OPERATOR-POLICY.md) when the question is operational guardrails rather than runtime failure analysis
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - health/status endpoint pointers
 - doctor command/navigation
 - common failure-mode triage

--- a/docs/operator/MEMORY.md
+++ b/docs/operator/MEMORY.md
@@ -40,9 +40,9 @@ Use this doc as the memory entrypoint for:
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need runtime semantics behind retrieval behavior
 - use [`../FUNCTIONALITY-CHECKLIST.md`](../FUNCTIONALITY-CHECKLIST.md) when you need implementation/evidence-oriented detail
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - memory storage conventions
 - privacy-boundary explanation
 - operator inspection/troubleshooting of memory retrieval

--- a/docs/operator/PROVIDERS.md
+++ b/docs/operator/PROVIDERS.md
@@ -30,9 +30,9 @@ Use this doc as the provider entrypoint for:
 - use [`../../rune-plan.md`](../../rune-plan.md) when the question is really about strategic provider direction
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need runtime semantics behind model/provider behavior
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - provider kinds and configuration expectations
 - Azure-specific setup notes
 - model routing/operator mental model

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -23,9 +23,9 @@ Use this doc as the API entrypoint for:
 - use [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when you need behavioral invariants and response expectations
 - use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) when you need the broad docs/parity navigation view by surface
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - core HTTP route families
 - auth expectations
 - dashboard/API shape pointers

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -63,9 +63,9 @@ Use this doc as the architecture entrypoint for:
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) and [`../parity/PARITY-CONTRACTS.md`](../parity/PARITY-CONTRACTS.md) when the question is really about runtime semantics and invariants
 - use [`../INDEX.md`](../INDEX.md) when you need to jump back out to the wider docs front door
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - cross-cutting runtime flows and boundaries
 - storage/provider/channel relationship details
 - architecture-level invariants and tradeoffs

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -23,9 +23,9 @@ Use this doc as the CLI entrypoint for:
 - use [`../OPENCLAW-COVERAGE-MAP.md`](../OPENCLAW-COVERAGE-MAP.md) when you need broader docs navigation by OpenClaw surface
 - use [`../parity/PROTOCOLS.md`](../parity/PROTOCOLS.md) when you need the runtime/state model behind a CLI behavior
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - top-level command families
 - operator mental model
 - lifecycle/status/config/doctor command pointers

--- a/docs/strategy/STANDALONE-STRATEGY.md
+++ b/docs/strategy/STANDALONE-STRATEGY.md
@@ -33,9 +33,9 @@ Use this doc as the strategy entrypoint for:
 - use [`../adr/ADR-0002-standalone-first-product-shape.md`](../adr/ADR-0002-standalone-first-product-shape.md) when you need the durable architectural rationale behind the product-shape choice
 - use [`AZURE-DATA-OPTIONS.md`](AZURE-DATA-OPTIONS.md) and [`COMPETITIVE-RESEARCH.md`](COMPETITIVE-RESEARCH.md) for adjacent strategic tradeoff context
 
-## Next depth to add
+## Further detail still missing
 
-This file can still grow into deeper reference for:
+Deeper follow-up documentation is still useful for:
 - standalone-first rationale
 - local-first vs server-grade positioning
 - deployment-shape tradeoffs


### PR DESCRIPTION
## Summary
- clarify the remaining follow-up sections across the secondary entry docs so they read like intentional deeper-detail gaps instead of vague future placeholders
- keep the wording cleanup coherent across operator/reference/contributor/strategy docs as one cross-surface package

## What changed
- `docs/operator/CONFIGURATION.md`
- `docs/operator/PROVIDERS.md`
- `docs/operator/CHANNELS.md`
- `docs/operator/HEALTH-AND-DOCTOR.md`
- `docs/operator/MEMORY.md`
- `docs/reference/API.md`
- `docs/reference/CLI.md`
- `docs/reference/ARCHITECTURE.md`
- `docs/contributor/CONTRIBUTING.md`
- `docs/contributor/TESTING.md`
- `docs/contributor/WORKFLOW.md`
- `docs/strategy/STANDALONE-STRATEGY.md`

## Validation
- local markdown link existence sweep across `README.md`, `ROADMAP.md`, `docs/**/*.md`, and `rune-plan.md`
- `git diff --check`

## Related
- advances #20
- coherent secondary-entry docs wording milestone