### PR TITLE
fix: repair main clippy regression in rune-gateway routes

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -3062,7 +3062,8 @@ pub struct MemoryStatusResponse {
 #[derive(Deserialize)]
 pub struct MemorySearchQuery {
     pub q: Option<String>,
-    pub limit: Option<usize>,
+    #[serde(rename = "limit")]
+    pub _limit: Option<usize>,
 }
 
 #[derive(Serialize)]
@@ -3106,10 +3107,14 @@ pub async fn memory_search(
 
 #[derive(Deserialize)]
 pub struct LogsQuery {
-    pub level: Option<String>,
-    pub source: Option<String>,
-    pub limit: Option<usize>,
-    pub since: Option<String>,
+    #[serde(rename = "level")]
+    pub _level: Option<String>,
+    #[serde(rename = "source")]
+    pub _source: Option<String>,
+    #[serde(rename = "limit")]
+    pub _limit: Option<usize>,
+    #[serde(rename = "since")]
+    pub _since: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -3178,18 +3183,14 @@ pub async fn doctor_run(State(state): State<AppState>) -> Result<Json<DoctorRepo
     drop(config);
 
     let session_check = state.session_repo.list(1, 0).await;
+    let (session_store_status, session_store_message) = match session_check {
+        Ok(_) => ("pass", "session store reachable".to_string()),
+        Err(error) => ("fail", format!("session store error: {error}")),
+    };
     checks.push(DoctorCheck {
         name: "session_store".to_string(),
-        status: if session_check.is_ok() {
-            "pass"
-        } else {
-            "fail"
-        },
-        message: if session_check.is_ok() {
-            "session store reachable".to_string()
-        } else {
-            format!("session store error: {}", session_check.unwrap_err())
-        },
+        status: session_store_status,
+        message: session_store_message,
     });
 
     checks.push(DoctorCheck {


### PR DESCRIPTION
## Summary
- rename unused query-only fields in  and  to underscore-prefixed bindings while preserving HTTP parameter names with 
- replace the unnecessary  pattern in  with an explicit match
- keep the change bounded to 

## Validation
- 
- 
- 
running 35 tests
test a2ui::tests::a2ui_tool_definition_exposes_expected_schema ... ok
test events::tests::all_event_families_roundtrip ... ok
test a2ui::tests::broadcast_a2ui_event_sends_session_event ... ok
test a2ui::tests::a2ui_tool_emits_push_event ... ok
test events::tests::approval_event_kinds_are_dotted ... ok
test events::tests::approval_events_always_change_state ... ok
test events::tests::broadcast_sends_converted_session_event ... ok
test events::tests::process_event_kinds_are_dotted ... ok
test events::tests::process_exited_omits_exit_code_when_none ... ok
test events::tests::process_output_does_not_change_state ... ok
test events::tests::runtime_event_converts_to_session_event ... ok
test events::tests::runtime_event_delegates_session_id ... ok
test events::tests::runtime_event_delegates_to_inner_event_kind ... ok
test events::tests::runtime_event_payload_is_inner_event_only ... ok
test events::tests::runtime_event_roundtrips_through_serde ... ok
test events::tests::tool_event_kinds_are_dotted ... ok
test events::tests::tool_failed_serialises_error ... ok
test events::tests::turn_completed_omits_usage_when_none ... ok
test events::tests::turn_completed_serialises_usage_when_present ... ok
test events::tests::turn_event_kinds_are_dotted ... ok
test events::tests::turn_started_serialises_with_kind_tag ... ok
test events::tests::turn_state_changed_flags ... ok
test supervisor::tests::supervisor_default_trait ... ok
test supervisor::tests::supervisor_starts_and_stops_cleanly ... ok
test ws::tests::conn_state_family_prefix_matches_dotted_event_kinds ... ok
test ws::tests::conn_state_matches_event_filters ... ok
test ws::tests::encode_res_includes_state_version ... ok
test ws::tests::legacy_subscribe_bumps_state_version_once ... ok
test ws::tests::legacy_subscribe_frame_returns_ack_and_updates_state ... ok
test ws::tests::malformed_frame_returns_parse_error_response ... ok
test ws::tests::missing_subscription_target_does_not_bump_state_version ... ok
test ws::tests::rpc_error_is_encoded_as_error_response ... ok
test ws::tests::subscribe_all_flag_controls_event_delivery_for_any_session ... ok
test ws::tests::subscribe_req_updates_connection_state_and_returns_ack ... ok
test ws::tests::unsubscribe_req_updates_connection_state_and_returns_ack ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 54 tests
test auth_rejection_on_bad_token ... ok
test auth_accepts_valid_token ... ok
test auth_rejection_on_missing_token ... ok
test cron_add_respects_interval_anchor_for_first_run ... ok
test dashboard_models_lists_provider_inventory ... ok
test mem_device_repo_prunes_expired_requests ... ok
test dashboard_html_requires_auth_when_enabled ... ok
test get_session_not_found ... ok
test dashboard_html_renders ... ok
test dashboard_summary_reports_runtime_counts ... ok
test patch_and_delete_session_routes_work ... ok
test dashboard_sessions_includes_kind_and_activity_fields ... ok
test device_list_masks_tokens_and_includes_pending_requests ... ok
test list_sessions_filters_by_channel_and_activity ... ok
test device_pair_approve_rejects_wrong_signature ... ok
test get_session_status_surfaces_subagent_metadata ... ok
test cron_add_computes_real_next_run_for_cron_schedule ... ok
test device_pair_approve_rejects_expired_request ... ok
test get_session_returns_aggregate_usage_and_turn_metadata ... ok
test dashboard_diagnostics_falls_back_to_status_notes ... ok
test create_session_returns_201 ... ok
test ws_handle_text_message_dispatches_rpc_errors ... ok
test ws_handle_text_message_subscribe_unsubscribe_and_errors ... ok
test ws_handle_text_message_supports_event_and_global_subscriptions ... ok
test ws_rpc_runtime_lanes_reports_lane_queue_stats ... ok
test ws_rpc_health_reports_session_count ... ok
test ws_rpc_session_get_includes_last_turn_timestamps ... ok
test ws_rpc_session_status_surfaces_defaults_and_usage ... ok
test device_management_requires_gateway_token_even_when_auth_enabled ... ok
test ws_rpc_session_status_rejects_invalid_uuid ... ok
test ws_rpc_status_matches_http_status_basics ... ok
test processes_routes_surface_empty_inventory ... ok
test ws_subscribe_bumps_state_version_once_and_non_subscription_rpc_does_not ... ok
test status_reports_configured_lane_capacities ... ok
test list_sessions_empty ... ok
test transcript_session_not_found ... ok
test health_is_public_even_with_auth ... ok
test ws_rpc_skills_reload_and_toggle_round_trip ... ok
test health_returns_200 ... ok
test status_returns_correct_shape ... ok
test status_includes_skill_status_shape ... ok
test list_sessions_includes_turn_aggregates ... ok
test send_message_and_transcript_with_shared_state ... ok
test get_session_status_returns_parity_card_fields ... ok
test expired_paired_device_token_is_rejected_without_refreshing_last_seen ... ok
test paired_device_token_can_access_general_protected_routes_but_not_device_management ... ok
test skills_routes_list_reload_and_toggle ... ok
test device_pair_request_rejects_duplicate_public_key ... ok
test device_pair_request_is_public_but_approve_requires_gateway_token ... ok
test paired_device_token_cannot_approve_or_reject_other_pairing_requests ... ok
test device_reject_rotate_and_delete_routes_work ... ok
test device_pair_pending_route_requires_gateway_token ... ok
test send_message_session_not_found ... ok
test cron_run_executes_and_records_run_history ... ok

test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Fixes the current main clippy regression seen in Rust CI run 23249029796.