### PR TITLE
feat(gateway): close cron CLI and operator parity gaps

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -1,6 +1,6 @@
 //! Clap-based CLI definition with all subcommands.
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 
 /// Rune — the operator CLI for managing the Rune AI runtime.
 #[derive(Debug, Parser)]
@@ -177,14 +177,31 @@ pub enum CronAction {
         /// Session target (`main` or `isolated`). Defaults to `main`.
         #[arg(long, default_value = "main")]
         session_target: String,
+        /// Delivery mode for the scheduled work (`none`, `announce`, or `webhook`).
+        #[arg(long, value_enum, default_value_t = CronDeliveryMode::None)]
+        delivery_mode: CronDeliveryMode,
     },
-    /// Update a job's display name.
+    /// Inspect a job.
+    Show {
+        /// Job ID.
+        id: String,
+    },
+    /// Update a job's display name or delivery mode.
+    #[command(group(
+        ArgGroup::new("cron_edit_changes")
+            .required(true)
+            .multiple(true)
+            .args(["name", "delivery_mode"])
+    ))]
     Edit {
         /// Job ID.
         id: String,
         /// New name.
         #[arg(long)]
-        name: String,
+        name: Option<String>,
+        /// New delivery mode.
+        #[arg(long, value_enum)]
+        delivery_mode: Option<CronDeliveryMode>,
     },
     /// Enable a job.
     Enable {
@@ -217,8 +234,8 @@ pub enum CronAction {
         #[arg(long)]
         text: String,
         /// Delivery timing mode (`next-heartbeat` or `now`).
-        #[arg(long, default_value = "next-heartbeat")]
-        mode: String,
+        #[arg(long, value_enum, default_value_t = WakeMode::NextHeartbeat)]
+        mode: WakeMode,
         /// Optional number of recent context messages to attach.
         #[arg(long = "context-messages")]
         context_messages: Option<u64>,
@@ -323,8 +340,8 @@ pub enum SystemAction {
         #[arg(long)]
         text: String,
         /// Delivery timing mode (`next-heartbeat` or `now`).
-        #[arg(long, default_value = "next-heartbeat")]
-        mode: String,
+        #[arg(long, value_enum, default_value_t = WakeMode::NextHeartbeat)]
+        mode: WakeMode,
         /// Optional number of recent context messages to attach.
         #[arg(long = "context-messages")]
         context_messages: Option<u64>,
@@ -393,6 +410,40 @@ pub enum CompletionShell {
     Fish,
     PowerShell,
     Zsh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CronDeliveryMode {
+    None,
+    Announce,
+    Webhook,
+}
+
+impl CronDeliveryMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Announce => "announce",
+            Self::Webhook => "webhook",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum WakeMode {
+    NextHeartbeat,
+    Now,
+}
+
+impl WakeMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NextHeartbeat => "next-heartbeat",
+            Self::Now => "now",
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -834,7 +885,7 @@ mod tests {
                     },
             } => {
                 assert_eq!(text, "Reminder: check Rune");
-                assert_eq!(mode, "now");
+                assert_eq!(mode, WakeMode::Now);
                 assert_eq!(context_messages, Some(2));
             }
             other => panic!("unexpected command: {other:?}"),
@@ -943,6 +994,8 @@ mod tests {
             "hello",
             "--at",
             "2026-03-13T13:00:00Z",
+            "--delivery-mode",
+            "announce",
         ])
         .unwrap();
         match cli.command {
@@ -952,27 +1005,55 @@ mod tests {
                         text,
                         at,
                         session_target,
+                        delivery_mode,
                         ..
                     },
             } => {
                 assert_eq!(text, "hello");
                 assert_eq!(at, "2026-03-13T13:00:00Z");
                 assert_eq!(session_target, "main");
+                assert_eq!(delivery_mode, CronDeliveryMode::Announce);
             }
             other => panic!("unexpected command: {other:?}"),
         }
     }
 
     #[test]
-    fn parse_cron_edit() {
-        let cli =
-            Cli::try_parse_from(["rune", "cron", "edit", "job-1", "--name", "renamed"]).unwrap();
+    fn parse_cron_show() {
+        let cli = Cli::try_parse_from(["rune", "cron", "show", "job-1"]).unwrap();
         match cli.command {
             Command::Cron {
-                action: CronAction::Edit { id, name },
+                action: CronAction::Show { id },
+            } => assert_eq!(id, "job-1"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cron_edit() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "cron",
+            "edit",
+            "job-1",
+            "--name",
+            "renamed",
+            "--delivery-mode",
+            "webhook",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Cron {
+                action:
+                    CronAction::Edit {
+                        id,
+                        name,
+                        delivery_mode,
+                    },
             } => {
                 assert_eq!(id, "job-1");
-                assert_eq!(name, "renamed");
+                assert_eq!(name.as_deref(), Some("renamed"));
+                assert_eq!(delivery_mode, Some(CronDeliveryMode::Webhook));
             }
             other => panic!("unexpected command: {other:?}"),
         }
@@ -1048,7 +1129,7 @@ mod tests {
                     },
             } => {
                 assert_eq!(text, "Reminder: check Rune");
-                assert_eq!(mode, "now");
+                assert_eq!(mode, WakeMode::Now);
                 assert_eq!(context_messages, Some(3));
             }
             other => panic!("unexpected command: {other:?}"),

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -11,11 +11,11 @@ use toml_edit::{DocumentMut, Item, Table, Value};
 use crate::output::{
     ActionResult, ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
-    ConfigValidationResult, CronJobSummary, CronListResponse, CronRunSummary, CronRunsResponse,
-    CronStatusResponse, DoctorCheck, DoctorReport, GatewayCallResponse, GatewayDiscoverResponse,
-    GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
-    ReminderSummary, RemindersListResponse, SessionDetailResponse, SessionListResponse,
-    SessionStatusCard, SessionSummary, StatusResponse,
+    ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
+    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
+    GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
+    HealthResponse, HeartbeatStatusResponse, ReminderSummary, RemindersListResponse,
+    SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -472,33 +472,33 @@ impl GatewayClient {
         let resp = self
             .http
             .get(self.url("/cron"))
-            .query(&[("includeDisabled", include_disabled)])
+            .query(&[("include_disabled", include_disabled)])
             .send()
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let items: serde_json::Value = resp.json().await.context("invalid JSON from /cron")?;
-            let jobs = items
-                .as_array()
-                .unwrap_or(&vec![])
-                .iter()
-                .map(|job| CronJobSummary {
-                    id: job["id"].as_str().unwrap_or("?").to_string(),
-                    name: job["name"].as_str().map(String::from),
-                    enabled: job["enabled"].as_bool().unwrap_or(false),
-                    session_target: job["session_target"]
-                        .as_str()
-                        .unwrap_or("unknown")
-                        .to_string(),
-                    schedule_kind: job["schedule"]["kind"]
-                        .as_str()
-                        .unwrap_or("unknown")
-                        .to_string(),
-                    next_run_at: job["next_run_at"].as_str().map(String::from),
-                    run_count: job["run_count"].as_u64().unwrap_or(0),
-                })
-                .collect();
+            let jobs = resp
+                .json::<Vec<CronJobSummary>>()
+                .await
+                .context("invalid JSON from /cron")?;
             Ok(CronListResponse { jobs })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /cron/{id}`
+    pub async fn cron_get(&self, id: &str) -> Result<CronJobDetailResponse> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/cron/{id}")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            resp.json()
+                .await
+                .context("invalid JSON from GET /cron/{id}")
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -511,6 +511,7 @@ impl GatewayClient {
         text: &str,
         at: DateTime<Utc>,
         session_target: &str,
+        delivery_mode: &str,
     ) -> Result<ActionResult> {
         let resp = self
             .http
@@ -519,7 +520,8 @@ impl GatewayClient {
                 "name": name,
                 "schedule": { "kind": "at", "at": at.to_rfc3339() },
                 "payload": { "kind": "system_event", "text": text },
-                "sessionTarget": session_target,
+                "session_target": session_target,
+                "delivery_mode": delivery_mode,
                 "enabled": true
             }))
             .send()
@@ -541,8 +543,20 @@ impl GatewayClient {
     }
 
     /// `POST /cron/{id}`
-    pub async fn cron_edit_name(&self, id: &str, name: &str) -> Result<ActionResult> {
-        self.cron_patch(id, json!({ "name": name }), "Cron job updated")
+    pub async fn cron_update(
+        &self,
+        id: &str,
+        name: Option<&str>,
+        delivery_mode: Option<&str>,
+    ) -> Result<ActionResult> {
+        let mut payload = serde_json::Map::new();
+        if let Some(name) = name {
+            payload.insert("name".to_string(), json!(name));
+        }
+        if let Some(delivery_mode) = delivery_mode {
+            payload.insert("delivery_mode".to_string(), json!(delivery_mode));
+        }
+        self.cron_patch(id, serde_json::Value::Object(payload), "Cron job updated")
             .await
     }
 
@@ -659,7 +673,7 @@ impl GatewayClient {
             .json(&json!({
                 "text": text,
                 "mode": mode,
-                "contextMessages": context_messages,
+                "context_messages": context_messages,
             }))
             .send()
             .await
@@ -1244,7 +1258,7 @@ pub fn show_config() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -1370,13 +1384,19 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/cron"))
+            .and(query_param("include_disabled", "false"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([
                 {
                     "id": "job-1",
                     "name": "test",
+                    "schedule": { "kind": "at", "at": "2026-03-18T10:00:00Z" },
+                    "payload": { "kind": "system_event", "text": "ping" },
+                    "delivery_mode": "announce",
                     "enabled": true,
                     "session_target": "main",
-                    "schedule": { "kind": "at" },
+                    "created_at": "2026-03-18T09:00:00Z",
+                    "last_run_at": null,
+                    "next_run_at": "2026-03-18T10:00:00Z",
                     "run_count": 0
                 }
             ])))
@@ -1386,6 +1406,120 @@ mod tests {
         let resp = client.cron_list(false).await.unwrap();
         assert_eq!(resp.jobs.len(), 1);
         assert_eq!(resp.jobs[0].id, "job-1");
+        assert_eq!(resp.jobs[0].delivery_mode, "announce");
+        assert_eq!(resp.jobs[0].payload.kind(), "system_event");
+    }
+
+    #[tokio::test]
+    async fn cron_get_parses_detail() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/cron/job-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "job-1",
+                "name": "test",
+                "schedule": { "kind": "cron", "expr": "0 * * * * *", "tz": "UTC" },
+                "payload": { "kind": "system_event", "text": "ping" },
+                "delivery_mode": "webhook",
+                "enabled": true,
+                "session_target": "main",
+                "created_at": "2026-03-18T09:00:00Z",
+                "last_run_at": "2026-03-18T09:30:00Z",
+                "next_run_at": "2026-03-18T10:00:00Z",
+                "run_count": 2
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.cron_get("job-1").await.unwrap();
+        assert_eq!(resp.job.id, "job-1");
+        assert_eq!(resp.job.delivery_mode, "webhook");
+        assert_eq!(resp.job.schedule.kind(), "cron");
+    }
+
+    #[tokio::test]
+    async fn cron_add_uses_snake_case_surface() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cron"))
+            .and(body_json(json!({
+                "name": "daily",
+                "schedule": { "kind": "at", "at": "2026-03-18T10:00:00+00:00" },
+                "payload": { "kind": "system_event", "text": "ping" },
+                "session_target": "main",
+                "delivery_mode": "announce",
+                "enabled": true
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "success": true,
+                "job_id": "job-1",
+                "message": "cron job created"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .cron_add_system_event(
+                Some("daily"),
+                "ping",
+                DateTime::parse_from_rfc3339("2026-03-18T10:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                "main",
+                "announce",
+            )
+            .await
+            .unwrap();
+        assert!(resp.success);
+    }
+
+    #[tokio::test]
+    async fn cron_update_sends_selected_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cron/job-1"))
+            .and(body_json(json!({
+                "name": "renamed",
+                "delivery_mode": "webhook"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "job_id": "job-1",
+                "message": "cron job updated"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .cron_update("job-1", Some("renamed"), Some("webhook"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+    }
+
+    #[tokio::test]
+    async fn cron_wake_uses_snake_case_context_messages() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cron/wake"))
+            .and(body_json(json!({
+                "text": "wake up",
+                "mode": "now",
+                "context_messages": 3
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "wake event queued for now"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.cron_wake("wake up", "now", Some(3)).await.unwrap();
+        assert!(resp.success);
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -24,8 +24,8 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 pub use cli::Cli;
 use cli::{
     ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell, ConfigAction,
-    CronAction, GatewayAction, MemoryAction, ModelsAction, RemindersAction, SessionsAction,
-    SystemAction, SystemHeartbeatAction,
+    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, ModelsAction, RemindersAction,
+    SessionsAction, SystemAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -745,17 +745,38 @@ pub async fn run(cli: Cli) -> Result<()> {
                 text,
                 at,
                 session_target,
+                delivery_mode,
             } => {
                 let at = DateTime::parse_from_rfc3339(&at)
                     .with_context(|| format!("invalid --at timestamp: {at}"))?
                     .with_timezone(&Utc);
                 let result = client
-                    .cron_add_system_event(name.as_deref(), &text, at, &session_target)
+                    .cron_add_system_event(
+                        name.as_deref(),
+                        &text,
+                        at,
+                        &session_target,
+                        delivery_mode.as_str(),
+                    )
                     .await?;
                 println!("{}", render(&result, format));
             }
-            CronAction::Edit { id, name } => {
-                let result = client.cron_edit_name(&id, &name).await?;
+            CronAction::Show { id } => {
+                let result = client.cron_get(&id).await?;
+                println!("{}", render(&result, format));
+            }
+            CronAction::Edit {
+                id,
+                name,
+                delivery_mode,
+            } => {
+                let result = client
+                    .cron_update(
+                        &id,
+                        name.as_deref(),
+                        delivery_mode.map(CronDeliveryMode::as_str),
+                    )
+                    .await?;
                 println!("{}", render(&result, format));
             }
             CronAction::Enable { id } => {
@@ -783,7 +804,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 mode,
                 context_messages,
             } => {
-                let result = client.cron_wake(&text, &mode, context_messages).await?;
+                let result = client
+                    .cron_wake(&text, mode.as_str(), context_messages)
+                    .await?;
                 println!("{}", render(&result, format));
             }
         },
@@ -892,7 +915,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 mode,
                 context_messages,
             } => {
-                let result = client.cron_wake(&text, &mode, context_messages).await?;
+                let result = client
+                    .cron_wake(&text, mode.as_str(), context_messages)
+                    .await?;
                 println!("{}", render(&result, format));
             }
             SystemAction::Heartbeat { action } => match action {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1259,12 +1259,114 @@ impl fmt::Display for CronStatusResponse {
 
 /// A cron job summary/detail item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CronScheduleSummary {
+    At {
+        at: String,
+    },
+    Every {
+        every_ms: u64,
+        #[serde(default)]
+        anchor_ms: Option<u64>,
+    },
+    Cron {
+        expr: String,
+        #[serde(default)]
+        tz: Option<String>,
+    },
+}
+
+impl CronScheduleSummary {
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::At { .. } => "at",
+            Self::Every { .. } => "every",
+            Self::Cron { .. } => "cron",
+        }
+    }
+
+    fn render_human(&self) -> String {
+        match self {
+            Self::At { at } => format!("at {at}"),
+            Self::Every {
+                every_ms,
+                anchor_ms,
+            } => {
+                let mut summary = format!("every {every_ms}ms");
+                if let Some(anchor_ms) = anchor_ms {
+                    summary.push_str(&format!(" anchor={anchor_ms}"));
+                }
+                summary
+            }
+            Self::Cron { expr, tz } => match tz {
+                Some(tz) => format!("cron {expr} tz={tz}"),
+                None => format!("cron {expr}"),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CronPayloadSummary {
+    SystemEvent {
+        text: String,
+    },
+    AgentTurn {
+        message: String,
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+    },
+}
+
+impl CronPayloadSummary {
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::SystemEvent { .. } => "system_event",
+            Self::AgentTurn { .. } => "agent_turn",
+        }
+    }
+
+    fn render_human(&self) -> String {
+        match self {
+            Self::SystemEvent { text } => format!("system_event text={}", quoted(text)),
+            Self::AgentTurn {
+                message,
+                model,
+                timeout_seconds,
+            } => {
+                let mut summary = format!("agent_turn message={}", quoted(message));
+                if let Some(model) = model {
+                    summary.push_str(&format!(" model={model}"));
+                }
+                if let Some(timeout_seconds) = timeout_seconds {
+                    summary.push_str(&format!(" timeout={}s", timeout_seconds));
+                }
+                summary
+            }
+        }
+    }
+}
+
+fn quoted(value: &str) -> String {
+    format!("{value:?}")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CronJobSummary {
     pub id: String,
     pub name: Option<String>,
+    pub schedule: CronScheduleSummary,
+    pub payload: CronPayloadSummary,
+    pub delivery_mode: String,
     pub enabled: bool,
     pub session_target: String,
-    pub schedule_kind: String,
+    pub created_at: String,
+    pub last_run_at: Option<String>,
     pub next_run_at: Option<String>,
     pub run_count: u64,
 }
@@ -1280,10 +1382,53 @@ impl fmt::Display for CronJobSummary {
             self.session_target,
             self.run_count
         )?;
+        write!(
+            f,
+            " delivery={} payload={} schedule={}",
+            self.delivery_mode,
+            self.payload.kind(),
+            self.schedule.kind()
+        )?;
         if let Some(next) = &self.next_run_at {
             write!(f, " next={next}")?;
         }
         Ok(())
+    }
+}
+
+/// Detailed cron job inspection response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CronJobDetailResponse {
+    #[serde(flatten)]
+    pub job: CronJobSummary,
+}
+
+impl fmt::Display for CronJobDetailResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Cron job")?;
+        writeln!(f, "  Id:             {}", self.job.id)?;
+        writeln!(
+            f,
+            "  Name:           {}",
+            self.job.name.as_deref().unwrap_or("(unnamed)")
+        )?;
+        writeln!(f, "  Enabled:        {}", self.job.enabled)?;
+        writeln!(f, "  Session target: {}", self.job.session_target)?;
+        writeln!(f, "  Delivery mode:  {}", self.job.delivery_mode)?;
+        writeln!(f, "  Schedule:       {}", self.job.schedule.render_human())?;
+        writeln!(f, "  Payload:        {}", self.job.payload.render_human())?;
+        writeln!(f, "  Created:        {}", self.job.created_at)?;
+        writeln!(
+            f,
+            "  Last run:       {}",
+            self.job.last_run_at.as_deref().unwrap_or("(never)")
+        )?;
+        writeln!(
+            f,
+            "  Next run:       {}",
+            self.job.next_run_at.as_deref().unwrap_or("(none)")
+        )?;
+        write!(f, "  Runs:           {}", self.job.run_count)
     }
 }
 
@@ -1575,6 +1720,69 @@ mod tests {
     fn render_cron_list_empty() {
         let l = CronListResponse { jobs: vec![] };
         assert_eq!(render(&l, OutputFormat::Human), "No cron jobs.");
+    }
+
+    #[test]
+    fn render_cron_list_item_includes_delivery_and_kinds() {
+        let response = CronListResponse {
+            jobs: vec![CronJobSummary {
+                id: "job-1".into(),
+                name: Some("daily-check".into()),
+                schedule: CronScheduleSummary::Cron {
+                    expr: "0 0 9 * * *".into(),
+                    tz: Some("Europe/Sarajevo".into()),
+                },
+                payload: CronPayloadSummary::SystemEvent {
+                    text: "run daily check".into(),
+                },
+                delivery_mode: "announce".into(),
+                enabled: true,
+                session_target: "main".into(),
+                created_at: "2026-03-18T09:00:00Z".into(),
+                last_run_at: None,
+                next_run_at: Some("2026-03-18T10:00:00Z".into()),
+                run_count: 3,
+            }],
+        };
+
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("delivery=announce"));
+        assert!(out.contains("payload=system_event"));
+        assert!(out.contains("schedule=cron"));
+    }
+
+    #[test]
+    fn render_cron_job_detail() {
+        let response = CronJobDetailResponse {
+            job: CronJobSummary {
+                id: "job-1".into(),
+                name: Some("daily-check".into()),
+                schedule: CronScheduleSummary::Every {
+                    every_ms: 60000,
+                    anchor_ms: Some(12345),
+                },
+                payload: CronPayloadSummary::AgentTurn {
+                    message: "check queue".into(),
+                    model: Some("gpt-5.4".into()),
+                    timeout_seconds: Some(30),
+                },
+                delivery_mode: "webhook".into(),
+                enabled: false,
+                session_target: "isolated".into(),
+                created_at: "2026-03-18T09:00:00Z".into(),
+                last_run_at: Some("2026-03-18T09:30:00Z".into()),
+                next_run_at: None,
+                run_count: 2,
+            },
+        };
+
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Delivery mode:  webhook"));
+        assert!(out.contains("Schedule:       every 60000ms anchor=12345"));
+        assert!(out.contains(
+            "Payload:        agent_turn message=\"check queue\" model=gpt-5.4 timeout=30s"
+        ));
+        assert!(out.contains("Next run:       (none)"));
     }
 
     #[test]

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -468,7 +468,7 @@ pub async fn gateway_restart() -> Json<ActionResponse> {
 
 #[derive(Deserialize)]
 pub struct CronListQuery {
-    #[serde(rename = "includeDisabled")]
+    #[serde(rename = "includeDisabled", alias = "include_disabled")]
     pub include_disabled: Option<bool>,
 }
 
@@ -484,7 +484,7 @@ pub struct SessionsListQuery {
 pub struct CronWakeRequest {
     pub text: String,
     pub mode: Option<String>,
-    #[serde(rename = "contextMessages")]
+    #[serde(rename = "contextMessages", alias = "context_messages")]
     pub context_messages: Option<u64>,
 }
 
@@ -493,8 +493,10 @@ pub struct CronJobRequest {
     pub name: Option<String>,
     pub schedule: CronScheduleRequest,
     pub payload: CronPayloadRequest,
-    #[serde(rename = "sessionTarget")]
+    #[serde(rename = "sessionTarget", alias = "session_target")]
     pub session_target: String,
+    #[serde(default, rename = "deliveryMode", alias = "delivery_mode")]
+    pub delivery_mode: Option<SchedulerDeliveryMode>,
     pub enabled: Option<bool>,
 }
 
@@ -533,6 +535,8 @@ pub struct CronUpdateRequest {
     pub enabled: Option<bool>,
     pub schedule: Option<CronScheduleRequest>,
     pub payload: Option<CronPayloadRequest>,
+    #[serde(default, rename = "deliveryMode", alias = "delivery_mode")]
+    pub delivery_mode: Option<SchedulerDeliveryMode>,
 }
 
 #[derive(Serialize)]
@@ -548,6 +552,7 @@ pub struct CronJobResponse {
     pub name: Option<String>,
     pub schedule: Schedule,
     pub payload: JobPayload,
+    pub delivery_mode: SchedulerDeliveryMode,
     pub session_target: SessionTarget,
     pub enabled: bool,
     pub created_at: String,
@@ -603,6 +608,19 @@ pub async fn cron_list(
     Ok(Json(jobs.into_iter().map(job_to_response).collect()))
 }
 
+pub async fn cron_get(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<CronJobResponse>, GatewayError> {
+    let job_id = JobId::from(id);
+    let job = state
+        .scheduler
+        .get_job(&job_id)
+        .await
+        .ok_or_else(|| GatewayError::JobNotFound(job_id.to_string()))?;
+    Ok(Json(job_to_response(job)))
+}
+
 pub async fn cron_add(
     State(state): State<AppState>,
     Json(body): Json<CronJobRequest>,
@@ -620,7 +638,7 @@ pub async fn cron_add(
         name: body.name,
         schedule,
         payload,
-        delivery_mode: SchedulerDeliveryMode::None,
+        delivery_mode: body.delivery_mode.unwrap_or(SchedulerDeliveryMode::None),
         session_target,
         enabled: body.enabled.unwrap_or(true),
         created_at: now,
@@ -669,7 +687,7 @@ pub async fn cron_update(
         enabled: body.enabled,
         schedule: new_schedule,
         payload: new_payload,
-        delivery_mode: None,
+        delivery_mode: body.delivery_mode,
     };
 
     state
@@ -771,7 +789,7 @@ pub async fn cron_wake(
     State(state): State<AppState>,
     Json(body): Json<CronWakeRequest>,
 ) -> Result<Json<CronWakeResponse>, GatewayError> {
-    let mode = body.mode.unwrap_or_else(|| "next-heartbeat".to_string());
+    let mode = normalize_wake_mode(body.mode.as_deref())?;
 
     let _ = state.event_tx.send(SessionEvent {
         session_id: "system".to_string(),
@@ -779,6 +797,7 @@ pub async fn cron_wake(
         payload: json!({
             "text": body.text,
             "mode": mode,
+            "context_messages": body.context_messages,
             "contextMessages": body.context_messages,
         }),
         state_changed: false,
@@ -1364,6 +1383,21 @@ fn parse_session_target(s: &str) -> Result<SessionTarget, GatewayError> {
     }
 }
 
+fn normalize_wake_mode(mode: Option<&str>) -> Result<String, GatewayError> {
+    match mode
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .as_deref()
+    {
+        None => Ok("next-heartbeat".to_string()),
+        Some("next-heartbeat") | Some("next_heartbeat") => Ok("next-heartbeat".to_string()),
+        Some("now") => Ok("now".to_string()),
+        Some(other) => Err(GatewayError::BadRequest(format!(
+            "unknown wake mode: {other}"
+        ))),
+    }
+}
+
 fn convert_schedule(request: CronScheduleRequest) -> Schedule {
     match request {
         CronScheduleRequest::At { at } => Schedule::At { at },
@@ -1472,6 +1506,7 @@ fn job_to_response(job: Job) -> CronJobResponse {
         name: job.name,
         schedule: job.schedule,
         payload: job.payload,
+        delivery_mode: job.delivery_mode,
         session_target: job.session_target,
         enabled: job.enabled,
         created_at: job.created_at.to_rfc3339(),

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -241,7 +241,9 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/cron/wake", post(routes::cron_wake))
         .route(
             "/cron/{id}",
-            post(routes::cron_update).delete(routes::cron_remove),
+            get(routes::cron_get)
+                .post(routes::cron_update)
+                .delete(routes::cron_remove),
         )
         .route("/cron/{id}/run", post(routes::cron_run))
         .route("/cron/{id}/runs", get(routes::cron_runs))

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -91,6 +91,7 @@ impl RpcDispatcher {
             "a2ui.form_submit" => self.a2ui_form_submit(params).await,
             "a2ui.action" => self.a2ui_action(params).await,
             "cron.list" => self.cron_list(params).await,
+            "cron.get" => self.cron_get(params).await,
             "cron.status" => self.cron_status(params).await,
             "runtime.lanes" => self.runtime_lanes().await,
             "skills.list" => self.skills_list().await,
@@ -512,6 +513,7 @@ impl RpcDispatcher {
     async fn cron_list(&self, params: Value) -> Result<Value, RpcError> {
         let include_disabled = params
             .get("include_disabled")
+            .or_else(|| params.get("includeDisabled"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
@@ -523,6 +525,10 @@ impl RpcDispatcher {
                 json!({
                     "id": job.id.to_string(),
                     "name": job.name,
+                    "schedule": job.schedule,
+                    "payload": job.payload,
+                    "delivery_mode": job.delivery_mode,
+                    "session_target": job.session_target,
                     "enabled": job.enabled,
                     "created_at": job.created_at.to_rfc3339(),
                     "last_run_at": job.last_run_at.map(|dt| dt.to_rfc3339()),
@@ -533,6 +539,39 @@ impl RpcDispatcher {
             .collect();
 
         Ok(json!(items))
+    }
+
+    /// Inspect a single cron job. Params: `id` or `job_id` (required UUID).
+    async fn cron_get(&self, params: Value) -> Result<Value, RpcError> {
+        let job_id = params
+            .get("id")
+            .or_else(|| params.get("job_id"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| RpcError::bad_request("missing required field: id"))?;
+        let job_id = Uuid::parse_str(job_id)
+            .map_err(|err| RpcError::bad_request(format!("invalid job id: {err}")))?;
+        let job_id = rune_core::JobId::from(job_id);
+
+        let job = self
+            .state
+            .scheduler
+            .get_job(&job_id)
+            .await
+            .ok_or_else(|| RpcError::not_found(format!("job not found: {job_id}")))?;
+
+        Ok(json!({
+            "id": job.id.to_string(),
+            "name": job.name,
+            "schedule": job.schedule,
+            "payload": job.payload,
+            "delivery_mode": job.delivery_mode,
+            "session_target": job.session_target,
+            "enabled": job.enabled,
+            "created_at": job.created_at.to_rfc3339(),
+            "last_run_at": job.last_run_at.map(|dt| dt.to_rfc3339()),
+            "next_run_at": job.next_run_at.map(|dt| dt.to_rfc3339()),
+            "run_count": job.run_count,
+        }))
     }
 
     /// Cron scheduler status summary.

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1309,6 +1309,113 @@ async fn ws_rpc_health_reports_session_count() {
 }
 
 #[tokio::test]
+async fn ws_rpc_cron_list_and_get_surface_delivery_mode() {
+    use rune_gateway::ws_rpc::RpcDispatcher;
+
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let (event_tx, _) = broadcast::channel::<SessionEvent>(64);
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let now = chrono::Utc::now();
+    let job_id = scheduler
+        .add_job(rune_runtime::scheduler::Job {
+            id: rune_core::JobId::new(),
+            name: Some("daily-check".into()),
+            schedule: rune_runtime::scheduler::Schedule::Cron {
+                expr: "0 0 9 * * *".into(),
+                tz: Some("UTC".into()),
+            },
+            payload: rune_runtime::scheduler::JobPayload::SystemEvent {
+                text: "run daily check".into(),
+            },
+            delivery_mode: rune_core::SchedulerDeliveryMode::Announce,
+            session_target: rune_runtime::scheduler::SessionTarget::Main,
+            enabled: true,
+            created_at: now,
+            last_run_at: None,
+            next_run_at: Some(now),
+            run_count: 0,
+        })
+        .await;
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        process_manager: ProcessManager::new(),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        event_tx,
+        tts_engine: None,
+        stt_engine: None,
+    };
+
+    let dispatcher = RpcDispatcher::new(state);
+    let list = dispatcher
+        .dispatch("cron.list", serde_json::json!({ "includeDisabled": true }))
+        .await
+        .unwrap();
+    let items = list.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["delivery_mode"], "announce");
+    assert_eq!(items[0]["schedule"]["kind"], "cron");
+    assert_eq!(items[0]["payload"]["kind"], "system_event");
+
+    let detail = dispatcher
+        .dispatch("cron.get", serde_json::json!({ "id": job_id.to_string() }))
+        .await
+        .unwrap();
+    assert_eq!(detail["id"], job_id.to_string());
+    assert_eq!(detail["delivery_mode"], "announce");
+    assert_eq!(detail["session_target"], "main");
+}
+
+#[tokio::test]
 async fn ws_rpc_session_status_surfaces_defaults_and_usage() {
     use rune_gateway::ws_rpc::RpcDispatcher;
 
@@ -3900,6 +4007,116 @@ async fn cron_add_respects_interval_anchor_for_first_run() {
     let next_run_at = items[0]["next_run_at"].as_str().unwrap();
     let parsed = chrono::DateTime::parse_from_rfc3339(next_run_at).unwrap();
     assert_eq!(parsed.timestamp_millis(), anchor);
+}
+
+#[tokio::test]
+async fn cron_get_and_update_delivery_mode() {
+    let app = build_test_app(None);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/cron")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "name":"daily-check",
+                        "schedule":{"kind":"at","at":"2026-03-18T10:00:00Z"},
+                        "payload":{"kind":"system_event","text":"run daily check"},
+                        "session_target":"main",
+                        "delivery_mode":"announce",
+                        "enabled":true
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let job_id = created["job_id"].as_str().unwrap().to_string();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let job = body_json(response).await;
+    assert_eq!(job["delivery_mode"], "announce");
+    assert_eq!(job["payload"]["kind"], "system_event");
+    assert_eq!(job["schedule"]["kind"], "at");
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/cron/{job_id}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{ "delivery_mode":"webhook" }"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let job = body_json(response).await;
+    assert_eq!(job["delivery_mode"], "webhook");
+}
+
+#[tokio::test]
+async fn cron_wake_accepts_snake_case_and_normalizes_mode() {
+    let app = build_test_app(None);
+    let response = app
+        .oneshot(
+            Request::post("/cron/wake")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "text":"wake up",
+                        "mode":"next_heartbeat",
+                        "context_messages":2
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["mode"], "next-heartbeat");
+    assert_eq!(body["context_messages"], 2);
+}
+
+#[tokio::test]
+async fn cron_wake_rejects_unknown_mode() {
+    let app = build_test_app(None);
+    let response = app
+        .oneshot(
+            Request::post("/cron/wake")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "text":"wake up",
+                        "mode":"later"
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- complete cron/job/operator CLI parity for delivery modes, wake semantics, and job inspection flows
- align gateway HTTP + ws operator surfaces with the persisted scheduler/reminder semantics landed in #106 and #107
- extend route-level operator tests and output rendering around cron/job inspection behavior

## Scope
This PR is issue-43-task-3 from the planner artifact for #43.

## Assumptions for follow-on work
- docs/review follow-ons can now treat the operator-facing cron/reminder semantics as materially stable
- no further scheduler persistence schema changes are expected in this lane; this is gateway/CLI parity completion on top of the already-merged semantics

## Validation
- cargo check -p rune-cli -p rune-gateway
- cargo test -p rune-gateway route_tests
