### PR TITLE
docs: clarify scheduler contracts and parity inventory for #43

### DIFF
--- a/docs/IMPLEMENTATION-PHASES.md
+++ b/docs/IMPLEMENTATION-PHASES.md
@@ -215,14 +215,19 @@ Reproduce proactive automation behavior.
 - scheduled jobs are durable and inspectable
 - heartbeat behavior preserves quiet/no-op semantics
 - reminders and cron runs create auditable isolated execution records
-- operator can list, inspect, enable, disable, and review job history
+- operator can list, inspect, enable, disable, wake, and review job history
+- `sessionTarget=main` vs `sessionTarget=isolated` semantics are preserved without payload coercion
+- `none` / `announce` / `webhook` delivery modes remain inspectable and behaviorally distinct
+- reminder outcomes persist as delivered / missed / cancelled rather than disappearing into logs only
 
 ### Recommended parity tests
 
-- cron create/list/disable/enable/run-now flows
-- reminder due/delivered/cancelled flows
-- heartbeat instruction loading and no-op behavior
-- duplicate-notification suppression for repeated heartbeats
+- cron create/list/edit/disable/enable/run-now/wake flows
+- due-only vs forced-run history tests
+- `systemEvent` vs `agentTurn` session-target validation tests
+- delivery-mode tests for `none` / `announce` / `webhook`
+- reminder due/delivered/missed/cancelled flows
+- heartbeat instruction loading, no-op suppression, and duplicate-notification suppression behavior
 
 ### Key risk retired
 Automation behavior mismatch.

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -196,11 +196,15 @@ Do not mark a subsystem parity-complete without black-box evidence.
 - heartbeat-driven checks
 - isolated scheduled agent runs
 - run history and next-run calculation
+- scheduled payload and delivery semantics
 
 ### Invariants
 
 - enabled/disabled state is durable
+- schedule definition is compatibility surface: `at`, `every`, and cron-expression semantics may not drift silently
+- `sessionTarget=main` maps to `systemEvent` payloads and `sessionTarget=isolated` maps to `agentTurn` payloads; invalid combinations fail explicitly
 - reminder timing and wording remain operator-predictable
+- delivery modes preserve `none`, `announce`, and `webhook` semantics
 - heartbeat quiet/no-op semantics are preserved
 - repeated heartbeats do not spam without new cause
 - isolated scheduled runs remain auditable as isolated runs
@@ -209,28 +213,38 @@ Do not mark a subsystem parity-complete without black-box evidence.
 
 - jobs
 - schedules/due times
+- session target and payload kind
+- delivery mode and wake mode
 - last/next run metadata
-- run history
+- run history with due/manual trigger visibility
 - delivered/missed/cancelled status for reminders
+- heartbeat anti-spam state sufficient to suppress duplicate notifications across restarts
 
 ### External surfaces
 
 - cron APIs/CLI
-- run-now and inspection workflows
+- reminder APIs/CLI
+- heartbeat status/enable/disable APIs and CLI workflows
+- run-now, wake, and inspection workflows
 - history views
 
 ### Failure behavior expectations
 
 - missed runs are visible
 - invalid schedules fail explicitly
+- invalid `sessionTarget`/payload combinations fail explicitly
 - disabled jobs do not run silently
+- reminder delivery failures resolve to explicit `missed` outcomes rather than disappearing
+- heartbeat no-op and duplicate suppressions remain operator-inspectable even when no outbound message is emitted
 
 ### Minimum parity evidence
 
-- cron create/list/update/disable/enable/run tests
-- reminder due/delivered/cancelled tests
-- heartbeat no-op and notify tests
-- duplicate-suppression tests
+- cron create/list/update/disable/enable/run/wake tests
+- due-only vs forced-run history tests
+- `systemEvent` vs `agentTurn` session-target tests
+- delivery-mode tests for `none`/`announce`/`webhook`
+- reminder due/delivered/missed/cancelled tests
+- heartbeat no-op, notify, and duplicate-suppression tests
 
 ---
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -1139,6 +1139,12 @@ The rewrite still needs an equivalent orchestration strategy if the surrounding 
 - next-run calculation
 - due-only vs forced run semantics
 - run history retention
+- explicit `at`, `every`, and cron-expression schedule support
+- explicit `sessionTarget=main` vs `sessionTarget=isolated` behavior
+- explicit `systemEvent` vs `agentTurn` payload validation
+- explicit `none` / `announce` / `webhook` delivery-mode retention
+
+Implementation note (2026-03-19): Rune now has executable operator parity for the core cron surface: gateway routes cover `GET /cron/status`, `GET /cron`, `POST /cron`, `POST /cron/wake`, `POST /cron/{id}`, `DELETE /cron/{id}`, `POST /cron/{id}/run`, and `GET /cron/{id}/runs`; CLI flows cover `cron status|list|add|edit|enable|disable|rm|run|runs|wake`; runtime schedule handling computes interval anchors and timezone-aware cron next-fire times; invalid cron/tz definitions fail instead of silently fabricating a next run; and durable PostgreSQL-backed `jobs`/`job_runs` persistence now preserves created jobs, next-run state, and scheduled/manual run history across gateway restarts. Scheduled `main` jobs reuse the stable `system:scheduled-main` session while scheduled `isolated` jobs create fresh descendant `subagent` sessions linked through `requester_session_id`. Remaining parity work is broader black-box evidence for webhook delivery paths and any quiet-window policy layered above the core scheduler.
 
 ---
 
@@ -1152,8 +1158,9 @@ The rewrite still needs an equivalent orchestration strategy if the surrounding 
 - reminder text shaped like a reminder when delivered
 - mention that it is a reminder depending on timing/context
 - target chat/session delivery
+- delivered / missed / cancelled terminal outcomes remain inspectable
 
-Implementation note (2026-03-13): Rune now ships an executable reminder surface end-to-end: gateway routes for `GET /reminders`, `POST /reminders`, and `DELETE /reminders/{id}`; CLI flows for `reminders add|list|cancel`; runtime due-checking and delivered-state tracking in the scheduler; and supervisor-driven delivery by executing reminder text as a scheduled turn. Remaining parity work is durability across restart and evidence that final delivered wording consistently matches the OpenClaw reminder-shaping contract.
+Implementation note (2026-03-19): Rune now ships an executable reminder surface end-to-end with durable outcomes: gateway routes expose `GET /reminders`, `POST /reminders`, and `DELETE /reminders/{id}`; CLI flows expose `reminders add|list|cancel`; reminders persist through the scheduler job repository as `reminder` jobs with `announce` delivery mode; due-checking records delivery attempts; successful sends mark reminders delivered; failed sends mark reminders missed with persisted error context; and user/operator cancellation produces an explicit cancelled terminal outcome instead of silent disappearance. The remaining parity gap is not basic durability anymore; it is stronger black-box evidence that final delivered wording consistently matches the OpenClaw reminder-shaping contract.
 
 ---
 
@@ -1166,6 +1173,8 @@ Implementation note (2026-03-13): Rune now ships an executable reminder surface 
 - immediate wake
 - next-heartbeat wake
 - optional context carry-forward
+
+Implementation note (2026-03-19): Rune currently normalizes wake mode to `now` or `next-heartbeat`, with `next-heartbeat` as the default, and exposes that control through the cron wake flow. Remaining work is mostly evidence and any higher-level operator ergonomics, not absence of the wake-mode contract itself.
 
 ---
 
@@ -1182,8 +1191,9 @@ Implementation note (2026-03-13): Rune now ships an executable reminder surface 
 - suppress outbound delivery when heartbeat result is no-op ack
 - respect quiet windows and anti-spam behavior
 - maintain minimal state for proactive checks
+- persist enough anti-spam state to avoid duplicate notifications after restart
 
-Implementation note (2026-03-13): Rune now has a real heartbeat runner with persisted runner state, `HEARTBEAT.md` prompt loading, due-checking, suppression of no-op `HEARTBEAT_OK` responses, supervisor execution, and operator surfaces through `GET /heartbeat/status`, `POST /heartbeat/enable`, `POST /heartbeat/disable`, and CLI `system heartbeat presence|last|enable|disable|status`. Remaining work is fuller parity around quiet-window/duplicate-notification policy and restart durability evidence.
+Implementation note (2026-03-19): Rune now has a real heartbeat runner with persisted runner state, `HEARTBEAT.md` prompt loading, due-checking, suppression of no-op `HEARTBEAT_OK` responses, duplicate-notification suppression via normalized-response fingerprinting, persisted suppression counters/fingerprint state, supervisor execution, and operator surfaces through `GET /heartbeat/status`, `POST /heartbeat/enable`, `POST /heartbeat/disable`, and CLI `system heartbeat presence|last|enable|disable|status`. The remaining gap has narrowed: this is no longer “duplicate suppression missing,” but fuller parity evidence for OpenClaw-equivalent quiet-window and broader anti-spam policy behavior.
 
 ---
 

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -916,6 +916,19 @@ Cron jobs must preserve:
 - isolated execution context
 - configurable runtime/model if supported
 - due-only vs forced-run semantics
+- explicit wake semantics for `now` vs `next-heartbeat` where wake flows exist
+
+Validation rules:
+
+- `sessionTarget=main` requires a `systemEvent` payload
+- `sessionTarget=isolated` requires an `agentTurn` payload
+- invalid target/payload pairings fail as validation errors, not silent coercions
+- invalid cron expressions or timezone values fail explicitly and must not fabricate future run times
+
+Run-history expectations:
+
+- history should distinguish at least due-triggered vs operator-forced/manual runs
+- history rows should remain attributable to the originating job, trigger kind, and resulting scheduled session/run
 
 ## 11.2 Payload and delivery contract
 
@@ -924,11 +937,22 @@ Scheduled work must preserve the conceptual distinction between:
 - `systemEvent` payloads for main-session jobs
 - `agentTurn` payloads for isolated jobs
 
+Session-target semantics must preserve:
+
+- main-target runs reusing the stable scheduled main-session context
+- isolated-target runs creating fresh isolated/subagent descendant sessions with requester linkage
+
 Delivery modes must preserve:
 
 - `none`
 - `announce`
 - `webhook`
+
+Delivery semantics must also preserve:
+
+- `announce` meaning an operator-visible/session-visible surfaced result
+- `webhook` meaning an outbound webhook-style delivery path rather than an in-band chat announcement
+- `none` meaning the run remains auditable in history without requiring an operator-facing message
 
 ## 11.3 Heartbeat contract
 
@@ -944,7 +968,14 @@ Heartbeat invariants:
 
 - heartbeat runs are isolated and auditable
 - repeated heartbeats should not duplicate notifications without new cause
-- quiet/no-op outcomes should still be representable in run history
+- quiet/no-op outcomes should still be representable in run history or persisted heartbeat state
+- anti-spam state must survive restart well enough to avoid replaying the same notification solely because the process restarted
+
+Heartbeat suppression semantics:
+
+- `HEARTBEAT_OK`-style no-op responses suppress outbound delivery
+- duplicate non-noop responses may be suppressed when their normalized fingerprint matches the last delivered notification
+- suppression decisions should remain inspectable through runner state/status surfaces even when no outbound message is emitted
 
 ## 11.4 Reminder contract
 
@@ -956,6 +987,12 @@ Reminders need:
 - one-shot vs recurring distinction
 - delivered / missed / cancelled outcome tracking
 - reminder wording that reads like a reminder when fired
+
+Reminder outcome semantics must preserve:
+
+- successful delivery marking the reminder terminal as delivered
+- failed delivery attempts marking the reminder terminal as missed with inspectable error context
+- operator/user cancellation marking the reminder terminal as cancelled rather than silently deleting auditability
 
 ---
 


### PR DESCRIPTION
## Summary
- tighten the scheduler contract across parity docs for cron, reminders, wake, and heartbeat behavior
- document the now-executable Rune semantics for `systemEvent` vs `agentTurn`, delivery modes, run history, reminder terminal outcomes, and heartbeat duplicate suppression
- update Phase 4 acceptance criteria/tests so the remaining parity gaps are evidence gaps, not stale docs drift

## Files changed
- `docs/parity/PARITY-CONTRACTS.md`
- `docs/parity/PROTOCOLS.md`
- `docs/parity/PARITY-INVENTORY.md`
- `docs/IMPLEMENTATION-PHASES.md`

## Validation
- `git diff --check`
- focused repo evidence review across scheduler/heartbeat/reminder CLI, gateway routes, and runtime/store implementation paths

## Issue
- Closes #43
