### PR TITLE
docs(parity): clarify remaining scheduler runtime gaps

### DIFF
--- a/docs/IMPLEMENTATION-PHASES.md
+++ b/docs/IMPLEMENTATION-PHASES.md
@@ -201,8 +201,9 @@ Reproduce proactive automation behavior.
 
 - cron scheduling
 - one-shot reminders
+- wake/system-event queueing
 - heartbeat runs
-- isolated scheduled session runs
+- isolated-target scheduled session runs
 - job history and next-run computation
 - missed-run and disable/enable semantics
 
@@ -213,21 +214,23 @@ Reproduce proactive automation behavior.
 ### Acceptance criteria
 
 - scheduled jobs are durable and inspectable
-- heartbeat behavior preserves quiet/no-op semantics
-- reminders and cron runs create auditable isolated execution records
+- heartbeat behavior preserves shipped no-op and duplicate-suppression semantics
+- scheduled executions are auditable; `sessionTarget=isolated` cron jobs create descendant subagent sessions while main-target cron jobs, reminders, and heartbeats reuse scheduled session contexts
 - operator can list, inspect, enable, disable, wake, and review job history
 - `sessionTarget=main` vs `sessionTarget=isolated` semantics are preserved without payload coercion
-- `none` / `announce` / `webhook` delivery modes remain inspectable and behaviorally distinct
+- `none` / `announce` / `webhook` delivery modes remain inspectable even though runtime-specific branching is still follow-on work
 - reminder outcomes persist as delivered / missed / cancelled rather than disappearing into logs only
+- reminder targets remain inspectable even though current runtime delivery still reuses the scheduled main session
 
 ### Recommended parity tests
 
-- cron create/list/edit/disable/enable/run-now/wake flows
+- cron create/list/show/edit/disable/enable/run-now/wake flows
 - due-only vs forced-run history tests
 - `systemEvent` vs `agentTurn` session-target validation tests
-- delivery-mode tests for `none` / `announce` / `webhook`
-- reminder due/delivered/missed/cancelled flows
-- heartbeat instruction loading, no-op suppression, and duplicate-notification suppression behavior
+- delivery-mode retention/inspection tests for `none` / `announce` / `webhook`
+- reminder due/delivered/missed/cancelled plus target-retention flows
+- wake mode normalization and queued-event payload tests
+- heartbeat instruction loading, no-op suppression, and duplicate-notification suppression persistence behavior
 
 ### Key risk retired
 Automation behavior mismatch.

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -203,18 +203,19 @@ Do not mark a subsystem parity-complete without black-box evidence.
 - enabled/disabled state is durable
 - schedule definition is compatibility surface: `at`, `every`, and cron-expression semantics may not drift silently
 - `sessionTarget=main` maps to `systemEvent` payloads and `sessionTarget=isolated` maps to `agentTurn` payloads; invalid combinations fail explicitly
-- reminder timing and wording remain operator-predictable
-- delivery modes preserve `none`, `announce`, and `webhook` semantics
-- heartbeat quiet/no-op semantics are preserved
+- reminder timing and terminal outcomes remain operator-predictable; reminder `target` is retained as operator-visible metadata even though current execution still reuses the scheduled main session
+- delivery modes preserve `none`, `announce`, and `webhook` as durable, inspectable job metadata; runtime-specific branching on those modes is not yet a shipped contract
+- heartbeat no-op and duplicate-suppression semantics are preserved; broader quiet-window policy is still follow-on work
 - repeated heartbeats do not spam without new cause
-- isolated scheduled runs remain auditable as isolated runs
+- `sessionTarget=isolated` cron jobs remain auditable as isolated descendant runs; main-target cron jobs, reminders, and heartbeats reuse scheduled session contexts
+- wake requests preserve explicit `now` vs `next-heartbeat` mode selection on the operator/event surface; durable wake execution is not yet a shipped contract
 
 ### Required persisted state
 
 - jobs
 - schedules/due times
 - session target and payload kind
-- delivery mode and wake mode
+- delivery mode
 - last/next run metadata
 - run history with due/manual trigger visibility
 - delivered/missed/cancelled status for reminders
@@ -222,29 +223,31 @@ Do not mark a subsystem parity-complete without black-box evidence.
 
 ### External surfaces
 
-- cron APIs/CLI
+- cron APIs/CLI, including inspection and wake/system-event queueing
 - reminder APIs/CLI
-- heartbeat status/enable/disable APIs and CLI workflows
+- heartbeat status/enable/disable APIs plus CLI presence/last/status workflows
 - run-now, wake, and inspection workflows
 - history views
 
 ### Failure behavior expectations
 
 - missed runs are visible
-- invalid schedules fail explicitly
+- invalid schedules fail explicitly; stored cron jobs whose next run can no longer be computed disable rather than fabricating future fire times
 - invalid `sessionTarget`/payload combinations fail explicitly
 - disabled jobs do not run silently
 - reminder delivery failures resolve to explicit `missed` outcomes rather than disappearing
+- invalid wake modes fail explicitly
 - heartbeat no-op and duplicate suppressions remain operator-inspectable even when no outbound message is emitted
 
 ### Minimum parity evidence
 
-- cron create/list/update/disable/enable/run/wake tests
+- cron create/list/show/update/disable/enable/run/wake tests
 - due-only vs forced-run history tests
 - `systemEvent` vs `agentTurn` session-target tests
-- delivery-mode tests for `none`/`announce`/`webhook`
-- reminder due/delivered/missed/cancelled tests
-- heartbeat no-op, notify, and duplicate-suppression tests
+- delivery-mode retention/inspection tests for `none`/`announce`/`webhook`
+- reminder due/delivered/missed/cancelled and target-retention tests
+- wake mode normalization/event-payload tests
+- heartbeat no-op, notify, and duplicate-suppression persistence tests
 
 ---
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -402,12 +402,14 @@ Observed subflows include:
 - `cron status`
 - `cron list`
 - `cron add`
+- `cron show`
 - `cron edit`
 - `cron enable`
 - `cron disable`
 - `cron rm`
 - `cron run`
 - `cron runs`
+- `cron wake`
 
 ### Parity
 - **exact** for workflow and job-payload concepts
@@ -418,7 +420,7 @@ Observed subflows include:
 - enabled/disabled state
 - main-session `systemEvent` jobs
 - isolated `agentTurn` jobs
-- announce/webhook/none delivery modes
+- retained `announce`/`webhook`/`none` delivery-mode metadata
 - history inspection
 - due-only vs forced run semantics
 
@@ -640,7 +642,7 @@ Observed local families include:
 - `secrets reload|audit|configure|apply`
 - `security audit`
 - `system event`
-- `system heartbeat last|enable|disable|presence`
+- `system heartbeat last|enable|disable|presence|status`
 - `sandbox list|recreate|explain`
 
 These are release-critical because they directly affect operability, setup posture, security posture, isolation posture, and proactive behavior.
@@ -1000,15 +1002,16 @@ Approval behavior matters.
 ### `cron`
 
 #### Parity
-- **exact**
+- **close** for durable scheduler semantics and operator inspection
+- **exact** for `sessionTarget`/payload validation and persisted run-history semantics
 
 #### Required behaviors
-- `status|list|add|update|remove|run|runs|wake`
+- `status|list|add|show|update|remove|run|runs|wake`
 - explicit job schema
 - `systemEvent` vs `agentTurn`
 - `sessionTarget=main` requiring `systemEvent`
 - `sessionTarget=isolated` requiring `agentTurn`
-- announce/webhook/none delivery modes
+- retained `announce`/`webhook`/`none` delivery-mode metadata
 - immediate and next-heartbeat wake modes
 
 ---
@@ -1131,7 +1134,8 @@ The rewrite still needs an equivalent orchestration strategy if the surrounding 
 ## 9.1 Cron jobs
 
 ### Parity
-- **exact**
+- **close** for durable scheduler semantics, gateway coverage, and operator inspection
+- **exact** for schedule parsing, `sessionTarget`/payload validation, and persisted due-vs-manual run history
 
 ### Required behaviors
 - durable job definition
@@ -1142,46 +1146,47 @@ The rewrite still needs an equivalent orchestration strategy if the surrounding 
 - explicit `at`, `every`, and cron-expression schedule support
 - explicit `sessionTarget=main` vs `sessionTarget=isolated` behavior
 - explicit `systemEvent` vs `agentTurn` payload validation
-- explicit `none` / `announce` / `webhook` delivery-mode retention
+- explicit `none` / `announce` / `webhook` delivery-mode retention and inspection
 
-Implementation note (2026-03-19): Rune now has executable operator parity for the core cron surface: gateway routes cover `GET /cron/status`, `GET /cron`, `POST /cron`, `POST /cron/wake`, `POST /cron/{id}`, `DELETE /cron/{id}`, `POST /cron/{id}/run`, and `GET /cron/{id}/runs`; CLI flows cover `cron status|list|add|edit|enable|disable|rm|run|runs|wake`; runtime schedule handling computes interval anchors and timezone-aware cron next-fire times; invalid cron/tz definitions fail instead of silently fabricating a next run; and durable PostgreSQL-backed `jobs`/`job_runs` persistence now preserves created jobs, next-run state, and scheduled/manual run history across gateway restarts. Scheduled `main` jobs reuse the stable `system:scheduled-main` session while scheduled `isolated` jobs create fresh descendant `subagent` sessions linked through `requester_session_id`. Remaining parity work is broader black-box evidence for webhook delivery paths and any quiet-window policy layered above the core scheduler.
+Implementation note (2026-03-19): Rune now has durable cron semantics end to end: gateway routes cover `GET /cron/status`, `GET /cron`, `GET /cron/{id}`, `POST /cron`, `POST /cron/wake`, `POST /cron/{id}`, `DELETE /cron/{id}`, `POST /cron/{id}/run`, and `GET /cron/{id}/runs`; CLI flows cover `cron status|list|add|show|edit|enable|disable|rm|run|runs|wake`; runtime schedule handling computes interval anchors and timezone-aware cron next-fire times; invalid cron/tz definitions fail instead of silently fabricating a next run; and durable PostgreSQL-backed `jobs`/`job_runs` persistence preserves created jobs, next-run state, and scheduled/manual run history across gateway restarts. Scheduled `main` jobs reuse the stable `system:scheduled-main` session while scheduled `isolated` jobs create fresh descendant `subagent` sessions linked through `requester_session_id`. The remaining gap is no longer job durability or validation; it is that the CLI create/edit surface is narrower than the gateway schema (`cron add` is one-shot `system_event` only and `cron edit` only mutates name/delivery mode), and runtime execution still treats `none` / `announce` / `webhook` as inspectable metadata rather than distinct delivery paths.
 
 ---
 
 ## 9.2 Reminders
 
 ### Parity
-- **exact**
+- **close** for one-shot timing, durable outcomes, and operator inspection
 
 ### Required behaviors
 - one-shot timing
 - reminder text shaped like a reminder when delivered
 - mention that it is a reminder depending on timing/context
-- target chat/session delivery
+- retained target chat/session metadata
 - delivered / missed / cancelled terminal outcomes remain inspectable
 
-Implementation note (2026-03-19): Rune now ships an executable reminder surface end-to-end with durable outcomes: gateway routes expose `GET /reminders`, `POST /reminders`, and `DELETE /reminders/{id}`; CLI flows expose `reminders add|list|cancel`; reminders persist through the scheduler job repository as `reminder` jobs with `announce` delivery mode; due-checking records delivery attempts; successful sends mark reminders delivered; failed sends mark reminders missed with persisted error context; and user/operator cancellation produces an explicit cancelled terminal outcome instead of silent disappearance. The remaining parity gap is not basic durability anymore; it is stronger black-box evidence that final delivered wording consistently matches the OpenClaw reminder-shaping contract.
+Implementation note (2026-03-19): Rune now ships an executable reminder surface with durable outcomes: gateway routes expose `GET /reminders`, `POST /reminders`, and `DELETE /reminders/{id}`; CLI flows expose `reminders add|list|cancel`; reminders persist through the scheduler job repository as `reminder` jobs with `announce` delivery mode; due-checking records delivery attempts; successful sends mark reminders delivered; failed sends mark reminders missed with persisted error context; and user/operator cancellation produces an explicit cancelled terminal outcome instead of silent disappearance. The remaining gap is target routing and final wording parity: the requested `target` is preserved for inspection, but the shipped runtime still executes reminder delivery in the stable scheduled main session rather than routing to a target-specific chat/session surface.
 
 ---
 
 ## 9.3 Wake events
 
 ### Parity
-- **exact**
+- **partial**
 
 ### Required behaviors
 - immediate wake
 - next-heartbeat wake
 - optional context carry-forward
 
-Implementation note (2026-03-19): Rune currently normalizes wake mode to `now` or `next-heartbeat`, with `next-heartbeat` as the default, and exposes that control through the cron wake flow. Remaining work is mostly evidence and any higher-level operator ergonomics, not absence of the wake-mode contract itself.
+Implementation note (2026-03-19): Rune currently normalizes wake mode to `now` or `next-heartbeat`, defaults omitted mode to `next-heartbeat`, accepts both `next-heartbeat` and `next_heartbeat`, and exposes that control through both `cron wake` and `system event`. Optional `context_messages` is preserved on the emitted `wake_event` payload for subscribers. The remaining gap is substantive rather than cosmetic: this is currently an operator/event-bus queueing surface, not a fully wired downstream wake-execution path.
 
 ---
 
 ## 9.4 Heartbeats
 
 ### Parity
-- **exact**
+- **close** for shipped no-op and duplicate-suppression semantics
+- **partial** for broader quiet-window policy
 
 ### Required behaviors
 - read `HEARTBEAT.md` if present
@@ -1193,7 +1198,7 @@ Implementation note (2026-03-19): Rune currently normalizes wake mode to `now` o
 - maintain minimal state for proactive checks
 - persist enough anti-spam state to avoid duplicate notifications after restart
 
-Implementation note (2026-03-19): Rune now has a real heartbeat runner with persisted runner state, `HEARTBEAT.md` prompt loading, due-checking, suppression of no-op `HEARTBEAT_OK` responses, duplicate-notification suppression via normalized-response fingerprinting, persisted suppression counters/fingerprint state, supervisor execution, and operator surfaces through `GET /heartbeat/status`, `POST /heartbeat/enable`, `POST /heartbeat/disable`, and CLI `system heartbeat presence|last|enable|disable|status`. The remaining gap has narrowed: this is no longer “duplicate suppression missing,” but fuller parity evidence for OpenClaw-equivalent quiet-window and broader anti-spam policy behavior.
+Implementation note (2026-03-19): Rune now has a real heartbeat runner with persisted runner state, `HEARTBEAT.md` prompt loading, due-checking, suppression of no-op `HEARTBEAT_OK` responses, duplicate-notification suppression via normalized-response fingerprinting, persisted suppression counters/fingerprint state, supervisor execution, and operator surfaces through `GET /heartbeat/status`, `POST /heartbeat/enable`, `POST /heartbeat/disable`, and CLI `system heartbeat presence|last|enable|disable|status`. The remaining gap has narrowed to quiet-window policy and broader anti-spam behavior: duplicate suppression now survives restart, but there is still no distinct runtime quiet-window mechanism beyond no-op and duplicate suppression.
 
 ---
 

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -913,7 +913,7 @@ Cron jobs must preserve:
 - `at`, `every`, and cron-expression schedule concepts
 - enable/disable state
 - run history
-- isolated execution context
+- isolated execution context for `sessionTarget=isolated` jobs
 - configurable runtime/model if supported
 - due-only vs forced-run semantics
 - explicit wake semantics for `now` vs `next-heartbeat` where wake flows exist
@@ -929,6 +929,13 @@ Run-history expectations:
 
 - history should distinguish at least due-triggered vs operator-forced/manual runs
 - history rows should remain attributable to the originating job, trigger kind, and resulting scheduled session/run
+
+Current surface note:
+
+- gateway create/update accepts full schedule and payload schemas
+- current CLI `cron add` creates one-shot `system_event` jobs only
+- current CLI `cron edit` is limited to name and delivery-mode mutation
+- `cron wake` and `system event` share the same wake-queueing surface
 
 ## 11.2 Payload and delivery contract
 
@@ -948,11 +955,17 @@ Delivery modes must preserve:
 - `announce`
 - `webhook`
 
-Delivery semantics must also preserve:
+Current shipped delivery semantics:
 
-- `announce` meaning an operator-visible/session-visible surfaced result
-- `webhook` meaning an outbound webhook-style delivery path rather than an in-band chat announcement
-- `none` meaning the run remains auditable in history without requiring an operator-facing message
+- the selected delivery mode is stored durably and remains operator-visible over gateway/CLI inspection surfaces
+- runtime execution does not yet branch on `none` vs `announce` vs `webhook`; outbound webhook-style delivery remains follow-on work
+- run history remains the durable audit surface regardless of delivery mode
+
+Wake semantics currently preserve:
+
+- accepted modes normalize to `now` or `next-heartbeat`
+- optional `context_messages` counts are surfaced on the queued wake event payload
+- the current shipped contract is queueing/inspection of wake events, not guaranteed downstream wake consumption
 
 ## 11.3 Heartbeat contract
 
@@ -970,6 +983,7 @@ Heartbeat invariants:
 - repeated heartbeats should not duplicate notifications without new cause
 - quiet/no-op outcomes should still be representable in run history or persisted heartbeat state
 - anti-spam state must survive restart well enough to avoid replaying the same notification solely because the process restarted
+- broader quiet-window policy is not yet part of the shipped runtime contract
 
 Heartbeat suppression semantics:
 
@@ -982,9 +996,9 @@ Heartbeat suppression semantics:
 Reminders need:
 
 - due time
-- target channel/session
+- target channel/session metadata
 - reminder payload/instruction
-- one-shot vs recurring distinction
+- one-shot-only reminder semantics distinct from cron jobs
 - delivered / missed / cancelled outcome tracking
 - reminder wording that reads like a reminder when fired
 
@@ -993,6 +1007,7 @@ Reminder outcome semantics must preserve:
 - successful delivery marking the reminder terminal as delivered
 - failed delivery attempts marking the reminder terminal as missed with inspectable error context
 - operator/user cancellation marking the reminder terminal as cancelled rather than silently deleting auditability
+- the current shipped runtime retaining the requested `target` while still delivering reminders through the stable scheduled main session
 
 ---
 


### PR DESCRIPTION
## Summary
- narrow scheduler parity docs to the behavior actually shipped today
- distinguish durable metadata retention from still-follow-on runtime delivery branching
- clarify wake and heartbeat remaining gaps so operator docs match implementation

## Testing
- docs-only change
- git diff --check