### PR TITLE
feat(models): wire fallback chain execution into provider routing (#72)

### DIFF
--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -419,6 +419,19 @@ impl ModelsConfig {
         ids
     }
 
+    /// Look up the fallback chain whose first entry matches `model_ref`.
+    ///
+    /// Returns the *remaining* entries (i.e. everything after the primary) so
+    /// the caller can iterate over alternatives without re-trying the primary.
+    #[must_use]
+    pub fn fallback_chain_for(&self, model_ref: &str) -> Option<&[String]> {
+        self.fallbacks
+            .iter()
+            .find(|chain| chain.chain.first().map(String::as_str) == Some(model_ref))
+            .and_then(|chain| chain.chain.get(1..))
+            .filter(|rest| !rest.is_empty())
+    }
+
     /// Resolve a configured model reference to its provider and raw model id.
     pub fn resolve_model<'a>(
         &'a self,
@@ -1888,5 +1901,64 @@ models = ["gpt-5.4", "gpt-image-1"]
         assert_eq!(RuntimeMode::Auto.as_str(), "auto");
         assert_eq!(RuntimeMode::Standalone.as_str(), "standalone");
         assert_eq!(RuntimeMode::Server.as_str(), "server");
+    }
+
+    #[test]
+    fn fallback_chain_for_returns_remaining_entries() {
+        let config = ModelsConfig {
+            fallbacks: vec![ModelFallbackChainConfig {
+                name: "default-chat".into(),
+                chain: vec![
+                    "openai/gpt-5.4".into(),
+                    "anthropic/claude-opus-4-6".into(),
+                    "google/gemini-2.0-flash".into(),
+                ],
+            }],
+            ..Default::default()
+        };
+
+        let chain = config
+            .fallback_chain_for("openai/gpt-5.4")
+            .expect("should find chain for primary model");
+        assert_eq!(
+            chain,
+            &["anthropic/claude-opus-4-6", "google/gemini-2.0-flash"]
+        );
+    }
+
+    #[test]
+    fn fallback_chain_for_returns_none_when_model_not_primary() {
+        let config = ModelsConfig {
+            fallbacks: vec![ModelFallbackChainConfig {
+                name: "default-chat".into(),
+                chain: vec!["openai/gpt-5.4".into(), "anthropic/claude-opus-4-6".into()],
+            }],
+            ..Default::default()
+        };
+
+        // A model that appears only as a fallback (not primary) should not match.
+        assert!(config
+            .fallback_chain_for("anthropic/claude-opus-4-6")
+            .is_none());
+    }
+
+    #[test]
+    fn fallback_chain_for_returns_none_when_no_chains_configured() {
+        let config = ModelsConfig::default();
+        assert!(config.fallback_chain_for("openai/gpt-5.4").is_none());
+    }
+
+    #[test]
+    fn fallback_chain_for_returns_none_for_single_entry_chain() {
+        let config = ModelsConfig {
+            fallbacks: vec![ModelFallbackChainConfig {
+                name: "solo".into(),
+                chain: vec!["openai/gpt-5.4".into()],
+            }],
+            ..Default::default()
+        };
+
+        // A chain with only one entry has no fallbacks.
+        assert!(config.fallback_chain_for("openai/gpt-5.4").is_none());
     }
 }

--- a/crates/rune-models/src/error.rs
+++ b/crates/rune-models/src/error.rs
@@ -50,3 +50,48 @@ pub enum ModelError {
     #[error("provider error: {0}")]
     Provider(String),
 }
+
+impl ModelError {
+    /// Whether this error class is safe to retry with a fallback provider.
+    ///
+    /// Retriable errors indicate transient or capacity problems with the
+    /// current provider — a different provider may succeed.  Non-retriable
+    /// errors (auth misconfiguration, content policy, context overflow) are
+    /// unlikely to resolve by switching providers.
+    #[must_use]
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            ModelError::RateLimited { .. }
+                | ModelError::Transient(_)
+                | ModelError::QuotaExhausted(_)
+                | ModelError::Http(_)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retriable_errors() {
+        assert!(ModelError::RateLimited {
+            message: "slow down".into(),
+            retry_after_secs: Some(30),
+        }
+        .is_retriable());
+        assert!(ModelError::Transient("500".into()).is_retriable());
+        assert!(ModelError::QuotaExhausted("done".into()).is_retriable());
+    }
+
+    #[test]
+    fn non_retriable_errors() {
+        assert!(!ModelError::Auth("bad key".into()).is_retriable());
+        assert!(!ModelError::Configuration("missing field".into()).is_retriable());
+        assert!(!ModelError::ContextLengthExceeded("too long".into()).is_retriable());
+        assert!(!ModelError::ContentFiltered("blocked".into()).is_retriable());
+        assert!(!ModelError::DeploymentNotFound("404".into()).is_retriable());
+        assert!(!ModelError::Provider("unknown".into()).is_retriable());
+    }
+}

--- a/crates/rune-models/src/lib.rs
+++ b/crates/rune-models/src/lib.rs
@@ -25,6 +25,7 @@ use rune_config::ModelProviderConfig;
 use rune_config::{ModelResolutionError, ModelsConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::warn;
 
 /// Build a `Box<dyn ModelProvider>` from a [`ModelProviderConfig`].
 ///
@@ -222,6 +223,57 @@ impl ModelProvider for RoutedModelProvider {
             ));
         };
 
+        // Try the primary model first.
+        let primary_result = self.dispatch_single(model_ref, request).await;
+
+        // On retriable failure, walk the fallback chain (if one is configured).
+        let primary_err = match primary_result {
+            Ok(resp) => return Ok(resp),
+            Err(e) if !e.is_retriable() => return Err(e),
+            Err(e) => e,
+        };
+
+        let Some(fallbacks) = self.models.fallback_chain_for(model_ref) else {
+            return Err(primary_err);
+        };
+
+        warn!(
+            primary = model_ref,
+            error = %primary_err,
+            fallback_count = fallbacks.len(),
+            "primary provider failed with retriable error, trying fallback chain"
+        );
+
+        let mut last_err = primary_err;
+        for fallback_ref in fallbacks {
+            match self.dispatch_single(fallback_ref, request).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) if e.is_retriable() => {
+                    warn!(
+                        fallback = fallback_ref.as_str(),
+                        error = %e,
+                        "fallback provider also failed, continuing chain"
+                    );
+                    last_err = e;
+                }
+                Err(e) => {
+                    // Non-retriable error from a fallback — stop the chain.
+                    return Err(e);
+                }
+            }
+        }
+
+        Err(last_err)
+    }
+}
+
+impl RoutedModelProvider {
+    /// Resolve and dispatch a single `model_ref` to its provider.
+    async fn dispatch_single(
+        &self,
+        model_ref: &str,
+        request: &CompletionRequest,
+    ) -> Result<CompletionResponse, ModelError> {
         let resolved = self
             .models
             .resolve_model(model_ref)

--- a/crates/rune-models/tests/provider_tests.rs
+++ b/crates/rune-models/tests/provider_tests.rs
@@ -856,3 +856,325 @@ async fn routed_provider_dispatches_by_provider_model_id_and_strips_prefix() {
         }
     }
 }
+
+// --- Fallback chain routing ---
+
+use rune_config::ModelFallbackChainConfig;
+
+#[tokio::test]
+async fn routed_provider_falls_back_on_retriable_error() {
+    let primary_server = MockServer::start().await;
+    let fallback_server = MockServer::start().await;
+
+    // Primary returns 429 (retriable).
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "60")
+                .set_body_json(serde_json::json!({
+                    "error": { "message": "rate limited", "code": "rate_limit" }
+                })),
+        )
+        .expect(1)
+        .mount(&primary_server)
+        .await;
+
+    // Fallback succeeds.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&fallback_server)
+        .await;
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("TEST_FALLBACK_PRIMARY_KEY", "fake-primary");
+            std::env::set_var("TEST_FALLBACK_SECONDARY_KEY", "fake-secondary");
+        }
+    }
+
+    let models = ModelsConfig {
+        default_model: Some("primary/gpt-5.4".into()),
+        default_image_model: None,
+        fallbacks: vec![ModelFallbackChainConfig {
+            name: "default-chat".into(),
+            chain: vec![
+                "primary/gpt-5.4".into(),
+                "secondary/claude-opus-4-6".into(),
+            ],
+        }],
+        image_fallbacks: vec![],
+        auth_orders: vec![],
+        providers: vec![
+            ModelProviderConfig {
+                name: "primary".into(),
+                kind: "openai".into(),
+                base_url: primary_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_FALLBACK_PRIMARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "secondary".into(),
+                kind: "openai".into(),
+                base_url: fallback_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_FALLBACK_SECONDARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-opus-4-6".into())],
+            },
+        ],
+    };
+
+    let provider = RoutedModelProvider::from_models_config(&models).unwrap();
+
+    let request = CompletionRequest {
+        model: Some("primary/gpt-5.4".into()),
+        ..simple_request()
+    };
+
+    // Should succeed via fallback.
+    let resp = provider.complete(&request).await.unwrap();
+    assert_eq!(resp.content.as_deref(), Some("Hello! How can I help?"));
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::remove_var("TEST_FALLBACK_PRIMARY_KEY");
+            std::env::remove_var("TEST_FALLBACK_SECONDARY_KEY");
+        }
+    }
+}
+
+#[tokio::test]
+async fn routed_provider_does_not_fallback_on_non_retriable_error() {
+    let primary_server = MockServer::start().await;
+    let fallback_server = MockServer::start().await;
+
+    // Primary returns 401 (non-retriable).
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": { "message": "Invalid key", "code": "invalid_api_key" }
+        })))
+        .expect(1)
+        .mount(&primary_server)
+        .await;
+
+    // Fallback should NOT be called.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(0)
+        .mount(&fallback_server)
+        .await;
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("TEST_NOFB_PRIMARY_KEY", "fake-primary");
+            std::env::set_var("TEST_NOFB_SECONDARY_KEY", "fake-secondary");
+        }
+    }
+
+    let models = ModelsConfig {
+        default_model: Some("primary/gpt-5.4".into()),
+        default_image_model: None,
+        fallbacks: vec![ModelFallbackChainConfig {
+            name: "default-chat".into(),
+            chain: vec![
+                "primary/gpt-5.4".into(),
+                "secondary/claude-opus-4-6".into(),
+            ],
+        }],
+        image_fallbacks: vec![],
+        auth_orders: vec![],
+        providers: vec![
+            ModelProviderConfig {
+                name: "primary".into(),
+                kind: "openai".into(),
+                base_url: primary_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_NOFB_PRIMARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "secondary".into(),
+                kind: "openai".into(),
+                base_url: fallback_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_NOFB_SECONDARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-opus-4-6".into())],
+            },
+        ],
+    };
+
+    let provider = RoutedModelProvider::from_models_config(&models).unwrap();
+
+    let request = CompletionRequest {
+        model: Some("primary/gpt-5.4".into()),
+        ..simple_request()
+    };
+
+    // Should fail immediately without trying fallback.
+    let err = provider.complete(&request).await.unwrap_err();
+    assert!(matches!(err, ModelError::Auth(_)));
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::remove_var("TEST_NOFB_PRIMARY_KEY");
+            std::env::remove_var("TEST_NOFB_SECONDARY_KEY");
+        }
+    }
+}
+
+#[tokio::test]
+async fn routed_provider_returns_last_error_when_all_fallbacks_fail() {
+    let primary_server = MockServer::start().await;
+    let fallback_server = MockServer::start().await;
+
+    // Primary returns 500 (retriable).
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .expect(1)
+        .mount(&primary_server)
+        .await;
+
+    // Fallback also returns 500 (retriable).
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Also Down"))
+        .expect(1)
+        .mount(&fallback_server)
+        .await;
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("TEST_ALLFB_PRIMARY_KEY", "fake-primary");
+            std::env::set_var("TEST_ALLFB_SECONDARY_KEY", "fake-secondary");
+        }
+    }
+
+    let models = ModelsConfig {
+        default_model: Some("primary/gpt-5.4".into()),
+        default_image_model: None,
+        fallbacks: vec![ModelFallbackChainConfig {
+            name: "default-chat".into(),
+            chain: vec![
+                "primary/gpt-5.4".into(),
+                "secondary/claude-opus-4-6".into(),
+            ],
+        }],
+        image_fallbacks: vec![],
+        auth_orders: vec![],
+        providers: vec![
+            ModelProviderConfig {
+                name: "primary".into(),
+                kind: "openai".into(),
+                base_url: primary_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_ALLFB_PRIMARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "secondary".into(),
+                kind: "openai".into(),
+                base_url: fallback_server.uri(),
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("TEST_ALLFB_SECONDARY_KEY".into()),
+                api_key: None,
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-opus-4-6".into())],
+            },
+        ],
+    };
+
+    let provider = RoutedModelProvider::from_models_config(&models).unwrap();
+
+    let request = CompletionRequest {
+        model: Some("primary/gpt-5.4".into()),
+        ..simple_request()
+    };
+
+    // Both fail — should get the last error (from fallback).
+    let err = provider.complete(&request).await.unwrap_err();
+    assert!(matches!(err, ModelError::Transient(_)));
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::remove_var("TEST_ALLFB_PRIMARY_KEY");
+            std::env::remove_var("TEST_ALLFB_SECONDARY_KEY");
+        }
+    }
+}
+
+#[tokio::test]
+async fn routed_provider_skips_fallback_when_no_chain_configured() {
+    let primary_server = MockServer::start().await;
+
+    // Primary returns 500 (retriable) but there's no fallback chain.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .expect(1)
+        .mount(&primary_server)
+        .await;
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("TEST_NOCHAIN_PRIMARY_KEY", "fake-primary");
+        }
+    }
+
+    let models = ModelsConfig {
+        default_model: Some("primary/gpt-5.4".into()),
+        default_image_model: None,
+        fallbacks: vec![], // No fallback chains.
+        image_fallbacks: vec![],
+        auth_orders: vec![],
+        providers: vec![ModelProviderConfig {
+            name: "primary".into(),
+            kind: "openai".into(),
+            base_url: primary_server.uri(),
+            deployment_name: None,
+            api_version: None,
+            api_key_env: Some("TEST_NOCHAIN_PRIMARY_KEY".into()),
+            api_key: None,
+            model_alias: None,
+            models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+        }],
+    };
+
+    let provider = RoutedModelProvider::from_models_config(&models).unwrap();
+
+    let request = CompletionRequest {
+        model: Some("primary/gpt-5.4".into()),
+        ..simple_request()
+    };
+
+    let err = provider.complete(&request).await.unwrap_err();
+    assert!(matches!(err, ModelError::Transient(_)));
+
+    {
+        let _guard = lock_env();
+        unsafe {
+            std::env::remove_var("TEST_NOCHAIN_PRIMARY_KEY");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ModelError::is_retriable()` to classify errors eligible for fallback (rate-limit, transient, quota, HTTP transport)
- Adds `ModelsConfig::fallback_chain_for()` to resolve the configured fallback chain by primary model reference
- Updates `RoutedModelProvider::complete()` to walk fallback entries on retriable failure; non-retriable errors (auth, config, content-filter) short-circuit immediately
- 4 WireMock integration tests covering: fallback success, no-fallback on auth error, all-fail returns last error, no-chain configured

Closes part of #72 (task 2 — fallback execution slice).

## Test plan
- [x] `cargo test -p rune-config -p rune-models` — 110 tests pass
- [x] `cargo check` — full workspace compiles clean