### PR TITLE
feat(models): add set-image and fallbacks CLI subcommands (#72)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -305,6 +305,13 @@ pub enum ModelsAction {
         /// Model id to set. Accepts canonical `provider/model` ids and unambiguous short names.
         model: String,
     },
+    /// Set the default image model in local config.toml after validating against configured inventory.
+    SetImage {
+        /// Image model id to set. Accepts canonical `provider/model` ids and unambiguous short names.
+        model: String,
+    },
+    /// List configured text and image fallback chains.
+    Fallbacks,
 }
 
 #[derive(Debug, Subcommand)]
@@ -801,6 +808,29 @@ mod tests {
             } => assert_eq!(model, "hamza-eastus2/gpt-5.4"),
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_models_set_image() {
+        let cli =
+            Cli::try_parse_from(["rune", "models", "set-image", "hamza-eastus2/dall-e-3"]).unwrap();
+        match cli.command {
+            Command::Models {
+                action: ModelsAction::SetImage { model },
+            } => assert_eq!(model, "hamza-eastus2/dall-e-3"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_models_fallbacks() {
+        let cli = Cli::try_parse_from(["rune", "models", "fallbacks"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Models {
+                action: ModelsAction::Fallbacks
+            }
+        ));
     }
 
     #[test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -34,8 +34,9 @@ use output::{
     ChannelCapabilitiesResponse, ChannelDetail, ChannelListResponse, ChannelLogFile,
     ChannelLogsResponse, ChannelResolveResponse, ChannelStatusResponse, DashboardChannelsSummary,
     DashboardModelsSummary, DashboardResponse, DashboardSessionsSummary, HeartbeatPresenceResponse,
-    ModelAliasDetail, ModelAliasesResponse, ModelListResponse, ModelProviderDetail,
-    ModelSetResponse, ModelStatusResponse, OutputFormat, render,
+    ModelAliasDetail, ModelAliasesResponse, ModelFallbackChainDetail, ModelFallbacksResponse,
+    ModelListResponse, ModelProviderDetail, ModelSetImageResponse, ModelSetResponse,
+    ModelStatusResponse, OutputFormat, render,
 };
 
 /// Initialize a workspace directory with default files.
@@ -239,6 +240,112 @@ fn set_default_model(model_ref: &str) -> Result<ModelSetResponse> {
         default_model: canonical,
         note: "Local config updated; restart gateway to apply new default sessions.".to_string(),
     })
+}
+
+fn set_default_image_model(model_ref: &str) -> Result<ModelSetImageResponse> {
+    let config_path = discover_local_config_path();
+    let config = rune_config::AppConfig::load(Some(&config_path)).with_context(|| {
+        format!(
+            "failed to load config from {} before updating default image model",
+            config_path.display()
+        )
+    })?;
+
+    let resolved = config.models.resolve_model(model_ref).with_context(|| {
+        format!("model `{model_ref}` is not resolvable from configured inventory")
+    })?;
+    let canonical = resolved.canonical_model_id();
+    let inventory = config.models.model_ids();
+    if !inventory.is_empty() && !inventory.iter().any(|entry| entry == &canonical) {
+        anyhow::bail!("model `{model_ref}` is not present in configured inventory");
+    }
+    let previous = config.models.default_image_model.clone();
+
+    let original = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+
+    let mut lines = original
+        .lines()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>();
+
+    let mut in_models = false;
+    let mut replaced = false;
+    let mut insert_at = None;
+
+    for (idx, line) in lines.iter_mut().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let section = trimmed.trim_matches(&['[', ']'][..]);
+            if section == "models" {
+                in_models = true;
+                insert_at = Some(idx + 1);
+                continue;
+            }
+            if in_models {
+                insert_at = Some(idx);
+                break;
+            }
+        }
+
+        if in_models && trimmed.starts_with("default_image_model") {
+            *line = format!("default_image_model = \"{canonical}\"");
+            replaced = true;
+            break;
+        }
+    }
+
+    if !replaced {
+        if let Some(idx) = insert_at {
+            lines.insert(idx, format!("default_image_model = \"{canonical}\""));
+        } else {
+            if !lines.is_empty() && !lines.last().is_some_and(|line| line.is_empty()) {
+                lines.push(String::new());
+            }
+            lines.push("[models]".to_string());
+            lines.push(format!("default_image_model = \"{canonical}\""));
+        }
+    }
+
+    let updated = format!("{}\n", lines.join("\n"));
+    std::fs::write(&config_path, updated)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    Ok(ModelSetImageResponse {
+        changed: previous.as_deref() != Some(canonical.as_str()),
+        config_path: config_path.display().to_string(),
+        previous_image_model: previous,
+        default_image_model: canonical,
+        note: "Local config updated; restart gateway to apply new default image model.".to_string(),
+    })
+}
+
+fn model_fallback_details() -> ModelFallbacksResponse {
+    let config = load_config();
+    let text_chains = config
+        .models
+        .fallbacks
+        .iter()
+        .map(|fb| ModelFallbackChainDetail {
+            name: fb.name.clone(),
+            kind: "text".to_string(),
+            chain: fb.chain.clone(),
+        })
+        .collect();
+    let image_chains = config
+        .models
+        .image_fallbacks
+        .iter()
+        .map(|fb| ModelFallbackChainDetail {
+            name: fb.name.clone(),
+            kind: "image".to_string(),
+            chain: fb.chain.clone(),
+        })
+        .collect();
+    ModelFallbacksResponse {
+        text_chains,
+        image_chains,
+    }
 }
 
 fn channel_details() -> Vec<ChannelDetail> {
@@ -893,6 +1000,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = set_default_model(&model)?;
                     println!("{}", render(&result, format));
                 }
+                ModelsAction::SetImage { model } => {
+                    let result = set_default_image_model(&model)?;
+                    println!("{}", render(&result, format));
+                }
+                ModelsAction::Fallbacks => {
+                    let result = model_fallback_details();
+                    println!("{}", render(&result, format));
+                }
             }
         }
         Command::Memory { action } => match action {
@@ -1068,6 +1183,124 @@ models = ["grok-4-fast-reasoning"]
         assert_eq!(
             response.default_model,
             "hamza-eastus2/grok-4-fast-reasoning"
+        );
+
+        unsafe {
+            std::env::remove_var("RUNE_CONFIG");
+        }
+    }
+
+    #[test]
+    fn set_default_image_model_updates_existing_models_section() {
+        let _guard = crate::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"[models]
+default_image_model = "oc-01-openai/dall-e-3"
+
+[[models.providers]]
+name = "oc-01-openai"
+kind = "openai"
+base_url = "https://example.test/openai/v1"
+api_key = "test-key"
+models = ["dall-e-3", "dall-e-4"]
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("RUNE_CONFIG", &config_path);
+        }
+
+        let response = set_default_image_model("oc-01-openai/dall-e-4").unwrap();
+        assert!(response.changed);
+        assert_eq!(
+            response.previous_image_model.as_deref(),
+            Some("oc-01-openai/dall-e-3")
+        );
+        assert_eq!(response.default_image_model, "oc-01-openai/dall-e-4");
+
+        let updated = std::fs::read_to_string(&config_path).unwrap();
+        assert!(updated.contains("default_image_model = \"oc-01-openai/dall-e-4\""));
+
+        unsafe {
+            std::env::remove_var("RUNE_CONFIG");
+        }
+    }
+
+    #[test]
+    fn set_default_image_model_inserts_when_missing() {
+        let _guard = crate::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"[models]
+
+[[models.providers]]
+name = "hamza-eastus2"
+kind = "openai"
+base_url = "https://example.test/openai/v1"
+api_key = "test-key"
+models = ["dall-e-3"]
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("RUNE_CONFIG", &config_path);
+        }
+
+        let response = set_default_image_model("dall-e-3").unwrap();
+        assert!(response.changed);
+        assert_eq!(
+            response.default_image_model,
+            "hamza-eastus2/dall-e-3"
+        );
+        assert!(response.previous_image_model.is_none());
+
+        let updated = std::fs::read_to_string(&config_path).unwrap();
+        assert!(updated.contains("default_image_model = \"hamza-eastus2/dall-e-3\""));
+
+        unsafe {
+            std::env::remove_var("RUNE_CONFIG");
+        }
+    }
+
+    #[test]
+    fn set_default_image_model_rejects_unknown_inventory_entry() {
+        let _guard = crate::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"[[models.providers]]
+name = "oc-01-openai"
+kind = "openai"
+base_url = "https://example.test/openai/v1"
+api_key = "test-key"
+models = ["dall-e-3"]
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("RUNE_CONFIG", &config_path);
+        }
+
+        let err = set_default_image_model("not-a-real-model").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("not present in configured inventory")
+                || err.to_string().contains("not resolvable")
         );
 
         unsafe {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -772,6 +772,78 @@ impl fmt::Display for ModelSetResponse {
     }
 }
 
+/// Result of updating the default image model in local config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelSetImageResponse {
+    pub changed: bool,
+    pub config_path: String,
+    pub previous_image_model: Option<String>,
+    pub default_image_model: String,
+    pub note: String,
+}
+
+impl fmt::Display for ModelSetImageResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Default image model set to {} in {}",
+            self.default_image_model, self.config_path
+        )?;
+        if let Some(previous) = &self.previous_image_model {
+            write!(f, "\nPrevious: {previous}")?;
+        }
+        if !self.note.is_empty() {
+            write!(f, "\nNote: {}", self.note)?;
+        }
+        Ok(())
+    }
+}
+
+/// A single named fallback chain entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelFallbackChainDetail {
+    pub name: String,
+    pub kind: String,
+    pub chain: Vec<String>,
+}
+
+impl fmt::Display for ModelFallbackChainDetail {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} [{}]: {}", self.name, self.kind, self.chain.join(" -> "))
+    }
+}
+
+/// Response for `models fallbacks`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelFallbacksResponse {
+    pub text_chains: Vec<ModelFallbackChainDetail>,
+    pub image_chains: Vec<ModelFallbackChainDetail>,
+}
+
+impl fmt::Display for ModelFallbacksResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.text_chains.is_empty() && self.image_chains.is_empty() {
+            return write!(f, "No fallback chains configured.");
+        }
+        if !self.text_chains.is_empty() {
+            writeln!(f, "Text fallback chains:")?;
+            for chain in &self.text_chains {
+                writeln!(f, "  {chain}")?;
+            }
+        }
+        if !self.image_chains.is_empty() {
+            if !self.text_chains.is_empty() {
+                writeln!(f)?;
+            }
+            writeln!(f, "Image fallback chains:")?;
+            for chain in &self.image_chains {
+                writeln!(f, "  {chain}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for ModelStatusResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Models")?;
@@ -1965,6 +2037,74 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Default model set to hamza-eastus2/grok-4-fast-reasoning"));
         assert!(out.contains("Previous: oc-01-openai/gpt-5.4"));
+    }
+
+    #[test]
+    fn render_model_set_image_response() {
+        let response = ModelSetImageResponse {
+            changed: true,
+            config_path: "config.toml".into(),
+            previous_image_model: Some("oc-01-openai/dall-e-3".into()),
+            default_image_model: "hamza-eastus2/dall-e-4".into(),
+            note: "Local config updated; restart gateway to apply new default image model.".into(),
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Default image model set to hamza-eastus2/dall-e-4"));
+        assert!(out.contains("Previous: oc-01-openai/dall-e-3"));
+    }
+
+    #[test]
+    fn render_model_fallbacks_empty() {
+        let response = ModelFallbacksResponse {
+            text_chains: vec![],
+            image_chains: vec![],
+        };
+        assert_eq!(
+            render(&response, OutputFormat::Human),
+            "No fallback chains configured."
+        );
+    }
+
+    #[test]
+    fn render_model_fallbacks_with_chains() {
+        let response = ModelFallbacksResponse {
+            text_chains: vec![ModelFallbackChainDetail {
+                name: "primary-text".into(),
+                kind: "text".into(),
+                chain: vec![
+                    "azure/gpt-5.4".into(),
+                    "openai/gpt-5.4".into(),
+                    "groq/llama-4".into(),
+                ],
+            }],
+            image_chains: vec![ModelFallbackChainDetail {
+                name: "primary-image".into(),
+                kind: "image".into(),
+                chain: vec!["openai/dall-e-4".into(), "azure/dall-e-3".into()],
+            }],
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Text fallback chains:"));
+        assert!(out.contains("azure/gpt-5.4 -> openai/gpt-5.4 -> groq/llama-4"));
+        assert!(out.contains("Image fallback chains:"));
+        assert!(out.contains("openai/dall-e-4 -> azure/dall-e-3"));
+    }
+
+    #[test]
+    fn render_model_fallbacks_json() {
+        let response = ModelFallbacksResponse {
+            text_chains: vec![ModelFallbackChainDetail {
+                name: "default".into(),
+                kind: "text".into(),
+                chain: vec!["a/m1".into(), "b/m2".into()],
+            }],
+            image_chains: vec![],
+        };
+        let out = render(&response, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["text_chains"][0]["name"], "default");
+        assert_eq!(v["text_chains"][0]["chain"][0], "a/m1");
+        assert!(v["image_chains"].as_array().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `rune models set-image <model>` — sets the default image model in local config.toml, validating against the configured provider inventory (mirrors `models set` for text default)
- Adds `rune models fallbacks` — lists all configured text and image fallback chains with human-readable and JSON output
- Includes CLI parse tests, unit tests for set-image mutation logic (update existing, insert when missing, reject unknown), and output rendering tests for both human and JSON modes

## Test plan
- [x] `cargo test -p rune-cli` — all 147 tests pass
- [x] `cargo clippy -p rune-cli` — clean, no warnings
- [x] `cargo check --workspace` — full workspace compiles
- [ ] Manual verification: `rune models set-image <model>` with a valid config
- [ ] Manual verification: `rune models fallbacks` with fallback chains configured