### PR TITLE
feat(models): add scan and image-fallback CLI parity (#72)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -310,8 +310,12 @@ pub enum ModelsAction {
         /// Image model id to set. Accepts canonical `provider/model` ids and unambiguous short names.
         model: String,
     },
-    /// List configured text and image fallback chains.
+    /// List configured text fallback chains.
     Fallbacks,
+    /// List configured image fallback chains.
+    ImageFallbacks,
+    /// Scan locally reachable providers (for example Ollama) for available models.
+    Scan,
 }
 
 #[derive(Debug, Subcommand)]
@@ -829,6 +833,28 @@ mod tests {
             cli.command,
             Command::Models {
                 action: ModelsAction::Fallbacks
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_models_image_fallbacks() {
+        let cli = Cli::try_parse_from(["rune", "models", "image-fallbacks"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Models {
+                action: ModelsAction::ImageFallbacks
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_models_scan() {
+        let cli = Cli::try_parse_from(["rune", "models", "scan"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Models {
+                action: ModelsAction::Scan
             }
         ));
     }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -14,8 +14,9 @@ use crate::output::{
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
     GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
-    HealthResponse, HeartbeatStatusResponse, ReminderSummary, RemindersListResponse,
-    SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
+    HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
+    ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
+    SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -155,6 +156,42 @@ impl GatewayClient {
                     .unwrap_or("heartbeat disabled")
                     .to_string(),
             })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `POST /models/scan`
+    pub async fn models_scan(&self) -> Result<ModelScanResponse> {
+        let resp = self
+            .http
+            .post(self.url("/models/scan"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let providers = resp
+                .json::<Vec<serde_json::Value>>()
+                .await
+                .context("invalid JSON from /models/scan")?
+                .into_iter()
+                .map(|value| ModelScanProviderResult {
+                    provider: value["provider"].as_str().unwrap_or("unknown").to_string(),
+                    models: value["models"]
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|model| ScannedModelDetail {
+                            name: model["name"].as_str().unwrap_or("unknown").to_string(),
+                            size: model["size"].as_u64(),
+                            modified_at: model["modified_at"].as_str().map(str::to_string),
+                        })
+                        .collect(),
+                })
+                .collect();
+            Ok(ModelScanResponse { providers })
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -1520,6 +1557,34 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let resp = client.cron_wake("wake up", "now", Some(3)).await.unwrap();
         assert!(resp.success);
+    }
+
+    #[tokio::test]
+    async fn models_scan_parses_provider_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/models/scan"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "provider": "ollama-local",
+                    "models": [
+                        {
+                            "name": "llama3.2:latest",
+                            "size": 12345,
+                            "modified_at": "2026-03-19T03:00:00Z"
+                        }
+                    ]
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.models_scan().await.unwrap();
+        assert_eq!(resp.providers.len(), 1);
+        assert_eq!(resp.providers[0].provider, "ollama-local");
+        assert_eq!(resp.providers[0].models[0].name, "llama3.2:latest");
+        assert_eq!(resp.providers[0].models[0].size, Some(12345));
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -35,8 +35,8 @@ use output::{
     ChannelLogsResponse, ChannelResolveResponse, ChannelStatusResponse, DashboardChannelsSummary,
     DashboardModelsSummary, DashboardResponse, DashboardSessionsSummary, HeartbeatPresenceResponse,
     ModelAliasDetail, ModelAliasesResponse, ModelFallbackChainDetail, ModelFallbacksResponse,
-    ModelListResponse, ModelProviderDetail, ModelSetImageResponse, ModelSetResponse,
-    ModelStatusResponse, OutputFormat, render,
+    ModelListResponse, ModelProviderDetail, ModelScanResponse, ModelSetImageResponse,
+    ModelSetResponse, ModelStatusResponse, OutputFormat, render,
 };
 
 /// Initialize a workspace directory with default files.
@@ -344,6 +344,24 @@ fn model_fallback_details() -> ModelFallbacksResponse {
         .collect();
     ModelFallbacksResponse {
         text_chains,
+        image_chains,
+    }
+}
+
+fn image_model_fallback_details() -> ModelFallbacksResponse {
+    let config = load_config();
+    let image_chains = config
+        .models
+        .image_fallbacks
+        .iter()
+        .map(|fb| ModelFallbackChainDetail {
+            name: fb.name.clone(),
+            kind: "image".to_string(),
+            chain: fb.chain.clone(),
+        })
+        .collect();
+    ModelFallbacksResponse {
+        text_chains: vec![],
         image_chains,
     }
 }
@@ -1006,6 +1024,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 ModelsAction::Fallbacks => {
                     let result = model_fallback_details();
+                    println!("{}", render(&result, format));
+                }
+                ModelsAction::ImageFallbacks => {
+                    let result = image_model_fallback_details();
+                    println!("{}", render(&result, format));
+                }
+                ModelsAction::Scan => {
+                    let result: ModelScanResponse = client.models_scan().await?;
                     println!("{}", render(&result, format));
                 }
             }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -813,7 +813,7 @@ impl fmt::Display for ModelFallbackChainDetail {
     }
 }
 
-/// Response for `models fallbacks`.
+/// Response for `models fallbacks` / `models image-fallbacks`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelFallbacksResponse {
     pub text_chains: Vec<ModelFallbackChainDetail>,
@@ -839,6 +839,67 @@ impl fmt::Display for ModelFallbacksResponse {
             for chain in &self.image_chains {
                 writeln!(f, "  {chain}")?;
             }
+        }
+        Ok(())
+    }
+}
+
+/// A single model discovered from a provider scan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScannedModelDetail {
+    pub name: String,
+    pub size: Option<u64>,
+    pub modified_at: Option<String>,
+}
+
+impl fmt::Display for ScannedModelDetail {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(size) = self.size {
+            write!(f, " size={size}")?;
+        }
+        if let Some(modified_at) = &self.modified_at {
+            write!(f, " modified={modified_at}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Provider-level scan response for `models scan`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelScanProviderResult {
+    pub provider: String,
+    pub models: Vec<ScannedModelDetail>,
+}
+
+impl fmt::Display for ModelScanProviderResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}:", self.provider)?;
+        if self.models.is_empty() {
+            writeln!(f, "  (no models reported)")?;
+        } else {
+            for model in &self.models {
+                writeln!(f, "  - {model}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response for `models scan`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelScanResponse {
+    pub providers: Vec<ModelScanProviderResult>,
+}
+
+impl fmt::Display for ModelScanResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.providers.is_empty() {
+            return write!(f, "No local model providers returned scan results.");
+        }
+        writeln!(f, "Discovered models:")?;
+        for provider in &self.providers {
+            write!(f, "{provider}")?;
         }
         Ok(())
     }
@@ -2105,6 +2166,51 @@ mod tests {
         assert_eq!(v["text_chains"][0]["name"], "default");
         assert_eq!(v["text_chains"][0]["chain"][0], "a/m1");
         assert!(v["image_chains"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn render_model_scan_empty() {
+        let response = ModelScanResponse { providers: vec![] };
+        assert_eq!(
+            render(&response, OutputFormat::Human),
+            "No local model providers returned scan results."
+        );
+    }
+
+    #[test]
+    fn render_model_scan_with_results() {
+        let response = ModelScanResponse {
+            providers: vec![ModelScanProviderResult {
+                provider: "ollama-local".into(),
+                models: vec![ScannedModelDetail {
+                    name: "llama3.2:latest".into(),
+                    size: Some(123456789),
+                    modified_at: Some("2026-03-19T03:00:00Z".into()),
+                }],
+            }],
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Discovered models:"));
+        assert!(out.contains("ollama-local:"));
+        assert!(out.contains("llama3.2:latest size=123456789 modified=2026-03-19T03:00:00Z"));
+    }
+
+    #[test]
+    fn render_model_scan_json() {
+        let response = ModelScanResponse {
+            providers: vec![ModelScanProviderResult {
+                provider: "ollama-local".into(),
+                models: vec![ScannedModelDetail {
+                    name: "llama3.2:latest".into(),
+                    size: None,
+                    modified_at: None,
+                }],
+            }],
+        };
+        let out = render(&response, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["providers"][0]["provider"], "ollama-local");
+        assert_eq!(v["providers"][0]["models"][0]["name"], "llama3.2:latest");
     }
 
     #[test]

--- a/docs/FUNCTIONALITY-CHECKLIST.md
+++ b/docs/FUNCTIONALITY-CHECKLIST.md
@@ -77,12 +77,12 @@ Interpretation rules:
 - [x] `models list`
 - [x] `models status`
 - [x] `models set`
-- [ ] `models set-image`
+- [x] `models set-image`
 - [x] `models aliases`
 - [ ] `models auth`
-- [ ] `models fallbacks`
-- [ ] `models image-fallbacks`
-- [ ] `models scan`
+- [x] `models fallbacks`
+- [x] `models image-fallbacks`
+- [x] `models scan`
 - [ ] per-agent auth order override
 - [ ] Azure-aware provider config
 


### PR DESCRIPTION
## Summary
- add `rune models scan` on top of the existing gateway `/models/scan` endpoint
- split `rune models image-fallbacks` from the combined fallback view for closer OpenClaw CLI parity
- update CLI/output tests and the functionality checklist for the newly shipped model subcommands

## Testing
- cargo test -p rune-cli --lib --quiet

Closes #72