### PR TITLE
fix(scheduler): recompute next_run_at on schedule/enable changes (#43)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -17,7 +17,7 @@ use rune_core::{JobId, SchedulerDeliveryMode, SchedulerRunTrigger, SessionKind};
 use rune_runtime::heartbeat::HeartbeatState;
 use rune_runtime::scheduler::{
     Job, JobPayload, JobRun, JobRunStatus, JobUpdate, Reminder, ReminderStatus, Schedule,
-    SessionTarget,
+    SessionTarget, compute_initial_next_run,
 };
 use rune_runtime::{LaneStats, Skill, SkillScanSummary};
 use rune_store::models::{SessionRow, TurnRow};
@@ -632,7 +632,7 @@ pub async fn cron_add(
 
     let now = Utc::now();
     let id = JobId::new();
-    let next_run_at = initial_next_run(&schedule);
+    let next_run_at = compute_initial_next_run(&schedule);
     let mut job = Job {
         id,
         name: body.name,
@@ -695,12 +695,6 @@ pub async fn cron_update(
         .update_job(&job_id, update)
         .await
         .ok_or_else(|| GatewayError::JobNotFound(job_id.to_string()))?;
-
-    if let Some(updated) = state.scheduler.get_job(&job_id).await {
-        if updated.next_run_at.is_none() && updated.enabled {
-            state.scheduler.advance_next_run(&job_id).await;
-        }
-    }
 
     Ok(Json(CronMutationResponse {
         success: true,
@@ -1441,63 +1435,6 @@ fn validate_job_contract(
             "sessionTarget=isolated requires payload.kind=agent_turn".to_string(),
         )),
     }
-}
-
-fn initial_next_run(schedule: &Schedule) -> Option<DateTime<Utc>> {
-    let now = Utc::now();
-    match schedule {
-        Schedule::At { at } => Some(*at),
-        Schedule::Every {
-            every_ms,
-            anchor_ms,
-        } => Some(compute_next_interval_run(*every_ms, *anchor_ms, now)),
-        Schedule::Cron { expr, tz } => compute_next_cron_run(expr, tz.as_deref(), now),
-    }
-}
-
-fn compute_next_interval_run(
-    every_ms: u64,
-    anchor_ms: Option<u64>,
-    now: DateTime<Utc>,
-) -> DateTime<Utc> {
-    let duration = chrono::Duration::milliseconds(every_ms as i64);
-
-    if let Some(anchor_ms) = anchor_ms {
-        let Some(anchor) = DateTime::<Utc>::from_timestamp_millis(anchor_ms as i64) else {
-            return now + duration;
-        };
-
-        if anchor > now {
-            return anchor;
-        }
-
-        let elapsed_ms = (now - anchor).num_milliseconds();
-        if elapsed_ms < 0 {
-            return anchor;
-        }
-
-        let steps = (elapsed_ms / every_ms as i64) + 1;
-        return anchor + chrono::Duration::milliseconds(steps * every_ms as i64);
-    }
-
-    now + duration
-}
-
-fn compute_next_cron_run(
-    expr: &str,
-    tz: Option<&str>,
-    now: DateTime<Utc>,
-) -> Option<DateTime<Utc>> {
-    let schedule = expr.parse::<cron::Schedule>().ok()?;
-    let timezone = match tz {
-        None => chrono_tz::UTC,
-        Some(value) => value.parse::<chrono_tz::Tz>().ok()?,
-    };
-    let after_local = now.with_timezone(&timezone);
-    schedule
-        .after(&after_local)
-        .next()
-        .map(|next| next.with_timezone(&Utc))
 }
 
 fn job_to_response(job: Job) -> CronJobResponse {

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4076,6 +4076,168 @@ async fn cron_get_and_update_delivery_mode() {
 }
 
 #[tokio::test]
+async fn cron_update_schedule_recomputes_next_run_at() {
+    let app = build_test_app(None);
+
+    // Create a job with a 60-second interval
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/cron")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "name":"recompute-test",
+                        "schedule":{"kind":"every","every_ms":60000},
+                        "payload":{"kind":"system_event","text":"tick"},
+                        "sessionTarget":"main",
+                        "enabled":true
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let job_id = created["job_id"].as_str().unwrap().to_string();
+
+    // Read the original next_run_at
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let original = body_json(response).await;
+    let original_next = original["next_run_at"].as_str().unwrap().to_string();
+
+    // Update the schedule to a cron expression (daily at 09:00 UTC)
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/cron/{job_id}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{ "schedule": {"kind":"cron","expr":"0 0 9 * * *","tz":"UTC"} }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Read the updated job and verify next_run_at changed
+    let response = app
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let updated = body_json(response).await;
+    let updated_next = updated["next_run_at"].as_str().unwrap().to_string();
+
+    assert_ne!(
+        original_next, updated_next,
+        "next_run_at must be recomputed when schedule changes"
+    );
+    // The new next_run_at should be at 09:00 UTC
+    let parsed = chrono::DateTime::parse_from_rfc3339(&updated_next).unwrap();
+    assert_eq!(parsed.hour(), 9);
+    assert_eq!(parsed.minute(), 0);
+}
+
+#[tokio::test]
+async fn cron_disable_clears_next_run_at_and_reenable_recomputes() {
+    let app = build_test_app(None);
+
+    // Create an enabled job
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/cron")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "name":"toggle-test",
+                        "schedule":{"kind":"every","every_ms":60000},
+                        "payload":{"kind":"system_event","text":"tick"},
+                        "sessionTarget":"main",
+                        "enabled":true
+                    }"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let job_id = created["job_id"].as_str().unwrap().to_string();
+
+    // Disable the job
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/cron/{job_id}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{ "enabled": false }"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify next_run_at is cleared
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let disabled = body_json(response).await;
+    assert!(
+        disabled["next_run_at"].is_null(),
+        "disabled job should have null next_run_at"
+    );
+
+    // Re-enable the job
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/cron/{job_id}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{ "enabled": true }"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify next_run_at is recomputed
+    let response = app
+        .oneshot(
+            Request::get(format!("/cron/{job_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let reenabled = body_json(response).await;
+    assert!(
+        !reenabled["next_run_at"].is_null(),
+        "re-enabled job should have a freshly computed next_run_at"
+    );
+}
+
+#[tokio::test]
 async fn cron_wake_accepts_snake_case_and_normalizes_mode() {
     let app = build_test_app(None);
     let response = app

--- a/crates/rune-runtime/src/scheduler.rs
+++ b/crates/rune-runtime/src/scheduler.rs
@@ -246,11 +246,18 @@ impl Scheduler {
     }
 
     /// Update a job.
+    ///
+    /// When the schedule or enabled state changes, `next_run_at` is recomputed
+    /// so that persisted jobs never fire on a stale cadence.
     pub async fn update_job(&self, id: &JobId, update: JobUpdate) -> Option<Job> {
+        let schedule_changed = update.schedule.is_some();
+        let enabled_change = update.enabled;
+
         match &self.backend {
             SchedulerBackend::Memory(jobs) => {
                 let mut jobs = jobs.lock().await;
                 let job = jobs.get_mut(id)?;
+                let was_enabled = job.enabled;
 
                 if let Some(name) = update.name {
                     job.name = Some(name);
@@ -267,11 +274,15 @@ impl Scheduler {
                 if let Some(delivery_mode) = update.delivery_mode {
                     job.delivery_mode = delivery_mode;
                 }
+
+                recompute_next_run(job, schedule_changed, enabled_change, was_enabled);
 
                 Some(job.clone())
             }
             SchedulerBackend::Repo { jobs: repo, .. } => {
                 let mut job = self.get_job(id).await?;
+                let was_enabled = job.enabled;
+
                 if let Some(name) = update.name {
                     job.name = Some(name);
                 }
@@ -287,6 +298,9 @@ impl Scheduler {
                 if let Some(delivery_mode) = update.delivery_mode {
                     job.delivery_mode = delivery_mode;
                 }
+
+                recompute_next_run(&mut job, schedule_changed, enabled_change, was_enabled);
+
                 let updated_at = Utc::now();
                 let payload = stored_job_payload(&job);
                 repo.update_job(
@@ -578,6 +592,19 @@ impl Scheduler {
                 }
             }
         }
+    }
+}
+
+/// Compute the initial `next_run_at` for a schedule (used on creation and after edits).
+pub fn compute_initial_next_run(schedule: &Schedule) -> Option<DateTime<Utc>> {
+    let now = Utc::now();
+    match schedule {
+        Schedule::At { at } => Some(*at),
+        Schedule::Every {
+            every_ms,
+            anchor_ms,
+        } => Some(compute_next_interval_run(*every_ms, *anchor_ms, now, now)),
+        Schedule::Cron { expr, tz } => compute_next_cron_run(expr, tz.as_deref(), now, now),
     }
 }
 
@@ -1153,6 +1180,30 @@ fn row_to_job_run(row: JobRunRow) -> JobRun {
     }
 }
 
+/// Recompute `next_run_at` when a schedule or enabled-state change occurs.
+///
+/// Rules:
+///   - schedule changed → fresh `next_run_at` from the new schedule
+///   - disabled → clear `next_run_at`
+///   - re-enabled (was disabled, now enabled) → fresh `next_run_at`
+fn recompute_next_run(
+    job: &mut Job,
+    schedule_changed: bool,
+    enabled_change: Option<bool>,
+    was_enabled: bool,
+) {
+    if !job.enabled {
+        // Job is disabled → no upcoming run.
+        job.next_run_at = None;
+        return;
+    }
+
+    if schedule_changed || (enabled_change == Some(true) && !was_enabled) {
+        // Schedule was edited or job was just re-enabled → compute fresh next_run_at.
+        job.next_run_at = compute_initial_next_run(&job.schedule);
+    }
+}
+
 fn stored_job_payload(job: &Job) -> serde_json::Value {
     serde_json::to_value(StoredJobRecord {
         name: job.name.clone(),
@@ -1545,5 +1596,143 @@ mod tests {
         let job = scheduler.get_job(&id).await.unwrap();
         assert!(!job.enabled);
         assert!(job.next_run_at.is_none());
+    }
+
+    // ── Schedule-edit / enable-disable recomputation tests ──────────────
+
+    #[tokio::test]
+    async fn update_schedule_recomputes_next_run_at() {
+        let scheduler = Scheduler::new();
+        let job = make_job("recompute-me");
+        let original_next = job.next_run_at;
+        let id = scheduler.add_job(job).await;
+
+        // Change from 60s interval to a cron schedule
+        let updated = scheduler
+            .update_job(
+                &id,
+                JobUpdate {
+                    schedule: Some(Schedule::Cron {
+                        expr: "0 0 9 * * *".into(),
+                        tz: Some("UTC".into()),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // next_run_at must have been recomputed (not the stale interval value)
+        assert_ne!(updated.next_run_at, original_next);
+        let next = updated.next_run_at.expect("should have a next_run_at");
+        assert_eq!(next.hour(), 9);
+        assert_eq!(next.minute(), 0);
+    }
+
+    #[tokio::test]
+    async fn update_interval_schedule_recomputes_next_run_at() {
+        let scheduler = Scheduler::new();
+        let job = make_job("interval-edit");
+        let id = scheduler.add_job(job).await;
+        let before = scheduler.get_job(&id).await.unwrap().next_run_at;
+
+        // Change from 60s to 300s interval
+        let updated = scheduler
+            .update_job(
+                &id,
+                JobUpdate {
+                    schedule: Some(Schedule::Every {
+                        every_ms: 300_000,
+                        anchor_ms: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // The new next_run_at should be ~5 minutes from now, not ~1 minute
+        let next = updated.next_run_at.expect("should have next_run_at");
+        assert_ne!(Some(next), before);
+        let delta_ms = (next - Utc::now()).num_milliseconds();
+        // Should be roughly 300_000ms from now (allow generous tolerance)
+        assert!(
+            delta_ms > 200_000 && delta_ms < 400_000,
+            "expected ~300s delta, got {delta_ms}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn disable_clears_next_run_at() {
+        let scheduler = Scheduler::new();
+        let job = make_job("disable-me");
+        let id = scheduler.add_job(job).await;
+        assert!(scheduler.get_job(&id).await.unwrap().next_run_at.is_some());
+
+        let updated = scheduler
+            .update_job(
+                &id,
+                JobUpdate {
+                    enabled: Some(false),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(!updated.enabled);
+        assert!(
+            updated.next_run_at.is_none(),
+            "disabled job should have no next_run_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn reenable_recomputes_next_run_at() {
+        let scheduler = Scheduler::new();
+        let mut job = make_job("reenable-me");
+        job.enabled = false;
+        job.next_run_at = None;
+        let id = scheduler.add_job(job).await;
+
+        // Re-enable the job
+        let updated = scheduler
+            .update_job(
+                &id,
+                JobUpdate {
+                    enabled: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(updated.enabled);
+        assert!(
+            updated.next_run_at.is_some(),
+            "re-enabled job should have a freshly computed next_run_at"
+        );
+        assert!(updated.next_run_at.unwrap() > Utc::now());
+    }
+
+    #[tokio::test]
+    async fn name_only_update_preserves_next_run_at() {
+        let scheduler = Scheduler::new();
+        let job = make_job("rename-only");
+        let id = scheduler.add_job(job).await;
+        let before = scheduler.get_job(&id).await.unwrap().next_run_at;
+
+        let updated = scheduler
+            .update_job(
+                &id,
+                JobUpdate {
+                    name: Some("new-name".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(updated.next_run_at, before, "name-only update must not change next_run_at");
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `Scheduler::update_job` preserved the existing `next_run_at` even when the cron schedule changed, leaving jobs firing on a stale cadence. Disabling a job did not clear `next_run_at`, and re-enabling did not recompute it.
- **Fix**: Added `compute_initial_next_run()` to the scheduler module. `update_job` now recomputes `next_run_at` when the schedule changes or the job is re-enabled, and clears it when disabled. Removed the partial workaround in the `cron_update` route handler and deduplicated schedule-computation helpers from routes.rs.
- Closes the first semantic gap documented in the issue #43 review: stale `next_run_at` after schedule edits.

## Test plan

- [x] 5 new scheduler unit tests: schedule-edit recomputation (cron + interval), disable-clears, re-enable-recomputes, name-only-preserves
- [x] 2 new route integration tests: full HTTP round-trip for schedule update recomputation and disable/re-enable transitions
- [x] All 96 rune-runtime tests pass
- [x] All 60 rune-gateway tests pass