### PR TITLE
docs(parity): align scheduler semantics with shipped issue-43 state

### DIFF
--- a/docs/IMPLEMENTATION-PHASES.md
+++ b/docs/IMPLEMENTATION-PHASES.md
@@ -214,6 +214,7 @@ Reproduce proactive automation behavior.
 ### Acceptance criteria
 
 - scheduled jobs are durable and inspectable
+- schedule edits and disable/re-enable transitions recompute or clear `next_run_at` rather than preserving stale due state
 - heartbeat behavior preserves shipped no-op and duplicate-suppression semantics
 - scheduled executions are auditable; `sessionTarget=isolated` cron jobs create descendant subagent sessions while main-target cron jobs, reminders, and heartbeats reuse scheduled session contexts
 - operator can list, inspect, enable, disable, wake, and review job history
@@ -225,6 +226,7 @@ Reproduce proactive automation behavior.
 ### Recommended parity tests
 
 - cron create/list/show/edit/disable/enable/run-now/wake flows
+- schedule-edit recompute plus disable/re-enable `next_run_at` transition tests
 - due-only vs forced-run history tests
 - `systemEvent` vs `agentTurn` session-target validation tests
 - delivery-mode retention/inspection tests for `none` / `announce` / `webhook`

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -202,6 +202,7 @@ Do not mark a subsystem parity-complete without black-box evidence.
 
 - enabled/disabled state is durable
 - schedule definition is compatibility surface: `at`, `every`, and cron-expression semantics may not drift silently
+- `next_run_at` is derived scheduler state, not sticky metadata: create, schedule-edit, disable, and re-enable transitions must clear or recompute the executable next-fire time from the current job contract rather than preserving stale cadence
 - `sessionTarget=main` maps to `systemEvent` payloads and `sessionTarget=isolated` maps to `agentTurn` payloads; invalid combinations fail explicitly
 - reminder timing and terminal outcomes remain operator-predictable; reminder `target` is retained as operator-visible metadata even though current execution still reuses the scheduled main session
 - delivery modes preserve `none`, `announce`, and `webhook` as durable, inspectable job metadata; runtime-specific branching on those modes is not yet a shipped contract
@@ -233,6 +234,7 @@ Do not mark a subsystem parity-complete without black-box evidence.
 
 - missed runs are visible
 - invalid schedules fail explicitly; stored cron jobs whose next run can no longer be computed disable rather than fabricating future fire times
+- schedule edits and disable/re-enable transitions must not preserve stale `next_run_at`; if a valid next fire cannot be derived, inspection should surface `next_run_at=null` or a disabled job rather than silently keeping the old cadence
 - invalid `sessionTarget`/payload combinations fail explicitly
 - disabled jobs do not run silently
 - reminder delivery failures resolve to explicit `missed` outcomes rather than disappearing
@@ -242,6 +244,7 @@ Do not mark a subsystem parity-complete without black-box evidence.
 ### Minimum parity evidence
 
 - cron create/list/show/update/disable/enable/run/wake tests
+- schedule-edit recompute plus disable/re-enable `next_run_at` transition tests
 - due-only vs forced-run history tests
 - `systemEvent` vs `agentTurn` session-target tests
 - delivery-mode retention/inspection tests for `none`/`announce`/`webhook`

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -418,6 +418,7 @@ Observed subflows include:
 - `at`, `every`, and cron expression schedules
 - timezone support
 - enabled/disabled state
+- schedule edits and disable/re-enable transitions recompute or clear `next_run_at` instead of preserving stale due state
 - main-session `systemEvent` jobs
 - isolated `agentTurn` jobs
 - retained `announce`/`webhook`/`none` delivery-mode metadata
@@ -1148,7 +1149,7 @@ The rewrite still needs an equivalent orchestration strategy if the surrounding 
 - explicit `systemEvent` vs `agentTurn` payload validation
 - explicit `none` / `announce` / `webhook` delivery-mode retention and inspection
 
-Implementation note (2026-03-19): Rune now has durable cron semantics end to end: gateway routes cover `GET /cron/status`, `GET /cron`, `GET /cron/{id}`, `POST /cron`, `POST /cron/wake`, `POST /cron/{id}`, `DELETE /cron/{id}`, `POST /cron/{id}/run`, and `GET /cron/{id}/runs`; CLI flows cover `cron status|list|add|show|edit|enable|disable|rm|run|runs|wake`; runtime schedule handling computes interval anchors and timezone-aware cron next-fire times; invalid cron/tz definitions fail instead of silently fabricating a next run; and durable PostgreSQL-backed `jobs`/`job_runs` persistence preserves created jobs, next-run state, and scheduled/manual run history across gateway restarts. Scheduled `main` jobs reuse the stable `system:scheduled-main` session while scheduled `isolated` jobs create fresh descendant `subagent` sessions linked through `requester_session_id`. The remaining gap is no longer job durability or validation; it is that the CLI create/edit surface is narrower than the gateway schema (`cron add` is one-shot `system_event` only and `cron edit` only mutates name/delivery mode), and runtime execution still treats `none` / `announce` / `webhook` as inspectable metadata rather than distinct delivery paths.
+Implementation note (2026-03-19): Rune now has durable cron semantics end to end around creation, inspection, persistence, and execution surface: gateway routes cover `GET /cron/status`, `GET /cron`, `GET /cron/{id}`, `POST /cron`, `POST /cron/wake`, `POST /cron/{id}`, `DELETE /cron/{id}`, `POST /cron/{id}/run`, and `GET /cron/{id}/runs`; CLI flows cover `cron status|list|add|show|edit|enable|disable|rm|run|runs|wake`; runtime schedule handling computes interval anchors and timezone-aware cron next-fire times; invalid cron/tz definitions fail instead of silently fabricating a next run; and durable PostgreSQL-backed `jobs`/`job_runs` persistence preserves created jobs, next-run state, and scheduled/manual run history across gateway restarts. Scheduled `main` jobs reuse the stable `system:scheduled-main` session while scheduled `isolated` jobs create fresh descendant `subagent` sessions linked through `requester_session_id`. The remaining gaps are now narrower and explicit: current `main` still preserves stale `next_run_at` across schedule edits and disable/re-enable transitions, the CLI create/edit surface is narrower than the gateway schema (`cron add` is one-shot `system_event` only and `cron edit` only mutates name/delivery mode), and runtime execution still treats `none` / `announce` / `webhook` as inspectable metadata rather than distinct delivery paths.
 
 ---
 

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -912,6 +912,7 @@ Cron jobs must preserve:
 - explicit schedule definition
 - `at`, `every`, and cron-expression schedule concepts
 - enable/disable state
+- derived `next_run_at` semantics that recompute on schedule edits and re-enable transitions, and clear executable due state when disabled
 - run history
 - isolated execution context for `sessionTarget=isolated` jobs
 - configurable runtime/model if supported
@@ -936,6 +937,7 @@ Current surface note:
 - current CLI `cron add` creates one-shot `system_event` jobs only
 - current CLI `cron edit` is limited to name and delivery-mode mutation
 - `cron wake` and `system event` share the same wake-queueing surface
+- current `main` still has one remaining cron-semantic gap: schedule edits and disable/re-enable transitions can preserve stale `next_run_at` because update-time recomputation is not yet durable
 
 ## 11.2 Payload and delivery contract
 


### PR DESCRIPTION
## Summary
- align the scheduler parity docs with what `main` actually ships today for cron, reminders, wake events, and heartbeats
- make `next_run_at` recomputation an explicit scheduler contract and parity test requirement
- document that the remaining cron semantic gap on `main` is stale `next_run_at` preservation across schedule edits and disable/re-enable transitions (covered by open PR #117), instead of overstating that fix as already shipped

## Files updated
- `docs/parity/PARITY-CONTRACTS.md`
- `docs/parity/PROTOCOLS.md`
- `docs/parity/PARITY-INVENTORY.md`
- `docs/IMPLEMENTATION-PHASES.md`

## Notes
- doc-only slice
- reminder, heartbeat, and wake notes remain aligned with shipped behavior on `main`
- cron notes now clearly separate durable shipped behavior from the still-open recompute fix in PR #117
