### PR TITLE
feat(scheduler): honor reminder target routing and expose outcome details (#43)

### DIFF
--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -765,6 +765,9 @@ impl GatewayClient {
                     delivered: item["delivered"].as_bool().unwrap_or(false),
                     created_at: item["created_at"].as_str().unwrap_or("?").to_string(),
                     delivered_at: item["delivered_at"].as_str().map(String::from),
+                    status: item["status"].as_str().unwrap_or("pending").to_string(),
+                    outcome_at: item["outcome_at"].as_str().map(String::from),
+                    last_error: item["last_error"].as_str().map(String::from),
                 })
                 .collect();
             Ok(RemindersListResponse { reminders })
@@ -1742,5 +1745,63 @@ mod tests {
         let json = show_config().unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(v["gateway"]["port"].is_number());
+    }
+
+    #[tokio::test]
+    async fn reminders_list_parses_outcome_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/reminders"))
+            .and(query_param("includeDelivered", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "id": "r-1",
+                    "message": "Stand up",
+                    "target": "isolated",
+                    "fire_at": "2026-04-01T09:00:00Z",
+                    "status": "delivered",
+                    "delivered": true,
+                    "created_at": "2026-03-19T10:00:00Z",
+                    "delivered_at": "2026-04-01T09:00:05Z",
+                    "outcome_at": "2026-04-01T09:00:05Z",
+                    "last_error": null
+                },
+                {
+                    "id": "r-2",
+                    "message": "Missed one",
+                    "target": "main",
+                    "fire_at": "2026-04-01T07:00:00Z",
+                    "status": "missed",
+                    "delivered": false,
+                    "created_at": "2026-03-19T10:00:00Z",
+                    "delivered_at": null,
+                    "outcome_at": "2026-04-01T07:01:00Z",
+                    "last_error": "session unavailable"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.reminders_list(true).await.unwrap();
+        assert_eq!(resp.reminders.len(), 2);
+
+        assert_eq!(resp.reminders[0].target, "isolated");
+        assert_eq!(resp.reminders[0].status, "delivered");
+        assert_eq!(
+            resp.reminders[0].outcome_at.as_deref(),
+            Some("2026-04-01T09:00:05Z")
+        );
+        assert!(resp.reminders[0].last_error.is_none());
+
+        assert_eq!(resp.reminders[1].status, "missed");
+        assert_eq!(
+            resp.reminders[1].last_error.as_deref(),
+            Some("session unavailable")
+        );
+        assert_eq!(
+            resp.reminders[1].outcome_at.as_deref(),
+            Some("2026-04-01T07:01:00Z")
+        );
     }
 }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1636,23 +1636,35 @@ pub struct ReminderSummary {
     pub delivered: bool,
     pub created_at: String,
     pub delivered_at: Option<String>,
+    /// Lifecycle status: pending, delivered, cancelled, missed.
+    #[serde(default)]
+    pub status: String,
+    /// When the reminder reached a terminal outcome.
+    pub outcome_at: Option<String>,
+    /// Last recorded terminal error, if any.
+    pub last_error: Option<String>,
 }
 
 impl fmt::Display for ReminderSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = if self.status.is_empty() {
+            if self.delivered { "delivered" } else { "pending" }
+        } else {
+            &self.status
+        };
         write!(
             f,
             "{} [{}] {} -> {}",
-            self.id,
-            if self.delivered {
-                "delivered"
-            } else {
-                "pending"
-            },
-            self.target,
-            self.message
+            self.id, label, self.target, self.message,
         )?;
-        write!(f, " at {}", self.fire_at)
+        write!(f, " at {}", self.fire_at)?;
+        if let Some(ref outcome_at) = self.outcome_at {
+            write!(f, " outcome={outcome_at}")?;
+        }
+        if let Some(ref last_error) = self.last_error {
+            write!(f, " error={last_error}")?;
+        }
+        Ok(())
     }
 }
 
@@ -2316,5 +2328,106 @@ mod tests {
         assert!(out.contains("Dashboard"));
         assert!(out.contains("Cron:      3 total / 2 enabled / 1 due"));
         assert!(out.contains("Default:   hamza-eastus2/gpt-5.4"));
+    }
+
+    #[test]
+    fn render_reminder_pending() {
+        let r = ReminderSummary {
+            id: "r-1".into(),
+            message: "Stand up".into(),
+            target: "main".into(),
+            fire_at: "2026-04-01T09:00:00Z".into(),
+            delivered: false,
+            created_at: "2026-03-19T10:00:00Z".into(),
+            delivered_at: None,
+            status: "pending".into(),
+            outcome_at: None,
+            last_error: None,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("[pending]"));
+        assert!(out.contains("main -> Stand up"));
+        assert!(!out.contains("outcome="));
+        assert!(!out.contains("error="));
+    }
+
+    #[test]
+    fn render_reminder_delivered() {
+        let r = ReminderSummary {
+            id: "r-2".into(),
+            message: "Take meds".into(),
+            target: "isolated".into(),
+            fire_at: "2026-04-01T08:00:00Z".into(),
+            delivered: true,
+            created_at: "2026-03-19T10:00:00Z".into(),
+            delivered_at: Some("2026-04-01T08:00:05Z".into()),
+            status: "delivered".into(),
+            outcome_at: Some("2026-04-01T08:00:05Z".into()),
+            last_error: None,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("[delivered]"));
+        assert!(out.contains("isolated -> Take meds"));
+        assert!(out.contains("outcome=2026-04-01T08:00:05Z"));
+    }
+
+    #[test]
+    fn render_reminder_missed_shows_error() {
+        let r = ReminderSummary {
+            id: "r-3".into(),
+            message: "Important".into(),
+            target: "main".into(),
+            fire_at: "2026-04-01T07:00:00Z".into(),
+            delivered: false,
+            created_at: "2026-03-19T10:00:00Z".into(),
+            delivered_at: None,
+            status: "missed".into(),
+            outcome_at: Some("2026-04-01T07:01:00Z".into()),
+            last_error: Some("session unavailable".into()),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("[missed]"));
+        assert!(out.contains("error=session unavailable"));
+        assert!(out.contains("outcome="));
+    }
+
+    #[test]
+    fn render_reminder_cancelled() {
+        let r = ReminderSummary {
+            id: "r-4".into(),
+            message: "Nevermind".into(),
+            target: "main".into(),
+            fire_at: "2026-04-01T12:00:00Z".into(),
+            delivered: false,
+            created_at: "2026-03-19T10:00:00Z".into(),
+            delivered_at: None,
+            status: "cancelled".into(),
+            outcome_at: Some("2026-03-20T10:00:00Z".into()),
+            last_error: None,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("[cancelled]"));
+    }
+
+    #[test]
+    fn render_reminder_json_includes_outcome_fields() {
+        let r = ReminderSummary {
+            id: "r-5".into(),
+            message: "JSON test".into(),
+            target: "isolated".into(),
+            fire_at: "2026-04-01T09:00:00Z".into(),
+            delivered: false,
+            created_at: "2026-03-19T10:00:00Z".into(),
+            delivered_at: None,
+            status: "missed".into(),
+            outcome_at: Some("2026-04-01T09:01:00Z".into()),
+            last_error: Some("timeout".into()),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["status"], "missed");
+        assert_eq!(v["outcome_at"], "2026-04-01T09:01:00Z");
+        assert_eq!(v["last_error"], "timeout");
+        assert_eq!(v["target"], "isolated");
     }
 }

--- a/crates/rune-gateway/src/supervisor.rs
+++ b/crates/rune-gateway/src/supervisor.rs
@@ -266,8 +266,8 @@ async fn supervisor_loop(deps: SupervisorDeps, mut shutdown_rx: watch::Receiver<
                 .start_delivery_attempt(&reminder.id)
                 .await;
 
-            // Deliver reminder by executing it as a turn in the stable scheduled session.
-            match run_reminder(&deps, &reminder.message).await {
+            // Deliver reminder via the session determined by its target field.
+            match run_reminder(&deps, &reminder.message, &reminder.target).await {
                 Ok(output) => {
                     if deps
                         .reminder_store
@@ -381,13 +381,39 @@ async fn run_agent_turn(
     }
 }
 
-/// Execute a reminder by running its message in the stable main scheduled session.
+/// Execute a reminder by running its message in the session determined by `target`.
+///
+/// Target routing:
+///   - `"main"` (default) → stable main scheduled session
+///   - `"isolated"` → one-shot subagent session under the main scheduled session
+///   - anything else → treated as `"main"` with a warning
 async fn run_reminder(
     deps: &SupervisorDeps,
     message: &str,
+    target: &str,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let session = get_or_create_main_scheduled_session(deps).await?;
-    execute_in_session(deps, &session, message, None, false, TriggerKind::Reminder).await
+    match target {
+        "isolated" => {
+            let parent = get_or_create_main_scheduled_session(deps).await?;
+            let session = deps
+                .session_engine
+                .create_session_full(
+                    SessionKind::Subagent,
+                    deps.workspace_root.clone(),
+                    Some(parent.id),
+                    None,
+                )
+                .await?;
+            execute_in_session(deps, &session, message, None, true, TriggerKind::Reminder).await
+        }
+        other => {
+            if other != "main" {
+                warn!(target = %other, "unrecognized reminder target; falling back to main");
+            }
+            let session = get_or_create_main_scheduled_session(deps).await?;
+            execute_in_session(deps, &session, message, None, false, TriggerKind::Reminder).await
+        }
+    }
 }
 
 async fn get_or_create_main_scheduled_session(

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4685,3 +4685,254 @@ async fn list_sessions_filters_by_channel_and_activity() {
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["channel"], "telegram");
 }
+
+// ── Reminder route tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn reminders_add_returns_created_with_target_and_status() {
+    let app = build_test_app(None);
+
+    let response = app
+        .oneshot(
+            Request::post("/reminders")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "message": "Stand up!",
+                        "fire_at": "2026-04-01T09:00:00Z",
+                        "target": "isolated"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(json["message"], "Stand up!");
+    assert_eq!(json["target"], "isolated");
+    assert_eq!(json["status"], "pending");
+    assert_eq!(json["delivered"], false);
+    assert!(json["outcome_at"].is_null());
+    assert!(json["last_error"].is_null());
+}
+
+#[tokio::test]
+async fn reminders_add_defaults_target_to_main() {
+    let app = build_test_app(None);
+
+    let response = app
+        .oneshot(
+            Request::post("/reminders")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "message": "Take meds",
+                        "fire_at": "2026-04-01T08:00:00Z"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(json["target"], "main");
+}
+
+#[tokio::test]
+async fn reminders_list_includes_outcome_fields() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let (event_tx, _) = broadcast::channel::<SessionEvent>(64);
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+
+    // Pre-populate reminder store with a cancelled reminder.
+    let reminder_store = Arc::new(ReminderStore::new());
+    let reminder = rune_runtime::scheduler::Reminder::new(
+        "Cancelled event",
+        "isolated",
+        chrono::Utc::now() + chrono::Duration::hours(2),
+    );
+    let id = reminder_store.add(reminder).await;
+    reminder_store.cancel(&id).await;
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store,
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        process_manager: ProcessManager::new(),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        event_tx,
+        tts_engine: None,
+        stt_engine: None,
+    };
+
+    let app = build_router(state, None);
+
+    // includeDelivered=true so cancelled reminder is visible
+    let response = app
+        .oneshot(
+            Request::get("/reminders?includeDelivered=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["target"], "isolated");
+    assert_eq!(items[0]["status"], "cancelled");
+    assert!(items[0]["outcome_at"].is_string());
+    assert_eq!(items[0]["delivered"], false);
+}
+
+#[tokio::test]
+async fn reminders_cancel_returns_success() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let (event_tx, _) = broadcast::channel::<SessionEvent>(64);
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+
+    // Pre-populate reminder store with a pending reminder.
+    let reminder_store = Arc::new(ReminderStore::new());
+    let reminder = rune_runtime::scheduler::Reminder::new(
+        "Cancel me",
+        "main",
+        chrono::Utc::now() + chrono::Duration::hours(1),
+    );
+    let id = reminder_store.add(reminder).await;
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: reminder_store.clone(),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        process_manager: ProcessManager::new(),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        event_tx,
+        tts_engine: None,
+        stt_engine: None,
+    };
+
+    let app = build_router(state, None);
+
+    let response = app
+        .oneshot(
+            Request::delete(format!("/reminders/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["success"], true);
+
+    // Verify the reminder was actually cancelled in the store.
+    let r = reminder_store.get(&id).await.unwrap();
+    assert_eq!(
+        serde_json::to_value(&r.status).unwrap(),
+        serde_json::json!("cancelled")
+    );
+    assert!(r.outcome_at.is_some());
+}


### PR DESCRIPTION
## Summary
- **Supervisor target routing**: `run_reminder()` now reads `reminder.target` to route delivery to `main` (default) or `isolated` (one-shot subagent) sessions. Unrecognized targets warn and fall back to main.
- **CLI outcome visibility**: `ReminderSummary` now includes `status`, `outcome_at`, and `last_error` fields. The Display impl shows the lifecycle label (pending/delivered/missed/cancelled) and any terminal error or timestamp.
- **CLI client parsing**: `reminders_list()` now extracts `status`, `outcome_at`, and `last_error` from the gateway JSON response.

## Test plan
- [x] 4 new route tests: add with target, default target, list with outcome fields, cancel via DELETE
- [x] 5 new CLI output tests: pending/delivered/missed/cancelled rendering + JSON roundtrip
- [x] 1 new CLI client test: mock server verifies outcome field parsing
- [x] All 96 existing tests pass across rune-cli, rune-runtime, rune-gateway
- [x] Zero clippy warnings

Closes part of #43 (task 3: reminder target routing and outcome parity).