### PR TITLE
feat(scheduler): durable claim/lease semantics for due jobs and reminders (#43)

### DIFF
--- a/crates/rune-gateway/src/supervisor.rs
+++ b/crates/rune-gateway/src/supervisor.rs
@@ -17,6 +17,11 @@ use rune_store::models::SessionRow;
 use crate::pairing::DeviceRegistry;
 use crate::state::SessionEvent;
 
+/// Default lease duration (seconds) for durable job/reminder claims.
+/// Claims older than this are considered expired and reclaimable by another
+/// supervisor instance (crash recovery).
+const CLAIM_LEASE_SECS: i64 = 300;
+
 /// Manages background services (heartbeat, scheduler, reminders).
 pub struct BackgroundSupervisor {
     handle: Option<tokio::task::JoinHandle<()>>,
@@ -249,16 +254,17 @@ async fn supervisor_loop(deps: SupervisorDeps, mut shutdown_rx: watch::Receiver<
             error!(error = %error, "failed to prune expired pairing requests");
         }
 
-        // --- Scheduled jobs ---
-        let due_jobs = deps.scheduler.get_due_jobs().await;
+        // --- Scheduled jobs (durable claim prevents duplicate execution) ---
+        let due_jobs = deps.scheduler.claim_due_jobs(CLAIM_LEASE_SECS).await;
         for job in due_jobs {
             let job_id = job.id;
-            debug!(job_id = %job_id, name = ?job.name, "executing due job");
+            debug!(job_id = %job_id, name = ?job.name, "executing claimed job");
             let _ = run_job_lifecycle(&deps, &job, true, SchedulerRunTrigger::Due).await;
+            deps.scheduler.release_claim(&job_id).await;
         }
 
-        // --- Reminders ---
-        let due_reminders = deps.reminder_store.get_due().await;
+        // --- Reminders (durable claim prevents duplicate delivery) ---
+        let due_reminders = deps.reminder_store.claim_due(CLAIM_LEASE_SECS).await;
         for reminder in due_reminders {
             info!(reminder_id = %reminder.id, target = %reminder.target, "delivering reminder");
             let attempt = deps
@@ -294,6 +300,7 @@ async fn supervisor_loop(deps: SupervisorDeps, mut shutdown_rx: watch::Receiver<
                     }
                 }
             }
+            deps.reminder_store.release_claim(&reminder.id).await;
         }
     }
 }

--- a/crates/rune-runtime/src/scheduler.rs
+++ b/crates/rune-runtime/src/scheduler.rs
@@ -528,6 +528,41 @@ impl Scheduler {
         }
     }
 
+    /// Atomically claim due cron jobs for execution, preventing duplicates.
+    ///
+    /// For in-memory backends this falls back to `get_due_jobs()`.
+    /// For durable backends, jobs are atomically marked with `claimed_at`
+    /// so that concurrent supervisors cannot double-execute the same job.
+    /// Claims older than `lease_secs` are considered expired and reclaimable.
+    pub async fn claim_due_jobs(&self, lease_secs: i64) -> Vec<Job> {
+        let now = Utc::now();
+        let stale_before = now - chrono::Duration::seconds(lease_secs);
+        match &self.backend {
+            SchedulerBackend::Memory(_) => self.get_due_jobs().await,
+            SchedulerBackend::Repo { jobs: repo, .. } => {
+                match repo.claim_due_jobs("cron", now, stale_before, 50).await {
+                    Ok(rows) => rows
+                        .into_iter()
+                        .filter_map(|row| row_to_job(row).ok())
+                        .collect(),
+                    Err(error) => {
+                        warn!(error = %error, "failed to claim due persisted cron jobs");
+                        Vec::new()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Release the durable claim on a job after execution completes.
+    pub async fn release_claim(&self, id: &JobId) {
+        if let SchedulerBackend::Repo { jobs: repo, .. } = &self.backend {
+            if let Err(error) = repo.release_claim(Uuid::from(*id)).await {
+                warn!(job_id = %id, error = %error, "failed to release job claim");
+            }
+        }
+    }
+
     /// Compute and set the next run time for a job after a firing attempt.
     pub async fn advance_next_run(&self, id: &JobId) {
         match &self.backend {
@@ -967,6 +1002,39 @@ impl ReminderStore {
                 .into_iter()
                 .filter(Reminder::is_due)
                 .collect(),
+        }
+    }
+
+    /// Atomically claim due reminders for delivery, preventing duplicates.
+    ///
+    /// For in-memory backends this falls back to `get_due()`.
+    /// For durable backends, reminders are atomically marked with `claimed_at`.
+    pub async fn claim_due(&self, lease_secs: i64) -> Vec<Reminder> {
+        let now = Utc::now();
+        let stale_before = now - chrono::Duration::seconds(lease_secs);
+        match &self.backend {
+            ReminderStoreBackend::Memory(_) => self.get_due().await,
+            ReminderStoreBackend::Repo { jobs: repo, .. } => {
+                match repo.claim_due_jobs("reminder", now, stale_before, 50).await {
+                    Ok(rows) => rows
+                        .into_iter()
+                        .filter_map(|row| row_to_reminder(row).ok())
+                        .collect(),
+                    Err(error) => {
+                        warn!(error = %error, "failed to claim due persisted reminders");
+                        Vec::new()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Release the durable claim on a reminder after delivery completes.
+    pub async fn release_claim(&self, id: &JobId) {
+        if let ReminderStoreBackend::Repo { jobs: repo, .. } = &self.backend {
+            if let Err(error) = repo.release_claim(Uuid::from(*id)).await {
+                warn!(reminder_id = %id, error = %error, "failed to release reminder claim");
+            }
         }
     }
 

--- a/crates/rune-store/migrations/2026-03-19-000010_add_durable_claims/down.sql
+++ b/crates/rune-store/migrations/2026-03-19-000010_add_durable_claims/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_jobs_due_unclaimed;
+ALTER TABLE jobs DROP COLUMN claimed_at;

--- a/crates/rune-store/migrations/2026-03-19-000010_add_durable_claims/up.sql
+++ b/crates/rune-store/migrations/2026-03-19-000010_add_durable_claims/up.sql
@@ -1,0 +1,5 @@
+-- Durable claim/lease column for preventing duplicate job execution.
+ALTER TABLE jobs ADD COLUMN claimed_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_jobs_due_unclaimed
+    ON jobs (enabled, next_run_at)
+    WHERE claimed_at IS NULL;

--- a/crates/rune-store/src/models.rs
+++ b/crates/rune-store/src/models.rs
@@ -140,6 +140,8 @@ pub struct JobRow {
     pub payload: serde_json::Value,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Set when a supervisor claims this job for execution; NULL = unclaimed.
+    pub claimed_at: Option<DateTime<Utc>>,
 }
 
 /// Insert payload for a new job.

--- a/crates/rune-store/src/pg.rs
+++ b/crates/rune-store/src/pg.rs
@@ -474,6 +474,62 @@ impl JobRepo for PgJobRepo {
             .await
             .map_err(|e| not_found_or(e, "job", id))
     }
+
+    async fn claim_due_jobs(
+        &self,
+        job_type: &str,
+        now: DateTime<Utc>,
+        stale_before: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<JobRow>, StoreError> {
+        let mut conn = self.pool.get().await.map_err(pool_err)?;
+        let due_col_sql = if job_type == "reminder" {
+            "due_at"
+        } else {
+            "next_run_at"
+        };
+        // Atomic claim: UPDATE with subquery + FOR UPDATE SKIP LOCKED,
+        // then SELECT the freshly claimed rows by matching claimed_at.
+        let update_sql = format!(
+            "UPDATE jobs SET claimed_at = $1 \
+             WHERE id IN (\
+                SELECT id FROM jobs \
+                WHERE job_type = $2 AND enabled = true \
+                  AND {due_col_sql} IS NOT NULL AND {due_col_sql} <= $1 \
+                  AND (claimed_at IS NULL OR claimed_at < $3) \
+                ORDER BY {due_col_sql} ASC \
+                LIMIT $4 \
+                FOR UPDATE SKIP LOCKED\
+             )"
+        );
+        sql_query(update_sql)
+            .bind::<diesel::sql_types::Timestamptz, _>(now)
+            .bind::<Text, _>(job_type)
+            .bind::<diesel::sql_types::Timestamptz, _>(stale_before)
+            .bind::<BigInt, _>(limit)
+            .execute(&mut conn)
+            .await
+            .map_err(StoreError::from)?;
+
+        // Fetch the rows we just claimed.
+        jobs::table
+            .filter(jobs::job_type.eq(job_type))
+            .filter(jobs::claimed_at.eq(Some(now)))
+            .select(JobRow::as_select())
+            .load(&mut conn)
+            .await
+            .map_err(StoreError::from)
+    }
+
+    async fn release_claim(&self, id: Uuid) -> Result<(), StoreError> {
+        let mut conn = self.pool.get().await.map_err(pool_err)?;
+        diesel::update(jobs::table.find(id))
+            .set(jobs::claimed_at.eq(None::<DateTime<Utc>>))
+            .execute(&mut conn)
+            .await
+            .map_err(StoreError::from)?;
+        Ok(())
+    }
 }
 
 // ── PgJobRunRepo ────────────────────────────────────────────────────

--- a/crates/rune-store/src/repos.rs
+++ b/crates/rune-store/src/repos.rs
@@ -152,6 +152,25 @@ pub trait JobRepo: Send + Sync {
         last_run_at: chrono::DateTime<chrono::Utc>,
         next_run_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<JobRow, StoreError>;
+
+    /// Atomically claim up to `limit` due jobs of `job_type` for execution.
+    ///
+    /// A job is claimable when:
+    ///   - `enabled = true`
+    ///   - `next_run_at <= now`  (or `due_at <= now` for reminders)
+    ///   - `claimed_at IS NULL` **or** `claimed_at < stale_before` (expired lease)
+    ///
+    /// Returns the claimed rows with `claimed_at` set to `now`.
+    async fn claim_due_jobs(
+        &self,
+        job_type: &str,
+        now: chrono::DateTime<chrono::Utc>,
+        stale_before: chrono::DateTime<chrono::Utc>,
+        limit: i64,
+    ) -> Result<Vec<JobRow>, StoreError>;
+
+    /// Release the claim on a job (clear `claimed_at`).
+    async fn release_claim(&self, id: Uuid) -> Result<(), StoreError>;
 }
 
 // ── Job run repository ──────────────────────────────────────────────────────

--- a/crates/rune-store/src/schema.rs
+++ b/crates/rune-store/src/schema.rs
@@ -67,6 +67,7 @@ table! {
         payload -> Jsonb,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        claimed_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/crates/rune-store/src/sqlite/migrations.rs
+++ b/crates/rune-store/src/sqlite/migrations.rs
@@ -244,6 +244,19 @@ SET delivery_mode = CASE
 END;
 "#,
     },
+    Migration {
+        version: 4,
+        name: "add_durable_claims",
+        sql: r#"
+-- Durable claim/lease column: set when a supervisor claims a due job for
+-- execution.  NULL means unclaimed.  A stale claimed_at (older than the
+-- lease duration) is treated as expired so another supervisor may reclaim.
+ALTER TABLE jobs ADD COLUMN claimed_at TEXT;
+CREATE INDEX IF NOT EXISTS idx_jobs_due_unclaimed
+    ON jobs (enabled, next_run_at)
+    WHERE claimed_at IS NULL;
+"#,
+    },
 ];
 
 /// Run all pending migrations on the given connection.

--- a/crates/rune-store/src/sqlite/mod.rs
+++ b/crates/rune-store/src/sqlite/mod.rs
@@ -160,6 +160,7 @@ fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<JobRow> {
         payload: parse_json(&row.get::<_, String>(9)?),
         created_at: parse_dt(&row.get::<_, String>(10)?),
         updated_at: parse_dt(&row.get::<_, String>(11)?),
+        claimed_at: parse_dt_opt(row.get(12)?),
     })
 }
 
@@ -255,7 +256,7 @@ fn row_to_pairing_request(row: &rusqlite::Row<'_>) -> rusqlite::Result<PairingRe
 const SESSION_COLS: &str = "id, kind, status, workspace_root, channel_ref, requester_session_id, latest_turn_id, metadata, created_at, updated_at, last_activity_at";
 const TURN_COLS: &str = "id, session_id, trigger_kind, status, model_ref, started_at, ended_at, usage_prompt_tokens, usage_completion_tokens";
 const TRANSCRIPT_COLS: &str = "id, session_id, turn_id, seq, kind, payload, created_at";
-const JOB_COLS: &str = "id, job_type, schedule, due_at, enabled, last_run_at, next_run_at, payload_kind, delivery_mode, payload, created_at, updated_at";
+const JOB_COLS: &str = "id, job_type, schedule, due_at, enabled, last_run_at, next_run_at, payload_kind, delivery_mode, payload, created_at, updated_at, claimed_at";
 const JOB_RUN_COLS: &str =
     "id, job_id, started_at, finished_at, trigger_kind, status, output, created_at";
 const APPROVAL_COLS: &str = "id, subject_type, subject_id, reason, decision, decided_by, decided_at, presented_payload, created_at";
@@ -621,7 +622,7 @@ impl JobRepo for SqliteJobRepo {
             .call(move |conn| {
                 conn.execute(
                     &format!(
-                        "INSERT INTO jobs ({JOB_COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)"
+                        "INSERT INTO jobs ({JOB_COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)"
                     ),
                     rusqlite::params![
                         j.id.to_string(),
@@ -636,6 +637,7 @@ impl JobRepo for SqliteJobRepo {
                         serde_json::to_string(&j.payload).unwrap_or_default(),
                         to_rfc3339(&j.created_at),
                         to_rfc3339(&j.updated_at),
+                        Option::<String>::None, // claimed_at
                     ],
                 )?;
                 conn.prepare(&format!("SELECT {JOB_COLS} FROM jobs WHERE id = ?1"))?
@@ -746,6 +748,69 @@ impl JobRepo for SqliteJobRepo {
             })
             .await
             .map_err(|e| map_err(e, "job", &id.to_string()))
+    }
+
+    async fn claim_due_jobs(
+        &self,
+        job_type: &str,
+        now: DateTime<Utc>,
+        stale_before: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<JobRow>, StoreError> {
+        let jt = job_type.to_string();
+        let now_s = to_rfc3339(&now);
+        let stale_s = to_rfc3339(&stale_before);
+        self.conn
+            .call(move |conn| {
+                // Use the due-at column for reminders, next_run_at for cron.
+                let due_col = if jt == "reminder" {
+                    "due_at"
+                } else {
+                    "next_run_at"
+                };
+
+                // Atomically claim: UPDATE … WHERE selects only claimable rows.
+                let update_sql = format!(
+                    "UPDATE jobs SET claimed_at = ?1 WHERE id IN (\
+                        SELECT id FROM jobs \
+                        WHERE job_type = ?2 AND enabled = 1 \
+                          AND {due_col} IS NOT NULL AND {due_col} <= ?1 \
+                          AND (claimed_at IS NULL OR claimed_at < ?3) \
+                        ORDER BY {due_col} ASC \
+                        LIMIT ?4\
+                    )"
+                );
+                conn.execute(
+                    &update_sql,
+                    rusqlite::params![&now_s, &jt, &stale_s, limit],
+                )?;
+
+                // Fetch the rows we just claimed.
+                let select_sql = format!(
+                    "SELECT {JOB_COLS} FROM jobs \
+                     WHERE job_type = ?1 AND claimed_at = ?2 \
+                     ORDER BY {due_col} ASC"
+                );
+                conn.prepare(&select_sql)?
+                    .query_map(rusqlite::params![&jt, &now_s], row_to_job)?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .await
+            .map_err(StoreError::from)
+    }
+
+    async fn release_claim(&self, id: Uuid) -> Result<(), StoreError> {
+        let id_s = id.to_string();
+        self.conn
+            .call(move |conn| {
+                conn.execute(
+                    "UPDATE jobs SET claimed_at = NULL WHERE id = ?1",
+                    [&id_s],
+                )?;
+                Ok(())
+            })
+            .await
+            .map_err(StoreError::from)
     }
 }
 

--- a/crates/rune-store/tests/contract_tests.rs
+++ b/crates/rune-store/tests/contract_tests.rs
@@ -533,6 +533,147 @@ async fn test_json_roundtrip(repo: &dyn SessionRepo) {
     assert_eq!(found.metadata, complex_json);
 }
 
+async fn test_claim_due_jobs(repo: &dyn JobRepo) {
+    let past = now() - chrono::Duration::seconds(60);
+    let future = now() + chrono::Duration::hours(1);
+
+    // Create a due cron job (next_run_at in the past).
+    let mut due_job = new_job();
+    due_job.job_type = "cron".into();
+    due_job.schedule = Some(r#"{"kind":"every","every_ms":60000}"#.into());
+    let due_id = due_job.id;
+    repo.create(due_job).await.unwrap();
+    // Set next_run_at to the past.
+    repo.record_run(due_id, past, Some(past)).await.unwrap();
+
+    // Create a not-yet-due cron job.
+    let mut future_job = new_job();
+    future_job.job_type = "cron".into();
+    future_job.schedule = Some(r#"{"kind":"every","every_ms":60000}"#.into());
+    let future_id = future_job.id;
+    repo.create(future_job).await.unwrap();
+    repo.record_run(future_id, now(), Some(future))
+        .await
+        .unwrap();
+
+    let claim_now = now();
+    let stale_before = claim_now - chrono::Duration::seconds(300);
+
+    // First claim should return only the due job.
+    let claimed = repo
+        .claim_due_jobs("cron", claim_now, stale_before, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1, "should claim exactly the one due job");
+    assert_eq!(claimed[0].id, due_id);
+    assert!(claimed[0].claimed_at.is_some());
+
+    // Second claim should return nothing (job already claimed, claim is fresh).
+    let claimed2 = repo
+        .claim_due_jobs("cron", now(), stale_before, 10)
+        .await
+        .unwrap();
+    assert!(
+        claimed2.is_empty(),
+        "duplicate claim must return empty (job is already claimed)"
+    );
+}
+
+async fn test_claim_stale_reclaim(repo: &dyn JobRepo) {
+    // Use a far-past next_run_at so it's "due" even at an old claim timestamp.
+    let far_past = now() - chrono::Duration::seconds(3600);
+
+    // Create a due cron job.
+    let mut job = new_job();
+    job.job_type = "cron".into();
+    job.schedule = Some(r#"{"kind":"every","every_ms":60000}"#.into());
+    let jid = job.id;
+    repo.create(job).await.unwrap();
+    repo.record_run(jid, far_past, Some(far_past)).await.unwrap();
+
+    let old_claim_time = now() - chrono::Duration::seconds(600);
+    let fresh_stale_before = now() - chrono::Duration::seconds(300);
+
+    // Simulate an old claim (as if a previous supervisor crashed 10 min ago).
+    let first_claimed = repo
+        .claim_due_jobs("cron", old_claim_time, old_claim_time, 10)
+        .await
+        .unwrap();
+    assert_eq!(first_claimed.len(), 1, "should claim the due job");
+
+    // Now reclaim with a fresh stale_before — old claim should be expired.
+    let reclaimed = repo
+        .claim_due_jobs("cron", now(), fresh_stale_before, 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        reclaimed.len(),
+        1,
+        "stale claim should be reclaimable by another supervisor"
+    );
+    assert_eq!(reclaimed[0].id, jid);
+}
+
+async fn test_release_claim(repo: &dyn JobRepo) {
+    let past = now() - chrono::Duration::seconds(60);
+
+    let mut job = new_job();
+    job.job_type = "cron".into();
+    job.schedule = Some(r#"{"kind":"every","every_ms":60000}"#.into());
+    let jid = job.id;
+    repo.create(job).await.unwrap();
+    repo.record_run(jid, past, Some(past)).await.unwrap();
+
+    // Claim the job.
+    let claimed = repo
+        .claim_due_jobs("cron", now(), now() - chrono::Duration::seconds(300), 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+
+    // Release the claim.
+    repo.release_claim(jid).await.unwrap();
+
+    // After release, the job should be re-claimable immediately.
+    let reclaimed = repo
+        .claim_due_jobs("cron", now(), now() - chrono::Duration::seconds(300), 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        reclaimed.len(),
+        1,
+        "released job should be immediately reclaimable"
+    );
+}
+
+async fn test_claim_due_reminders(repo: &dyn JobRepo) {
+    let past = now() - chrono::Duration::seconds(60);
+
+    // Create a due reminder.
+    let mut reminder = new_job();
+    reminder.job_type = "reminder".into();
+    reminder.due_at = Some(past);
+    let rid = reminder.id;
+    repo.create(reminder).await.unwrap();
+
+    let claim_now = now();
+    let stale_before = claim_now - chrono::Duration::seconds(300);
+
+    let claimed = repo
+        .claim_due_jobs("reminder", claim_now, stale_before, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, rid);
+
+    // Second claim returns empty.
+    let claimed2 = repo
+        .claim_due_jobs("reminder", now(), stale_before, 10)
+        .await
+        .unwrap();
+    assert!(claimed2.is_empty());
+}
+
 // ── SQLite contract module ───────────────────────────────────────────
 
 #[cfg(feature = "sqlite")]
@@ -649,5 +790,29 @@ mod sqlite_contract {
     async fn json_roundtrip() {
         let (s, ..) = repos().await;
         test_json_roundtrip(&s).await;
+    }
+
+    #[tokio::test]
+    async fn claim_due_jobs() {
+        let (_, _, _, j, ..) = repos().await;
+        test_claim_due_jobs(&j).await;
+    }
+
+    #[tokio::test]
+    async fn claim_stale_reclaim() {
+        let (_, _, _, j, ..) = repos().await;
+        test_claim_stale_reclaim(&j).await;
+    }
+
+    #[tokio::test]
+    async fn release_claim() {
+        let (_, _, _, j, ..) = repos().await;
+        test_release_claim(&j).await;
+    }
+
+    #[tokio::test]
+    async fn claim_due_reminders() {
+        let (_, _, _, j, ..) = repos().await;
+        test_claim_due_reminders(&j).await;
     }
 }


### PR DESCRIPTION
## Summary
- Adds durable claim/lease semantics to prevent duplicate execution of cron jobs and reminders across concurrent supervisor ticks or process restarts.
- Introduces `claimed_at` column on the `jobs` table with atomic claim-and-fetch SQL in both SQLite and PostgreSQL backends.
- Supervisor loop now uses `claim_due_jobs()`/`claim_due()` instead of non-atomic `get_due_jobs()`/`get_due()`, with configurable 5-minute lease expiration for crash recovery.

## What changed
| Layer | Change |
|-------|--------|
| **Store – schema** | Migration v4 (SQLite) + Diesel migration 000010 (PG): `claimed_at TEXT` column + partial index |
| **Store – trait** | `JobRepo::claim_due_jobs()` and `JobRepo::release_claim()` |
| **Store – SQLite** | Atomic `UPDATE … WHERE id IN (SELECT … WHERE unclaimed)` then `SELECT` |
| **Store – PG** | Same pattern with `FOR UPDATE SKIP LOCKED` |
| **Runtime – Scheduler** | `claim_due_jobs(lease_secs)` / `release_claim(id)` |
| **Runtime – ReminderStore** | `claim_due(lease_secs)` / `release_claim(id)` |
| **Gateway – Supervisor** | Replaced `get_due_jobs`/`get_due` with claim variants; release after execution |
| **Tests** | 4 new contract tests: duplicate suppression, stale reclaim, release-then-reclaim, reminder claims |

## Test plan
- [x] `cargo test -p rune-store --features sqlite --test contract_tests` — 18/18 pass (4 new claim tests)
- [x] `cargo test -p rune-runtime --lib -- scheduler` — 26/26 pass
- [x] `cargo test -p rune-gateway --lib -- supervisor` — 5/5 pass
- [x] `cargo test -p rune-store --test pg_integration` — 12/12 pass
- [x] `cargo clippy -p rune-store -p rune-runtime -p rune-gateway --features sqlite` — clean

Closes task 4 of #43.