### PR TITLE
feat(models): Azure request-shape hardening and golden tests (#69)

### DIFF
--- a/crates/rune-models/src/lib.rs
+++ b/crates/rune-models/src/lib.rs
@@ -70,6 +70,27 @@ fn validate_azure_endpoint(base_url: &str, provider_kind: &str) -> Result<(), Mo
     Ok(())
 }
 
+/// Validate that an Azure deployment name is safe for URL path embedding.
+///
+/// Deployment names are interpolated directly into the Azure OpenAI URL path
+/// (`/openai/deployments/{name}/…`), so they must be non-empty, non-whitespace,
+/// and must not contain characters that would break the URL structure.
+fn validate_azure_deployment_name(name: &str) -> Result<(), ModelError> {
+    if name.trim().is_empty() {
+        return Err(ModelError::Configuration(
+            "Azure deployment_name must not be empty or whitespace-only".into(),
+        ));
+    }
+    const FORBIDDEN: &[char] = &['/', '?', '#', '%', ' '];
+    if let Some(bad) = name.chars().find(|c| FORBIDDEN.contains(c)) {
+        return Err(ModelError::Configuration(format!(
+            "Azure deployment_name '{name}' contains invalid character '{bad}' \
+             — deployment names are embedded in the URL path and must not contain /, ?, #, %, or spaces"
+        )));
+    }
+    Ok(())
+}
+
 /// Build a `Box<dyn ModelProvider>` from a [`ModelProviderConfig`].
 ///
 /// Provider selection is driven by `provider_name`:
@@ -123,6 +144,7 @@ pub fn provider_from_config(
             let deployment = cfg.deployment_name.as_deref().ok_or_else(|| {
                 ModelError::Configuration("Azure provider requires deployment_name".into())
             })?;
+            validate_azure_deployment_name(deployment)?;
             let api_version = cfg.api_version.as_deref().ok_or_else(|| {
                 ModelError::Configuration("Azure provider requires api_version".into())
             })?;
@@ -585,6 +607,66 @@ mod tests {
         let err = provider_from_config(&cfg).unwrap_err();
         assert!(matches!(err, ModelError::Configuration(_)));
         assert!(err.to_string().contains("non-empty base_url"));
+    }
+
+    // --- Azure deployment-name validation ---
+
+    #[test]
+    fn valid_azure_deployment_names() {
+        assert!(validate_azure_deployment_name("gpt-4o").is_ok());
+        assert!(validate_azure_deployment_name("my-deployment-v2").is_ok());
+        assert!(validate_azure_deployment_name("GPT4o_prod").is_ok());
+        assert!(validate_azure_deployment_name("a").is_ok());
+    }
+
+    #[test]
+    fn azure_deployment_name_rejects_empty() {
+        let err = validate_azure_deployment_name("").unwrap_err();
+        assert!(matches!(err, ModelError::Configuration(_)));
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn azure_deployment_name_rejects_whitespace_only() {
+        let err = validate_azure_deployment_name("   ").unwrap_err();
+        assert!(matches!(err, ModelError::Configuration(_)));
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn azure_deployment_name_rejects_path_unsafe_chars() {
+        for (name, bad_char) in [
+            ("my/deploy", '/'),
+            ("deploy?v=1", '?'),
+            ("deploy#frag", '#'),
+            ("deploy%20name", '%'),
+            ("has space", ' '),
+        ] {
+            let err = validate_azure_deployment_name(name).unwrap_err();
+            assert!(matches!(err, ModelError::Configuration(_)));
+            assert!(
+                err.to_string().contains(&format!("'{bad_char}'")),
+                "expected mention of '{bad_char}' in error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn azure_config_rejects_path_unsafe_deployment_name() {
+        let cfg = ModelProviderConfig {
+            name: "azure".into(),
+            kind: "azure-openai".into(),
+            base_url: "https://test.openai.azure.com".into(),
+            deployment_name: Some("my/bad-deploy".into()),
+            api_version: Some("2024-06-01".into()),
+            api_key: Some("test-key".into()),
+            api_key_env: None,
+            model_alias: None,
+            models: vec![],
+        };
+        let err = provider_from_config(&cfg).unwrap_err();
+        assert!(matches!(err, ModelError::Configuration(_)));
+        assert!(err.to_string().contains("invalid character"));
     }
 
     #[test]

--- a/crates/rune-models/src/provider/azure.rs
+++ b/crates/rune-models/src/provider/azure.rs
@@ -1,13 +1,19 @@
 //! Azure OpenAI provider — correct URL construction with deployment/api-version.
+//!
+//! Azure OpenAI uses the deployment name embedded in the URL path, so the
+//! request body intentionally **excludes** the `model` field.  This matches
+//! the Azure OpenAI REST contract where the deployment already identifies the
+//! model.
 
 use async_trait::async_trait;
 use reqwest::Client;
+use serde::Serialize;
 use tracing::debug;
 
 use super::ModelProvider;
 use super::response::{ApiResponse, map_error_response, parse_response};
 use crate::error::ModelError;
-use crate::types::{CompletionRequest, CompletionResponse};
+use crate::types::{ChatMessage, CompletionRequest, CompletionResponse, ToolDefinition};
 
 /// Azure OpenAI provider.
 ///
@@ -44,20 +50,42 @@ impl AzureOpenAiProvider {
     }
 }
 
+/// Azure OpenAI request body.
+///
+/// Intentionally **omits** `model` — Azure routes by deployment name in the URL.
+/// Uses `max_tokens` which is the field name Azure OpenAI expects.
+#[derive(Debug, Serialize)]
+struct AzureOpenAiRequest<'a> {
+    messages: &'a [ChatMessage],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: &'a Option<Vec<ToolDefinition>>,
+}
+
 #[async_trait]
 impl ModelProvider for AzureOpenAiProvider {
     async fn complete(
         &self,
         request: &CompletionRequest,
     ) -> Result<CompletionResponse, ModelError> {
-        debug!(url = %self.url, "Azure OpenAI completion request");
+        let body = AzureOpenAiRequest {
+            messages: &request.messages,
+            temperature: request.temperature,
+            max_tokens: request.max_tokens,
+            tools: &request.tools,
+        };
+
+        debug!(url = %self.url, msg_count = body.messages.len(), "Azure OpenAI completion request");
 
         let resp = self
             .client
             .post(&self.url)
             .header("api-key", &self.api_key)
             .header("Content-Type", "application/json")
-            .json(request)
+            .json(&body)
             .send()
             .await?;
 

--- a/crates/rune-models/tests/provider_tests.rs
+++ b/crates/rune-models/tests/provider_tests.rs
@@ -2,8 +2,9 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use rune_config::{ConfiguredModel, ModelProviderConfig, ModelsConfig};
 use rune_models::{
-    AzureOpenAiProvider, ChatMessage, CompletionRequest, FinishReason, ModelError, ModelProvider,
-    OpenAiProvider, Role, RoutedModelProvider, provider_from_config,
+    AzureOpenAiProvider, ChatMessage, CompletionRequest, FinishReason, FunctionDefinition,
+    ModelError, ModelProvider, OpenAiProvider, Role, RoutedModelProvider, ToolDefinition,
+    provider_from_config,
 };
 use wiremock::matchers::{body_partial_json, header, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -92,6 +93,273 @@ async fn azure_sends_api_key_header() {
     assert_eq!(resp.content.as_deref(), Some("Hello! How can I help?"));
     assert_eq!(resp.finish_reason, Some(FinishReason::Stop));
     assert_eq!(resp.usage.total_tokens, 18);
+}
+
+// --- Azure request body golden tests ---
+
+/// Azure OpenAI must NOT send the `model` field — the deployment name in the URL
+/// identifies the model.  This contrasts with vanilla OpenAI which always sends `model`.
+#[tokio::test]
+async fn azure_body_omits_model_field() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o", "2024-06-01", "k");
+    let _ = p.complete(&simple_request()).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert!(
+        body.get("model").is_none(),
+        "Azure OpenAI body must NOT contain 'model' — deployment is in the URL. Got: {body}"
+    );
+}
+
+/// Azure OpenAI uses `max_tokens`, not `max_completion_tokens`.
+#[tokio::test]
+async fn azure_body_uses_max_tokens_not_max_completion_tokens() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o", "2024-06-01", "k");
+    let mut request = simple_request();
+    request.max_tokens = Some(512);
+    let _ = p.complete(&request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(
+        body.get("max_tokens"),
+        Some(&serde_json::json!(512)),
+        "Azure body should use 'max_tokens'"
+    );
+    assert!(
+        body.get("max_completion_tokens").is_none(),
+        "Azure body must NOT contain 'max_completion_tokens'"
+    );
+}
+
+/// When max_tokens is None, the field should be omitted entirely.
+#[tokio::test]
+async fn azure_body_omits_max_tokens_when_none() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o", "2024-06-01", "k");
+    let mut request = simple_request();
+    request.max_tokens = None;
+    let _ = p.complete(&request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert!(
+        body.get("max_tokens").is_none(),
+        "Azure body should omit 'max_tokens' when not set"
+    );
+}
+
+/// Azure request body forwards tools correctly.
+#[tokio::test]
+async fn azure_body_includes_tools_when_provided() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o", "2024-06-01", "k");
+    let mut request = simple_request();
+    request.tools = Some(vec![ToolDefinition {
+        tool_type: "function".into(),
+        function: FunctionDefinition {
+            name: "get_weather".into(),
+            description: "Get current weather".into(),
+            parameters: serde_json::json!({"type": "object", "properties": {"city": {"type": "string"}}}),
+        },
+    }]);
+    let _ = p.complete(&request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let tools = body.get("tools").expect("Azure body should include 'tools'");
+    assert!(tools.is_array());
+    assert_eq!(tools.as_array().unwrap().len(), 1);
+    assert_eq!(tools[0]["function"]["name"], "get_weather");
+}
+
+/// Azure request body omits tools when None.
+#[tokio::test]
+async fn azure_body_omits_tools_when_none() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o", "2024-06-01", "k");
+    let mut request = simple_request();
+    request.tools = None;
+    let _ = p.complete(&request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert!(
+        body.get("tools").is_none(),
+        "Azure body should omit 'tools' when not set"
+    );
+}
+
+/// Golden test: full Azure request shape with all fields populated.
+#[tokio::test]
+async fn azure_request_golden_shape_full() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = AzureOpenAiProvider::new(&server.uri(), "gpt-4o-prod", "2024-06-01", "secret-key");
+    let request = CompletionRequest {
+        messages: vec![
+            ChatMessage {
+                role: Role::System,
+                content: Some("You are helpful.".into()),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+            ChatMessage {
+                role: Role::User,
+                content: Some("Hello".into()),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        ],
+        model: Some("gpt-4o".into()), // should NOT appear in Azure body
+        temperature: Some(0.7),
+        max_tokens: Some(1024),
+        tools: None,
+    };
+    let _ = p.complete(&request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let req = &requests[0];
+
+    // Header assertions
+    let api_key_header = req
+        .headers
+        .get("api-key")
+        .expect("Azure must send api-key header");
+    assert_eq!(api_key_header.to_str().unwrap(), "secret-key");
+    assert!(
+        req.headers.get("authorization").is_none(),
+        "Azure must NOT send Authorization header"
+    );
+
+    // URL path assertion
+    assert!(
+        req.url.path().contains("/openai/deployments/gpt-4o-prod/"),
+        "URL must contain deployment name in path: {}",
+        req.url
+    );
+    assert!(
+        req.url
+            .query()
+            .unwrap_or("")
+            .contains("api-version=2024-06-01"),
+        "URL must contain api-version query param: {}",
+        req.url
+    );
+
+    // Body assertions
+    let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+
+    // Must NOT have model
+    assert!(body.get("model").is_none(), "Azure body must omit 'model'");
+
+    // Must have messages
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(msgs[0]["role"], "system");
+    assert_eq!(msgs[1]["role"], "user");
+
+    // Must have temperature and max_tokens
+    assert_eq!(body["temperature"], serde_json::json!(0.7));
+    assert_eq!(body["max_tokens"], serde_json::json!(1024));
+
+    // Only expected keys present
+    let keys: Vec<&str> = body.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+    for key in &keys {
+        assert!(
+            ["messages", "temperature", "max_tokens", "tools"].contains(key),
+            "unexpected key '{key}' in Azure request body"
+        );
+    }
+}
+
+/// Contrast test: OpenAI sends model + max_completion_tokens while Azure sends neither.
+#[tokio::test]
+async fn azure_vs_openai_body_shape_contrast() {
+    let azure_server = MockServer::start().await;
+    let openai_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&azure_server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&openai_server)
+        .await;
+
+    let azure = AzureOpenAiProvider::new(&azure_server.uri(), "dep", "2024-06-01", "k");
+    let openai = OpenAiProvider::new(&openai_server.uri(), "k");
+
+    let mut request = simple_request();
+    request.max_tokens = Some(256);
+
+    let _ = azure.complete(&request).await.unwrap();
+    let _ = openai.complete(&request).await.unwrap();
+
+    let azure_reqs = azure_server.received_requests().await.unwrap();
+    let openai_reqs = openai_server.received_requests().await.unwrap();
+
+    let azure_body: serde_json::Value = serde_json::from_slice(&azure_reqs[0].body).unwrap();
+    let openai_body: serde_json::Value = serde_json::from_slice(&openai_reqs[0].body).unwrap();
+
+    // Azure: no model, max_tokens
+    assert!(azure_body.get("model").is_none(), "Azure must omit model");
+    assert_eq!(azure_body["max_tokens"], 256);
+    assert!(azure_body.get("max_completion_tokens").is_none());
+
+    // OpenAI: has model, max_completion_tokens
+    assert!(openai_body.get("model").is_some(), "OpenAI must include model");
+    assert_eq!(openai_body["max_completion_tokens"], 256);
+    assert!(openai_body.get("max_tokens").is_none());
 }
 
 // --- OpenAI header handling ---


### PR DESCRIPTION
## Summary

Continues Azure hardening (issue #69) after PR #125. This slice focuses on **request construction correctness** and **golden tests** that verify the exact wire format Azure OpenAI expects.

- **Dedicated `AzureOpenAiRequest` body struct** — intentionally omits `model` (Azure routes by deployment name in URL path) and uses `max_tokens` (the field Azure OpenAI expects), contrasting with OpenAI's `max_completion_tokens`
- **Deployment-name validation** — rejects URL-unsafe characters (`/`, `?`, `#`, `%`, space) at config time before they corrupt the URL path
- **8 request-shape golden tests** covering:
  - Azure body omits `model` field
  - Azure uses `max_tokens`, not `max_completion_tokens`
  - Optional fields (`max_tokens`, `tools`) omitted when `None`
  - Tools serialize correctly in Azure body
  - Full golden shape test: headers, URL path, query params, body keys
  - Azure-vs-OpenAI body shape contrast test

## Acceptance criteria touched (from #69)
- [x] Azure OpenAI requests use deployment-name and explicit API-version header
- [x] Request construction golden tests against Azure API expectations
- [x] Provider abstraction: Azure behavior does not leak into non-Azure code paths

## Test plan
- [x] `cargo test -p rune-models --tests --quiet` — 49 tests pass (8 new)
- [x] `cargo test -p rune-models --lib --quiet` — 43 tests pass
- [x] `cargo check` — full workspace compiles clean