### PR TITLE
docs(parity): read-only detection semantics and secrets-never-logged contract (#70)

### DIFF
--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -478,12 +478,38 @@ See [DEPLOYMENT.md §5.1](../operator/DEPLOYMENT.md#51-local--docker-path-equiva
 - read-only or degraded storage modes surface explicit errors
 - backup/restore workflows are documented and testable
 
+#### Read-only filesystem detection
+
+Writability is verified by write-probe (create + delete temp file), not by metadata/permission-bit inspection. This catches bind-mount RO, UID mismatch, SELinux/AppArmor denials, and filesystem-level RO mounts.
+
+All three detection surfaces must agree:
+
+- `rune doctor` CLI — Fail status per unwritable path, mode-aware fix hint
+- startup validation (`validate_paths`) — exit with clear error naming the path
+- gateway `POST /api/doctor/run` — per-path writability findings in response
+
+Unwritable required paths are Fail, never Warn. Silent fallback to ephemeral storage is never acceptable.
+
+#### Secrets-never-logged contract
+
+Secret **values** must never appear in: log output (any level), error messages, status/health/doctor responses, WebSocket payloads, transcript items, or diagnostic bundles.
+
+Scope: provider API keys, channel tokens, database credentials, certificate key material, any value from `/secrets` or secret-reference config fields.
+
+Secret **references** (key names, vault paths, env var names) may appear in diagnostics. Values may not.
+
+Violation is a release-blocking defect.
+
+See [PROTOCOLS.md §3.7](PROTOCOLS.md#secrets-never-logged-invariant) for the full invariant definition.
+
 ### Minimum parity evidence
 
 - local Docker deployment with mounted state
 - restart durability tests
 - PostgreSQL-backed Azure-hosted mode tests
 - Azure Files/Blob mapping validation for intended domains
+- write-probe detection of read-only mounts (Docker bind-mount with `ro` flag)
+- no secret values in `rune doctor` output, `/api/doctor/run` response, or structured logs
 
 ---
 

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -175,6 +175,23 @@ The config subsystem owns:
 - provider-, channel-, and agent-specific overrides
 - secrets references and injection model
 
+#### Secrets-never-logged invariant
+
+Secret values must never appear in:
+
+- log output (structured or unstructured, any severity level)
+- error messages returned to callers or rendered in CLI output
+- status/health/doctor endpoint responses
+- WebSocket event payloads
+- transcript items or tool result summaries
+- diagnostic bundles or debug dumps
+
+This applies to provider API keys, channel tokens, database credentials, certificate key material, and any value loaded from `/secrets` or injected via secret-reference config fields.
+
+Secret references (e.g. key names, vault paths, environment variable names) may appear in diagnostics. Secret values may not.
+
+Violation of this invariant is a release-blocking defect, not a cosmetic issue.
+
 ### 3.8 Doctor and diagnostics contract
 
 The diagnostic subsystem owns:
@@ -183,6 +200,27 @@ The diagnostic subsystem owns:
 - doctor checks and repair workflows
 - inspectable mismatch and drift reports
 - diagnostic bundle/export generation where shipped
+
+#### Read-only filesystem detection semantics
+
+Writability of configured storage paths is verified by **write-probe**, not by metadata inspection. The probe creates and immediately deletes a temporary file in the target directory. This catches failure modes that permission-bit checks miss:
+
+- bind-mount read-only (`ro` flag in Docker or fstab)
+- UID/GID mismatch between the runtime process and the mount owner
+- SELinux or AppArmor policy denials
+- filesystem-level read-only mounts
+
+Detection surfaces:
+
+| Surface | Behavior |
+|---|---|
+| `rune doctor` (CLI) | reports Fail (not Warn) per unwritable path with mode-aware fix hint |
+| `AppConfig::validate_paths()` (startup) | exits with a clear error naming the path and expected permissions |
+| `POST /api/doctor/run` (gateway) | includes per-path writability findings in the response body |
+
+Fix hints are **mode-aware**: standalone mode suggests `mkdir -p` / `chmod`; server/Docker mode suggests volume mount adjustments and UID guidance.
+
+An unwritable required storage path is a **Fail**, not a warning. Silent fallback to ephemeral storage is never acceptable.
 
 ---
 


### PR DESCRIPTION
## Summary

- **PROTOCOLS.md §3.7**: Adds the secrets-never-logged invariant — defines exactly what secret values must never appear in (logs, errors, status/health/doctor responses, WebSocket payloads, transcripts, diagnostic bundles) and marks violation as release-blocking
- **PROTOCOLS.md §3.8**: Adds read-only filesystem detection semantics — documents write-probe method, four failure modes it catches (bind-mount RO, UID mismatch, SELinux/AppArmor, filesystem RO), detection surface table (CLI/startup/gateway), and mode-aware fix hints
- **PARITY-CONTRACTS.md §11**: Adds read-only detection and secrets-never-logged contract sub-sections under failure behavior expectations, plus two new minimum parity evidence items

Addresses acceptance criteria from #70:
- "Secrets never appear in logs, error messages, or status output"
- "Read-only filesystem detected and reported (not silently ignored)"

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Cross-reference links resolve (PROTOCOLS.md §3.7 ↔ PARITY-CONTRACTS.md §11)
- [ ] No code changes — doc-only patch