### PR TITLE
docs(storage): define backup and restore workflow contract (#70)

### DIFF
--- a/docs/FUNCTIONALITY-CHECKLIST.md
+++ b/docs/FUNCTIONALITY-CHECKLIST.md
@@ -366,8 +366,8 @@ Implementation note (2026-03-13): `completion generate <shell>` now emits real s
 
 - [ ] structured logs
 - [ ] metrics/tracing
-- [ ] backup/export
-- [ ] restore/migration workflow
+- [x] backup/export
+- [x] restore/migration workflow
 - [ ] update path
 - [ ] doctor/diagnostics
 - [ ] doctor interactive repair flow

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -564,6 +564,18 @@ Container deployment must make backup/restore straightforward.
 
 A restore should reconstruct the runtime without needing image-layer recovery or undocumented hidden paths.
 
+## 12.4 Minimum workflow contract
+
+Any documented Rune backup/restore workflow should make these steps explicit:
+
+1. **Quiesce or coordinate writes** where required (for example, ensure embedded PostgreSQL export/snapshot consistency and avoid mid-write filesystem capture).
+2. **Capture all required durable domains**: DB state, sessions, memory, media when retained, skills, logs/exports as policy requires, config overlays, and backup staging outputs.
+3. **Exclude secret values from backup metadata** while preserving secret references/config needed to reconnect the runtime after restore.
+4. **Restore into the same logical path layout** (`~/.rune/*` locally or `/data/*`, `/config`, `/secrets` in Docker).
+5. **Run post-restore verification**: `rune doctor`, health/status checks, scheduler/job sanity, and session/transcript inspectability checks.
+
+If a deployment mode uses managed PostgreSQL or external object storage, the operator docs must state which parts are restored from provider-native snapshots versus local filesystem artifacts.
+
 ---
 
 ## 13. Upgrade and migration expectations

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -505,6 +505,8 @@ See [PROTOCOLS.md §3.7](PROTOCOLS.md#secrets-never-logged-invariant) for the fu
 ### Minimum parity evidence
 
 - local Docker deployment with mounted state
+- backup workflow documentation naming included durable-state domains and exclusions
+- restore workflow documentation naming prerequisites and post-restore verification checks
 - restart durability tests
 - PostgreSQL-backed Azure-hosted mode tests
 - Azure Files/Blob mapping validation for intended domains

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -1215,7 +1215,57 @@ Where supported, repair flows should distinguish between:
 - perform fix interactively
 - perform fix non-interactively when explicitly requested
 
-## 15.4 Logging and diagnostics contract
+## 15.4 Backup and restore workflow contract
+
+Backup/restore is part of the operator contract, not an implementation afterthought.
+
+### 15.4.1 Backup scope
+
+A compliant backup workflow must preserve or explicitly account for:
+
+- database state (`/data/db` or managed PostgreSQL equivalent)
+- session/transcript artifacts (`/data/sessions`)
+- memory files (`/data/memory`)
+- media artifacts when retained (`/data/media`)
+- skills/plugins bundles (`/data/skills`)
+- logs/exports when operator policy requires them (`/data/logs`)
+- backup archives/staging outputs (`/data/backups`)
+- config overlays (`/config`)
+- secret references/config metadata without exposing secret values (`/secrets` references, env-var names, vault paths)
+
+### 15.4.2 Backup behavior expectations
+
+Backup workflows must be:
+
+- **documented**  operator can tell what is included and what is intentionally excluded
+- **restorable**  output is suitable for reconstructing runtime state
+- **image-independent**  no reliance on hidden image-layer state or container archaeology
+- **mode-aware**  local embedded-PostgreSQL, mounted Docker, and managed-PostgreSQL deployments can differ in mechanism but not in operator clarity
+- **secret-safe**  secret values never appear in archive manifests, logs, doctor output, or status surfaces
+
+### 15.4.3 Restore behavior expectations
+
+A restore workflow must, at minimum, be able to reconstruct enough durable state to recover:
+
+- session and transcript inspectability
+- memory files and curated workspace state
+- scheduler/job state and next-run derivation
+- pending approvals and related operator auditability
+- config overlays and path layout expectations
+
+Where a restore cannot fully recreate a subsystem (for example, external provider-managed data), the limitation must be stated explicitly in operator docs.
+
+### 15.4.4 Minimum operator evidence
+
+The project should provide enough operator-facing documentation and/or commands that a reviewer can verify:
+
+- what to snapshot or export before upgrade
+- where backup artifacts live (`/data/backups` or equivalent)
+- how local paths map to Docker-mounted paths
+- what preconditions are required for a clean restore
+- what post-restore checks to run (`doctor`, health/status, scheduler state sanity)
+
+## 15.5 Logging and diagnostics contract
 
 Every major action should emit structured events/logs with:
 


### PR DESCRIPTION
## Summary
- define the backup/restore workflow contract in parity protocols
- add minimum operator workflow expectations to deployment docs
- update parity evidence and checklist coverage for documented backup/restore workflows

## Testing
- doc-only change

Refs #70