### PR TITLE
docs(storage): define restart preservation contract (#70)

### DIFF
--- a/docs/FUNCTIONALITY-CHECKLIST.md
+++ b/docs/FUNCTIONALITY-CHECKLIST.md
@@ -368,6 +368,7 @@ Implementation note (2026-03-13): `completion generate <shell>` now emits real s
 - [ ] metrics/tracing
 - [x] backup/export
 - [x] restore/migration workflow
+- [x] restart preservation workflow
 - [ ] update path
 - [ ] doctor/diagnostics
 - [ ] doctor interactive repair flow

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -441,6 +441,14 @@ After restart, the runtime must preserve and recover at minimum:
 
 Long-running OS child processes may not survive restart in all modes, but their prior existence and terminal or lost state must remain inspectable. The runtime must not pretend the work never existed.
 
+Operators should treat container restart verification as a first-class workflow, not an ad hoc sanity check. At minimum the documented post-restart path should verify:
+
+1. `rune doctor` for writable mounts and path sanity
+2. health/status surfaces for dependency readiness
+3. scheduler/job state for expected next runs and preserved history
+4. session/transcript inspectability for recently active work
+5. approval queues / durable audit trails for work that was pending across restart
+
 ---
 
 ## 10. Probe and doctor expectations in containers

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -507,6 +507,7 @@ See [PROTOCOLS.md §3.7](PROTOCOLS.md#secrets-never-logged-invariant) for the fu
 - local Docker deployment with mounted state
 - backup workflow documentation naming included durable-state domains and exclusions
 - restore workflow documentation naming prerequisites and post-restore verification checks
+- restart-preservation documentation naming which state must survive container restart and which post-restart checks operators should run
 - restart durability tests
 - PostgreSQL-backed Azure-hosted mode tests
 - Azure Files/Blob mapping validation for intended domains


### PR DESCRIPTION
## Summary
- define container restart preservation expectations for durable operator-visible state
- add explicit post-restart verification steps to deployment docs
- update parity evidence and checklist coverage for restart-preservation documentation

## Testing
- doc-only change

Refs #70