### PR TITLE
feat(models): auto-detect local Ollama at startup (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -176,7 +176,7 @@ fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
         port = config.gateway.port,
         config_path = %display_config_path(config_path),
         store_backend,
-        model_backend = if config.models.providers.is_empty() { "demo-echo" } else { "configured-provider-or-demo-fallback" },
+        model_backend = if config.models.providers.is_empty() { "auto-detect (probing Ollama…)" } else { "configured" },
         "starting rune gateway"
     );
 }
@@ -208,7 +208,7 @@ async fn build_services(
         SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
     );
 
-    let model_provider: Arc<dyn ModelProvider> = build_model_provider(&config);
+    let model_provider: Arc<dyn ModelProvider> = build_model_provider(&config).await;
     let scheduler = Arc::new(Scheduler::new_with_repos(
         job_repo.clone(),
         job_run_repo.clone(),
@@ -1975,7 +1975,7 @@ impl SubagentManager for LiveSubagentManager {
     }
 }
 
-fn build_model_provider(config: &AppConfig) -> Arc<dyn ModelProvider> {
+async fn build_model_provider(config: &AppConfig) -> Arc<dyn ModelProvider> {
     if !config.models.providers.is_empty() {
         match RoutedModelProvider::from_models_config(&config.models) {
             Ok(provider) => Arc::new(provider),
@@ -1985,8 +1985,19 @@ fn build_model_provider(config: &AppConfig) -> Arc<dyn ModelProvider> {
             }
         }
     } else {
-        info!("no model providers configured — using echo fallback");
-        Arc::new(EchoModelProvider)
+        // Zero-config Ollama auto-detection (issue #61): probe localhost:11434
+        // before falling back to the inert echo provider.
+        info!("no model providers configured — probing for local Ollama…");
+        match rune_models::OllamaProvider::probe_local().await {
+            Some(provider) => {
+                info!("local Ollama detected at http://localhost:11434 — using as default provider");
+                Arc::new(provider)
+            }
+            None => {
+                info!("no local Ollama found — using echo fallback (configure a provider in config.toml)");
+                Arc::new(EchoModelProvider)
+            }
+        }
     }
 }
 

--- a/crates/rune-models/src/provider/ollama.rs
+++ b/crates/rune-models/src/provider/ollama.rs
@@ -111,6 +111,46 @@ impl Default for OllamaProvider {
     }
 }
 
+impl OllamaProvider {
+    /// Probe `http://localhost:11434` (or a custom URL) for a running Ollama
+    /// instance.  Returns `Some(OllamaProvider)` if the server responds to
+    /// `GET /api/tags` within a short timeout, `None` otherwise.
+    ///
+    /// This is intentionally fire-and-forget: network errors, timeouts, and
+    /// non-200 responses all map to `None` so the caller can fall back
+    /// gracefully.
+    pub async fn probe_local() -> Option<Self> {
+        Self::probe_url(DEFAULT_OLLAMA_BASE).await
+    }
+
+    /// Like [`probe_local`] but against an arbitrary Ollama base URL.
+    pub async fn probe_url(base_url: &str) -> Option<Self> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .ok()?;
+
+        let url = format!("{}/api/tags", base_url.trim_end_matches('/'));
+        let resp = client.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+
+        // Parse just enough to confirm the response is valid Ollama JSON.
+        let _tags: OllamaTagsResponse = resp.json().await.ok()?;
+
+        let openai_url = format!("{}/v1", base_url.trim_end_matches('/'));
+        Some(Self {
+            inner: OpenAiProvider::new(&openai_url, "ollama"),
+            ollama_base: base_url.trim_end_matches('/').to_string(),
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(300))
+                .build()
+                .unwrap_or_default(),
+        })
+    }
+}
+
 /// Response from Ollama's `/api/tags` endpoint.
 #[derive(Debug, Deserialize)]
 pub struct OllamaTagsResponse {
@@ -169,5 +209,12 @@ mod tests {
     fn base_url_without_v1_suffix() {
         let p = OllamaProvider::with_base_url("http://myhost:11434");
         assert_eq!(p.ollama_base, "http://myhost:11434");
+    }
+
+    #[tokio::test]
+    async fn probe_unreachable_returns_none() {
+        // Port 19999 should not have an Ollama instance.
+        let result = OllamaProvider::probe_url("http://127.0.0.1:19999").await;
+        assert!(result.is_none(), "probe of unreachable host should return None");
     }
 }


### PR DESCRIPTION
## Summary
- When no model providers are configured, the gateway now probes `http://localhost:11434/api/tags` (2 s timeout) at startup.
- If a local Ollama instance responds, it becomes the default provider — completions route to real models with zero configuration.
- If Ollama is unreachable, the existing echo fallback is used (no regression).

Closes the biggest remaining zero-config gap from #61: `./rune` on a machine with Ollama installed now works end-to-end with no config file or env vars.

### Changes
| File | What |
|------|------|
| `crates/rune-models/src/provider/ollama.rs` | `probe_local()` / `probe_url()` — async health-check returning `Option<OllamaProvider>` |
| `apps/gateway/src/main.rs` | `build_model_provider()` → async; calls `probe_local()` before echo fallback; banner updated |

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p rune-models` — 29 unit + 23 integration pass (including new `probe_unreachable_returns_none`)
- [x] `cargo test -p rune-gateway-app` — 12 tests pass
- [ ] Manual: start `ollama serve`, then `./rune` with no config — verify log shows "local Ollama detected" and completions work
- [ ] Manual: stop Ollama, start `./rune` — verify log shows "no local Ollama found — using echo fallback"