### PR TITLE
feat(models): auto-select default Ollama model in zero-config mode (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -208,7 +208,8 @@ async fn build_services(
         SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
     );
 
-    let model_provider: Arc<dyn ModelProvider> = build_model_provider(&config).await;
+    let (model_provider, auto_default_model) = build_model_provider(&config).await;
+    let model_provider: Arc<dyn ModelProvider> = model_provider;
     let scheduler = Arc::new(Scheduler::new_with_repos(
         job_repo.clone(),
         job_run_repo.clone(),
@@ -308,13 +309,14 @@ async fn build_services(
         Arc::new(NoOpCompaction),
     );
 
-    // Resolve default model: agent config → models.default_model
+    // Resolve default model: agent config → models.default_model → auto-detected Ollama model
     let default_model = config
         .agents
         .default_agent()
         .and_then(|a| config.agents.effective_model(a))
         .map(String::from)
-        .or_else(|| config.models.default_model.clone());
+        .or_else(|| config.models.default_model.clone())
+        .or(auto_default_model);
 
     if let Some(ref model) = default_model {
         turn_executor = turn_executor.with_default_model(model);
@@ -1975,28 +1977,48 @@ impl SubagentManager for LiveSubagentManager {
     }
 }
 
-async fn build_model_provider(config: &AppConfig) -> Arc<dyn ModelProvider> {
+/// Build the model provider and, for zero-config Ollama, auto-select a
+/// default model from the locally pulled models.
+///
+/// Returns `(provider, Option<auto_detected_default_model>)`.  The second
+/// element is `Some` only when Ollama was auto-detected **and** at least one
+/// model is available — callers should use it as a fallback when no explicit
+/// `default_model` is configured.
+async fn build_model_provider(
+    config: &AppConfig,
+) -> (Arc<dyn ModelProvider>, Option<String>) {
     if !config.models.providers.is_empty() {
-        match RoutedModelProvider::from_models_config(&config.models) {
-            Ok(provider) => Arc::new(provider),
-            Err(error) => {
-                warn!(error = %error, "failed to build routed model provider, falling back to echo");
-                Arc::new(EchoModelProvider)
+        let provider: Arc<dyn ModelProvider> =
+            match RoutedModelProvider::from_models_config(&config.models) {
+                Ok(provider) => Arc::new(provider),
+                Err(error) => {
+                    warn!(error = %error, "failed to build routed model provider, falling back to echo");
+                    Arc::new(EchoModelProvider)
+                }
+            };
+        return (provider, None);
+    }
+
+    // Zero-config Ollama auto-detection (issue #61): honour OLLAMA_HOST
+    // for non-default endpoints, then fall back to localhost:11434.
+    info!("no model providers configured — probing for local Ollama…");
+    match rune_models::OllamaProvider::probe_env().await {
+        Some(provider) => {
+            info!(url = %provider.url(), "Ollama detected — using as default provider");
+
+            // Auto-select the best pulled model as the default (issue #61).
+            let auto_model = provider.pick_default_model().await;
+            if let Some(ref model) = auto_model {
+                info!(model = %model, "auto-selected default Ollama model");
+            } else {
+                warn!("Ollama is running but no models are pulled — run `ollama pull <model>` to get started");
             }
+
+            (Arc::new(provider), auto_model)
         }
-    } else {
-        // Zero-config Ollama auto-detection (issue #61): honour OLLAMA_HOST
-        // for non-default endpoints, then fall back to localhost:11434.
-        info!("no model providers configured — probing for local Ollama…");
-        match rune_models::OllamaProvider::probe_env().await {
-            Some(provider) => {
-                info!(url = %provider.url(), "Ollama detected — using as default provider");
-                Arc::new(provider)
-            }
-            None => {
-                info!("no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)");
-                Arc::new(EchoModelProvider)
-            }
+        None => {
+            info!("no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)");
+            (Arc::new(EchoModelProvider), None)
         }
     }
 }

--- a/crates/rune-models/src/provider/ollama.rs
+++ b/crates/rune-models/src/provider/ollama.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::ModelProvider;
 use super::openai::OpenAiProvider;
@@ -103,6 +103,87 @@ impl OllamaProvider {
 
         Ok(tags.models)
     }
+
+    /// Select the best available model as a zero-config default.
+    ///
+    /// Heuristic (applied in order):
+    /// 1. If no models are pulled, return `None`.
+    /// 2. If exactly one model exists, use it.
+    /// 3. Otherwise rank by a preference table of well-known families
+    ///    (preferring larger / more capable variants), breaking ties by
+    ///    model size descending.
+    ///
+    /// The returned name is suitable for use in the `model` field of an
+    /// OpenAI-compatible completion request to this Ollama instance.
+    pub async fn pick_default_model(&self) -> Option<String> {
+        let models = match self.list_models().await {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(error = %e, "failed to list Ollama models for auto-selection");
+                return None;
+            }
+        };
+
+        if models.is_empty() {
+            return None;
+        }
+        if models.len() == 1 {
+            return Some(models[0].name.clone());
+        }
+
+        Some(rank_preferred_model(&models).name.clone())
+    }
+}
+
+/// Well-known model family prefixes in descending preference order.
+///
+/// Within each family the table entry is just a prefix — e.g. `"llama3"`
+/// matches `llama3:latest`, `llama3.3:70b`, etc.  Earlier entries win.
+const MODEL_PREFERENCE: &[&str] = &[
+    // Meta Llama family — newest / largest first.
+    "llama3.3",
+    "llama3.2",
+    "llama3.1",
+    "llama3",
+    // Alibaba Qwen
+    "qwen2.5",
+    "qwen2",
+    // Mistral
+    "mixtral",
+    "mistral",
+    // Google Gemma
+    "gemma2",
+    "gemma",
+    // Microsoft Phi
+    "phi3",
+    "phi",
+    // DeepSeek
+    "deepseek-r1",
+    "deepseek-v2",
+    "deepseek",
+    // Generic catch-all for anything with "llama" in the name.
+    "llama",
+];
+
+/// Pick the best model from a non-empty slice using the preference table.
+///
+/// Falls back to the largest model by `size` if nothing matches the table.
+fn rank_preferred_model(models: &[OllamaModel]) -> &OllamaModel {
+    debug_assert!(!models.is_empty());
+
+    for prefix in MODEL_PREFERENCE {
+        // Find the largest model matching this prefix (size descending).
+        let best = models
+            .iter()
+            .filter(|m| m.name.starts_with(prefix))
+            .max_by_key(|m| m.size);
+        if let Some(model) = best {
+            return model;
+        }
+    }
+
+    // Nothing matched the preference table — return the largest model.
+    models.iter().max_by_key(|m| m.size).unwrap()
 }
 
 impl Default for OllamaProvider {
@@ -342,5 +423,76 @@ mod tests {
         let result = OllamaProvider::probe_env().await;
         assert!(result.is_none(), "unreachable OLLAMA_HOST should return None");
         unsafe { std::env::remove_var("OLLAMA_HOST"); }
+    }
+
+    // --- rank_preferred_model tests ---
+
+    fn make_model(name: &str, size: u64) -> OllamaModel {
+        OllamaModel {
+            name: name.to_string(),
+            model: name.to_string(),
+            size,
+            digest: String::new(),
+            modified_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn rank_prefers_llama3_family() {
+        let models = vec![
+            make_model("mistral:latest", 4_000_000_000),
+            make_model("llama3.1:8b", 8_000_000_000),
+            make_model("phi3:latest", 2_000_000_000),
+        ];
+        assert_eq!(rank_preferred_model(&models).name, "llama3.1:8b");
+    }
+
+    #[test]
+    fn rank_prefers_larger_within_same_family() {
+        let models = vec![
+            make_model("llama3.1:8b", 4_000_000_000),
+            make_model("llama3.1:70b", 40_000_000_000),
+            make_model("llama3.1:latest", 4_000_000_000),
+        ];
+        assert_eq!(rank_preferred_model(&models).name, "llama3.1:70b");
+    }
+
+    #[test]
+    fn rank_prefers_newer_llama_generation() {
+        let models = vec![
+            make_model("llama3:latest", 4_000_000_000),
+            make_model("llama3.3:latest", 4_000_000_000),
+        ];
+        assert_eq!(rank_preferred_model(&models).name, "llama3.3:latest");
+    }
+
+    #[test]
+    fn rank_falls_back_to_largest_when_no_known_family() {
+        let models = vec![
+            make_model("custom-model:v1", 2_000_000_000),
+            make_model("my-finetune:latest", 8_000_000_000),
+            make_model("tiny-model:latest", 500_000_000),
+        ];
+        assert_eq!(rank_preferred_model(&models).name, "my-finetune:latest");
+    }
+
+    #[test]
+    fn rank_with_qwen_and_gemma() {
+        let models = vec![
+            make_model("gemma2:latest", 5_000_000_000),
+            make_model("qwen2.5:14b", 14_000_000_000),
+        ];
+        // qwen2.5 is higher in the preference table than gemma2.
+        assert_eq!(rank_preferred_model(&models).name, "qwen2.5:14b");
+    }
+
+    #[test]
+    fn rank_deepseek_family() {
+        let models = vec![
+            make_model("deepseek-r1:latest", 7_000_000_000),
+            make_model("phi:latest", 2_000_000_000),
+        ];
+        // phi is higher in preference table than deepseek.
+        assert_eq!(rank_preferred_model(&models).name, "phi:latest");
     }
 }


### PR DESCRIPTION
## Summary
- When Ollama is auto-detected with no config, automatically pick the best pulled model as the default — removing the last manual step for zero-config startup.
- Adds `pick_default_model()` to `OllamaProvider` with a preference heuristic: llama3 family → qwen → mistral → gemma → phi → deepseek, tie-broken by model size. Falls back to the largest model if no known family matches.
- Wires auto-detected model into the existing default-model resolution chain as the lowest-priority fallback (agent config → `models.default_model` → auto-detected).
- If Ollama is running but has no models pulled, logs a warning guiding the user to `ollama pull <model>`.

## What zero-config gap this closes
Previously (after PRs #135–#137): `rune` auto-detects Ollama and auto-creates dirs, but requests fail without a manually configured `default_model`. After this PR: a fresh `rune` + local Ollama with at least one pulled model works end-to-end with zero configuration.

## Test plan
- [x] 6 new unit tests for `rank_preferred_model` covering: family preference, size tiebreaker, generation preference, unknown-model fallback, qwen-vs-gemma ordering, and phi-vs-deepseek ordering
- [x] All 20 Ollama tests pass (`cargo test --package rune-models -- ollama`)
- [x] `cargo check` passes for `rune-models`, `rune-gateway`, `rune` binary
- [ ] Manual: start `rune` with local Ollama running + one pulled model, confirm auto-selected model appears in logs and chat requests succeed without config

Closes zero-config model selection gap from #61.