### PR TITLE
feat(models): surface guidance when Ollama has no models pulled (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -2011,7 +2011,11 @@ async fn build_model_provider(
             if let Some(ref model) = auto_model {
                 info!(model = %model, "auto-selected default Ollama model");
             } else {
-                warn!("Ollama is running but no models are pulled — run `ollama pull <model>` to get started");
+                // Surface prominent, actionable guidance so zero-config
+                // users know exactly what to do next (issue #61).
+                let guidance = provider.empty_model_guidance();
+                warn!("Ollama is running but has no models pulled");
+                eprintln!("{guidance}");
             }
 
             (Arc::new(provider), auto_model)

--- a/crates/rune-models/src/provider/ollama.rs
+++ b/crates/rune-models/src/provider/ollama.rs
@@ -104,6 +104,32 @@ impl OllamaProvider {
         Ok(tags.models)
     }
 
+    /// Generate actionable guidance when no models are pulled.
+    ///
+    /// Returns a multi-line string with suggested `ollama pull` commands
+    /// for well-known models, sized for common hardware tiers.  Intended
+    /// for display at startup so zero-config users know exactly what to
+    /// do next.
+    pub fn empty_model_guidance(&self) -> String {
+        let base = &self.ollama_base;
+        format!(
+            "\n\
+            ╭─────────────────────────────────────────────────────────────╮\n\
+            │  Ollama is running at {base:<37} │\n\
+            │  but no models are pulled yet.                             │\n\
+            │                                                            │\n\
+            │  Quick start — pull a model:                               │\n\
+            │                                                            │\n\
+            │    ollama pull llama3.2        (2 GB, good for most tasks)  │\n\
+            │    ollama pull llama3.1:8b     (4.7 GB, stronger reasoning) │\n\
+            │    ollama pull qwen2.5:7b     (4.4 GB, multilingual)       │\n\
+            │                                                            │\n\
+            │  After pulling, restart Rune — it will auto-detect the     │\n\
+            │  model and configure itself.                               │\n\
+            ╰─────────────────────────────────────────────────────────────╯"
+        )
+    }
+
     /// Select the best available model as a zero-config default.
     ///
     /// Heuristic (applied in order):
@@ -494,5 +520,33 @@ mod tests {
         ];
         // phi is higher in preference table than deepseek.
         assert_eq!(rank_preferred_model(&models).name, "phi:latest");
+    }
+
+    // --- empty_model_guidance tests ---
+
+    #[test]
+    fn guidance_contains_pull_commands() {
+        let provider = OllamaProvider::new();
+        let guidance = provider.empty_model_guidance();
+        assert!(guidance.contains("ollama pull llama3.2"), "should suggest llama3.2");
+        assert!(guidance.contains("ollama pull llama3.1:8b"), "should suggest llama3.1:8b");
+        assert!(guidance.contains("ollama pull qwen2.5:7b"), "should suggest qwen2.5:7b");
+    }
+
+    #[test]
+    fn guidance_mentions_restart() {
+        let provider = OllamaProvider::new();
+        let guidance = provider.empty_model_guidance();
+        assert!(guidance.contains("restart Rune"), "should mention restarting Rune");
+    }
+
+    #[test]
+    fn guidance_shows_custom_endpoint() {
+        let provider = OllamaProvider::with_base_url("http://192.168.1.50:11434/v1");
+        let guidance = provider.empty_model_guidance();
+        assert!(
+            guidance.contains("192.168.1.50:11434"),
+            "should show the actual Ollama endpoint in guidance"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- When Ollama is auto-detected but has zero models pulled, Rune now displays a prominent boxed guide on stderr with specific `ollama pull` commands, model sizes, and a restart hint.
- Adds `OllamaProvider::empty_model_guidance()` that renders an endpoint-aware guidance box.
- Replaces the previous terse `warn!` log with a visible, actionable message so zero-config users know exactly what to do next.

Closes the "no guidance when Ollama has zero models pulled" gap identified in PR #138.

Part of #61.

## Test plan
- [x] 3 new unit tests: `guidance_contains_pull_commands`, `guidance_mentions_restart`, `guidance_shows_custom_endpoint`
- [x] All 24 Ollama tests pass (`cargo test -p rune-models -- ollama`)
- [x] `cargo check` clean for all targets