### PR TITLE
feat(config): add --yolo and --no-sandbox CLI startup flags (#64)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -68,13 +68,17 @@ const DEFAULT_MEMORY_INDEX_POLL_INTERVAL_SECS: u64 = 5;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config_path = discover_config_path();
-    let mut config = AppConfig::load(config_path.as_deref()).with_context(|| {
+    let flags = parse_startup_flags();
+    let config_path = flags.config_path.as_deref();
+    let mut config = AppConfig::load(config_path).with_context(|| {
         format!(
             "failed to load config from {}",
-            display_config_path(config_path.as_deref())
+            display_config_path(config_path)
         )
     })?;
+
+    // Apply CLI bypass flags (issue #64) on top of file/env config.
+    config.apply_cli_overrides(flags.yolo, flags.no_sandbox);
 
     // Resolve runtime mode and swap Docker-default paths to ~/.rune/* when
     // running standalone on a bare host (zero-config quick-start, issue #61).
@@ -82,7 +86,7 @@ async fn main() -> Result<()> {
     config.adjust_paths_for_mode(&resolved_mode);
 
     init_logging(&config.logging);
-    emit_startup_banner(&config, config_path.as_deref());
+    emit_startup_banner(&config, config_path);
 
     // Auto-create missing directories in Standalone mode so that `rune` boots
     // without manual `mkdir` (zero-config, issue #61).
@@ -131,19 +135,49 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn discover_config_path() -> Option<PathBuf> {
-    std::env::args_os()
-        .skip(1)
-        .collect::<Vec<_>>()
-        .windows(2)
-        .find_map(|window| {
-            if window[0] == "--config" {
-                Some(PathBuf::from(&window[1]))
-            } else {
-                None
+/// Lightweight startup flags parsed from argv.
+///
+/// The gateway binary intentionally avoids pulling in clap to keep binary size
+/// small.  We parse the handful of supported flags manually.
+struct StartupFlags {
+    config_path: Option<PathBuf>,
+    yolo: bool,
+    no_sandbox: bool,
+}
+
+fn parse_startup_flags() -> StartupFlags {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut config_path: Option<PathBuf> = None;
+    let mut yolo = false;
+    let mut no_sandbox = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--config" => {
+                if i + 1 < args.len() {
+                    config_path = Some(PathBuf::from(&args[i + 1]));
+                    i += 2;
+                    continue;
+                }
             }
-        })
-        .or_else(|| std::env::var_os("RUNE_CONFIG").map(PathBuf::from))
+            "--yolo" => yolo = true,
+            "--no-sandbox" => no_sandbox = true,
+            _ => {}
+        }
+        i += 1;
+    }
+
+    // Fall back to RUNE_CONFIG env var when --config is not passed.
+    if config_path.is_none() {
+        config_path = std::env::var_os("RUNE_CONFIG").map(PathBuf::from);
+    }
+
+    StartupFlags {
+        config_path,
+        yolo,
+        no_sandbox,
+    }
 }
 
 fn display_config_path(path: Option<&Path>) -> String {
@@ -177,6 +211,8 @@ fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
         config_path = %display_config_path(config_path),
         store_backend,
         model_backend = if config.models.providers.is_empty() { "auto-detect (probing Ollama…)" } else { "configured" },
+        approval_mode = config.approval.mode.as_str(),
+        security_posture = config.security.posture(),
         "starting rune gateway"
     );
 }

--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -35,6 +35,20 @@ pub struct Cli {
     )]
     pub gateway_url: String,
 
+    /// Auto-approve all tool calls (sets approval.mode=yolo for this invocation).
+    ///
+    /// Intended for trusted local dev environments where interactive approval
+    /// prompts are unwanted.  Equivalent to `RUNE_APPROVAL__MODE=yolo`.
+    #[arg(long, global = true)]
+    pub yolo: bool,
+
+    /// Disable filesystem sandbox / workspace boundary enforcement.
+    ///
+    /// Intended for trusted environments where the agent needs unrestricted
+    /// filesystem access.  Equivalent to `RUNE_SECURITY__SANDBOX=false`.
+    #[arg(long, global = true)]
+    pub no_sandbox: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -1592,5 +1606,42 @@ mod tests {
     #[test]
     fn missing_subcommand_is_error() {
         assert!(Cli::try_parse_from(["rune"]).is_err());
+    }
+
+    // ── Trusted-environment bypass flags (#64) ───────────────────────
+
+    #[test]
+    fn parse_yolo_flag() {
+        let cli = Cli::try_parse_from(["rune", "--yolo", "status"]).unwrap();
+        assert!(cli.yolo);
+        assert!(!cli.no_sandbox);
+    }
+
+    #[test]
+    fn parse_no_sandbox_flag() {
+        let cli = Cli::try_parse_from(["rune", "--no-sandbox", "doctor"]).unwrap();
+        assert!(cli.no_sandbox);
+        assert!(!cli.yolo);
+    }
+
+    #[test]
+    fn parse_yolo_and_no_sandbox_combined() {
+        let cli = Cli::try_parse_from(["rune", "--yolo", "--no-sandbox", "status"]).unwrap();
+        assert!(cli.yolo);
+        assert!(cli.no_sandbox);
+    }
+
+    #[test]
+    fn bypass_flags_default_to_false() {
+        let cli = Cli::try_parse_from(["rune", "status"]).unwrap();
+        assert!(!cli.yolo);
+        assert!(!cli.no_sandbox);
+    }
+
+    #[test]
+    fn yolo_flag_works_after_subcommand() {
+        // clap global flags can appear before or after the subcommand.
+        let cli = Cli::try_parse_from(["rune", "gateway", "status", "--yolo"]).unwrap();
+        assert!(cli.yolo);
     }
 }

--- a/crates/rune-cli/src/doctor.rs
+++ b/crates/rune-cli/src/doctor.rs
@@ -1410,4 +1410,37 @@ mod tests {
             "expected unrestricted warning for yolo + no-sandbox"
         );
     }
+
+    /// Simulate what happens when --yolo --no-sandbox CLI flags are applied
+    /// via `apply_cli_overrides` before doctor runs.
+    #[test]
+    fn cli_bypass_flags_flow_through_to_doctor() {
+        let mut config = AppConfig::default();
+        // Default should pass
+        let before = check_approval_security(&config);
+        assert!(before.iter().all(|r| r.status == CheckStatus::Pass));
+
+        // Apply CLI overrides (simulating --yolo --no-sandbox)
+        config.apply_cli_overrides(true, true);
+
+        let after = check_approval_security(&config);
+        assert!(
+            after
+                .iter()
+                .any(|r| r.name == "approval.mode" && r.status == CheckStatus::Warn),
+            "yolo via CLI flag should warn in doctor"
+        );
+        assert!(
+            after
+                .iter()
+                .any(|r| r.name == "security.posture" && r.status == CheckStatus::Warn),
+            "no-sandbox via CLI flag should warn in doctor"
+        );
+        assert!(
+            after
+                .iter()
+                .any(|r| r.name == "security.unrestricted" && r.status == CheckStatus::Warn),
+            "combined CLI flags should trigger unrestricted warning"
+        );
+    }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -92,13 +92,33 @@ fn apply_global_cli_environment(cli: &Cli) {
         }
         clap::builder::styling::Styles::plain();
     }
+
+    // Trusted-environment bypass flags (issue #64): set env vars so that
+    // subsequent config loads (e.g. `rune doctor`) resolve the override
+    // without requiring a TOML edit.
+    if cli.yolo {
+        unsafe {
+            std::env::set_var("RUNE_APPROVAL__MODE", "yolo");
+        }
+    }
+    if cli.no_sandbox {
+        unsafe {
+            std::env::set_var("RUNE_SECURITY__SANDBOX", "false");
+        }
+    }
 }
 
-fn run_gateway_foreground() -> Result<()> {
+fn run_gateway_foreground(yolo: bool, no_sandbox: bool) -> Result<()> {
     let mut args = Vec::new();
     if let Some(config_path) = std::env::var_os("RUNE_CONFIG") {
         args.push("--config".to_string());
         args.push(config_path.to_string_lossy().into_owned());
+    }
+    if yolo {
+        args.push("--yolo".to_string());
+    }
+    if no_sandbox {
+        args.push("--no-sandbox".to_string());
     }
 
     let status = StdCommand::new("rune-gateway")
@@ -762,6 +782,10 @@ pub async fn run(cli: Cli) -> Result<()> {
     let format = OutputFormat::from_json_flag(cli.json);
     let client = GatewayClient::new(&cli.gateway_url);
 
+    // Capture bypass flags before the match moves fields out of `cli`.
+    let bypass_yolo = cli.yolo;
+    let bypass_no_sandbox = cli.no_sandbox;
+
     match cli.command {
         Command::Gateway { action } | Command::Daemon { action } => match action {
             GatewayAction::Status => {
@@ -808,7 +832,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 println!("{}", render(&result, format));
             }
             GatewayAction::Run => {
-                run_gateway_foreground()?;
+                run_gateway_foreground(bypass_yolo, bypass_no_sandbox)?;
             }
         },
         Command::Status => {

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -161,6 +161,21 @@ impl AppConfig {
         }
     }
 
+    /// Apply CLI startup-flag overrides on top of the resolved config.
+    ///
+    /// Used by `--yolo` and `--no-sandbox` CLI flags to override the persisted
+    /// config without editing files or setting environment variables.
+    /// This is the *only* entry point for CLI→config bypass wiring; runtime
+    /// execution semantics are not altered here (see issue #64 follow-ups).
+    pub fn apply_cli_overrides(&mut self, yolo: bool, no_sandbox: bool) {
+        if yolo {
+            self.approval.mode = ApprovalMode::Yolo;
+        }
+        if no_sandbox {
+            self.security.sandbox = false;
+        }
+    }
+
     /// When mode resolves to Standalone and paths are still at Docker defaults,
     /// swap to `~/.rune/*`.
     pub fn adjust_paths_for_mode(&mut self, resolved_mode: &RuntimeMode) {
@@ -2363,5 +2378,63 @@ mode = "auto-exec"
             Capabilities::detect(&config, RuntimeMode::Standalone, "sqlite", false, false, 0);
         assert_eq!(caps.approval_mode, "yolo");
         assert_eq!(caps.security_posture, "unrestricted");
+    }
+
+    // ── CLI override tests (#64) ─────────────────────────────────────
+
+    #[test]
+    fn apply_cli_overrides_yolo() {
+        let mut config = AppConfig::default();
+        assert_eq!(config.approval.mode, ApprovalMode::Prompt);
+
+        config.apply_cli_overrides(true, false);
+        assert_eq!(config.approval.mode, ApprovalMode::Yolo);
+        // security unchanged
+        assert!(config.security.sandbox);
+    }
+
+    #[test]
+    fn apply_cli_overrides_no_sandbox() {
+        let mut config = AppConfig::default();
+        assert!(config.security.sandbox);
+
+        config.apply_cli_overrides(false, true);
+        assert!(!config.security.sandbox);
+        // approval unchanged
+        assert_eq!(config.approval.mode, ApprovalMode::Prompt);
+    }
+
+    #[test]
+    fn apply_cli_overrides_both() {
+        let mut config = AppConfig::default();
+        config.apply_cli_overrides(true, true);
+        assert_eq!(config.approval.mode, ApprovalMode::Yolo);
+        assert!(!config.security.sandbox);
+        assert_eq!(config.security.posture(), "no-sandbox");
+    }
+
+    #[test]
+    fn apply_cli_overrides_noop_when_both_false() {
+        let original = AppConfig::default();
+        let mut config = original.clone();
+        config.apply_cli_overrides(false, false);
+        assert_eq!(config.approval, original.approval);
+        assert_eq!(config.security, original.security);
+    }
+
+    #[test]
+    fn apply_cli_overrides_on_top_of_file_config() {
+        // Simulate file config that already sets auto-file mode.
+        let mut config = AppConfig::default();
+        config.approval.mode = ApprovalMode::AutoFile;
+        config.security.trust_spells = true;
+
+        // --yolo should override auto-file → yolo
+        config.apply_cli_overrides(true, true);
+        assert_eq!(config.approval.mode, ApprovalMode::Yolo);
+        assert!(!config.security.sandbox);
+        // trust_spells is untouched by CLI flags
+        assert!(config.security.trust_spells);
+        assert_eq!(config.security.posture(), "unrestricted");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `--yolo` and `--no-sandbox` global CLI flags to the `rune` CLI and `rune-gateway` binary, wiring them into the existing approval/security config plumbing.
- Operators in trusted local dev environments can now bypass approval prompts and sandbox enforcement at startup without editing TOML or setting env vars: `rune --yolo --no-sandbox gateway run`.
- This is the **flag→config wiring slice** of #64; runtime bypass execution semantics are deferred to a follow-up.

### Changes

| File | What |
|------|------|
| `crates/rune-config/src/lib.rs` | `AppConfig::apply_cli_overrides(yolo, no_sandbox)` method + 5 tests |
| `crates/rune-cli/src/cli.rs` | `--yolo` and `--no-sandbox` global clap flags + 5 CLI parsing tests |
| `crates/rune-cli/src/lib.rs` | Thread flags via env vars for `doctor`; pass to `rune-gateway` subprocess |
| `crates/rune-cli/src/doctor.rs` | 1 integration test: CLI flags flow through to doctor warnings |
| `apps/gateway/src/main.rs` | `parse_startup_flags()` replaces `discover_config_path()`; apply overrides before service init; log approval_mode/security_posture in startup banner |

### What this does NOT do (follow-ups)

- Does not implement runtime approval-bypass execution semantics (the tool executor still ignores these flags at call time)
- Does not add `--trust-spells` flag (kept narrow)
- Does not persist CLI overrides back to config file

## Test plan

- [x] `cargo test -p rune-config` — 58 pass (5 new)
- [x] `cargo test -p rune-cli` — 177 pass (6 new)
- [x] `cargo clippy -p rune-config -p rune-cli -p rune-gateway-app -- -D warnings` — clean
- [x] `cargo check -p rune-gateway-app` — compiles