### PR TITLE
feat(config): warn on unrestricted startup posture (#64)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -215,6 +215,19 @@ fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
         security_posture = config.security.posture(),
         "starting rune gateway"
     );
+
+    let unrestricted = config.approval.mode.is_yolo() || !config.security.sandbox;
+    if unrestricted {
+        let warning = if config.approval.mode.is_yolo() && !config.security.sandbox {
+            "WARNING: Rune is starting in unrestricted mode (--yolo + --no-sandbox). All approvals are auto-bypassed and sandbox boundaries are disabled. Use only in trusted environments."
+        } else if config.approval.mode.is_yolo() {
+            "WARNING: Rune is starting with approval bypass enabled (--yolo). Use only in trusted environments."
+        } else {
+            "WARNING: Rune is starting with sandbox disabled (--no-sandbox). Workspace boundary enforcement is off. Use only in trusted environments."
+        };
+        eprintln!("{warning}");
+        warn!(warning = warning, "trusted-environment bypass active");
+    }
 }
 
 /// Build all services, returning an optional `EmbeddedPg` handle that


### PR DESCRIPTION
## Summary
- add a startup warning surface for `--yolo`, `--no-sandbox`, and combined unrestricted posture
- emit the trusted-environment warning to both stderr and structured logs
- keep scope limited to operator-visible startup warning behavior, not runtime auto-approval semantics

## Testing
- cargo test -p rune-config --quiet
- cargo test -p rune-cli --quiet

Refs #64