### PR TITLE
feat(cli): first-class system event inject/schedule/list surface (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -367,8 +367,22 @@ pub enum MemoryAction {
 
 #[derive(Debug, Subcommand)]
 pub enum SystemAction {
-    /// Queue a system event/wake for the runtime.
+    /// Inject, schedule, and list system events.
     Event {
+        #[command(subcommand)]
+        action: SystemEventAction,
+    },
+    /// Show whether HEARTBEAT.md exists and when it last changed.
+    Heartbeat {
+        #[command(subcommand)]
+        action: SystemHeartbeatAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SystemEventAction {
+    /// Inject an immediate system event/wake into the runtime.
+    Inject {
         /// Text to inject.
         #[arg(long)]
         text: String,
@@ -379,10 +393,32 @@ pub enum SystemAction {
         #[arg(long = "context-messages")]
         context_messages: Option<u64>,
     },
-    /// Show whether HEARTBEAT.md exists and when it last changed.
-    Heartbeat {
-        #[command(subcommand)]
-        action: SystemHeartbeatAction,
+    /// Schedule a future system event as a cron job.
+    Schedule {
+        /// Text for the system event payload.
+        #[arg(long)]
+        text: String,
+        /// Fire time as RFC3339/ISO-8601.
+        #[arg(long)]
+        at: String,
+        /// Human-readable name for the job.
+        #[arg(long)]
+        name: Option<String>,
+        /// Session target (`main` or `isolated`). Defaults to `main`.
+        #[arg(long, default_value = "main")]
+        session_target: String,
+        /// Delivery mode for the scheduled work (`none`, `announce`, or `webhook`).
+        #[arg(long, value_enum, default_value_t = CronDeliveryMode::None)]
+        delivery_mode: CronDeliveryMode,
+        /// Webhook URL for `webhook` delivery mode.
+        #[arg(long)]
+        webhook_url: Option<String>,
+    },
+    /// List system-event cron jobs.
+    List {
+        /// Include disabled jobs in the listing.
+        #[arg(long)]
+        include_disabled: bool,
     },
 }
 
@@ -951,11 +987,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_system_event() {
+    fn parse_system_event_inject() {
         let cli = Cli::try_parse_from([
             "rune",
             "system",
             "event",
+            "inject",
             "--text",
             "Reminder: check Rune",
             "--mode",
@@ -968,14 +1005,166 @@ mod tests {
             Command::System {
                 action:
                     SystemAction::Event {
-                        text,
-                        mode,
-                        context_messages,
+                        action:
+                            SystemEventAction::Inject {
+                                text,
+                                mode,
+                                context_messages,
+                            },
                     },
             } => {
                 assert_eq!(text, "Reminder: check Rune");
                 assert_eq!(mode, WakeMode::Now);
                 assert_eq!(context_messages, Some(2));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_system_event_inject_defaults() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "system",
+            "event",
+            "inject",
+            "--text",
+            "ping",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::System {
+                action:
+                    SystemAction::Event {
+                        action:
+                            SystemEventAction::Inject {
+                                text,
+                                mode,
+                                context_messages,
+                            },
+                    },
+            } => {
+                assert_eq!(text, "ping");
+                assert_eq!(mode, WakeMode::NextHeartbeat);
+                assert_eq!(context_messages, None);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_system_event_schedule() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "system",
+            "event",
+            "schedule",
+            "--text",
+            "deploy check",
+            "--at",
+            "2026-04-01T09:00:00Z",
+            "--name",
+            "morning-check",
+            "--session-target",
+            "isolated",
+            "--delivery-mode",
+            "announce",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::System {
+                action:
+                    SystemAction::Event {
+                        action:
+                            SystemEventAction::Schedule {
+                                text,
+                                at,
+                                name,
+                                session_target,
+                                delivery_mode,
+                                webhook_url,
+                            },
+                    },
+            } => {
+                assert_eq!(text, "deploy check");
+                assert_eq!(at, "2026-04-01T09:00:00Z");
+                assert_eq!(name.as_deref(), Some("morning-check"));
+                assert_eq!(session_target, "isolated");
+                assert_eq!(delivery_mode, CronDeliveryMode::Announce);
+                assert!(webhook_url.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_system_event_schedule_defaults() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "system",
+            "event",
+            "schedule",
+            "--text",
+            "hello",
+            "--at",
+            "2026-04-01T09:00:00Z",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::System {
+                action:
+                    SystemAction::Event {
+                        action:
+                            SystemEventAction::Schedule {
+                                session_target,
+                                delivery_mode,
+                                name,
+                                ..
+                            },
+                    },
+            } => {
+                assert_eq!(session_target, "main");
+                assert_eq!(delivery_mode, CronDeliveryMode::None);
+                assert!(name.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_system_event_list() {
+        let cli = Cli::try_parse_from(["rune", "system", "event", "list"]).unwrap();
+        match cli.command {
+            Command::System {
+                action:
+                    SystemAction::Event {
+                        action: SystemEventAction::List { include_disabled },
+                    },
+            } => {
+                assert!(!include_disabled);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_system_event_list_include_disabled() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "system",
+            "event",
+            "list",
+            "--include-disabled",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::System {
+                action:
+                    SystemAction::Event {
+                        action: SystemEventAction::List { include_disabled },
+                    },
+            } => {
+                assert!(include_disabled);
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -12,7 +12,7 @@ use crate::output::{
     ActionResult, ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
-    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
+    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport, SystemEventListResponse,
     GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
     HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
     ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
@@ -739,6 +739,20 @@ impl GatewayClient {
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
+    }
+
+    /// List cron jobs filtered to only those with `system_event` payloads.
+    pub async fn system_event_list(
+        &self,
+        include_disabled: bool,
+    ) -> Result<SystemEventListResponse> {
+        let all = self.cron_list(include_disabled).await?;
+        let events = all
+            .jobs
+            .into_iter()
+            .filter(|job| job.payload.kind() == "system_event")
+            .collect();
+        Ok(SystemEventListResponse { events })
     }
 
     /// `GET /reminders`
@@ -1803,5 +1817,65 @@ mod tests {
             resp.reminders[1].outcome_at.as_deref(),
             Some("2026-04-01T07:01:00Z")
         );
+    }
+
+    #[tokio::test]
+    async fn system_event_list_filters_by_payload_kind() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/cron"))
+            .and(query_param("include_disabled", "false"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "id": "job-1",
+                    "name": "sys-ping",
+                    "schedule": { "kind": "at", "at": "2026-04-01T09:00:00Z" },
+                    "payload": { "kind": "system_event", "text": "ping" },
+                    "delivery_mode": "none",
+                    "enabled": true,
+                    "session_target": "main",
+                    "created_at": "2026-03-19T10:00:00Z",
+                    "last_run_at": null,
+                    "next_run_at": "2026-04-01T09:00:00Z",
+                    "run_count": 0
+                },
+                {
+                    "id": "job-2",
+                    "name": "agent-task",
+                    "schedule": { "kind": "cron", "expr": "0 * * * *" },
+                    "payload": { "kind": "agent_turn", "message": "do stuff" },
+                    "delivery_mode": "announce",
+                    "enabled": true,
+                    "session_target": "isolated",
+                    "created_at": "2026-03-19T10:00:00Z",
+                    "last_run_at": null,
+                    "next_run_at": "2026-04-01T10:00:00Z",
+                    "run_count": 0
+                },
+                {
+                    "id": "job-3",
+                    "name": "sys-check",
+                    "schedule": { "kind": "every", "every_ms": 60000 },
+                    "payload": { "kind": "system_event", "text": "health check" },
+                    "delivery_mode": "webhook",
+                    "webhook_url": "https://example.com/hook",
+                    "enabled": true,
+                    "session_target": "main",
+                    "created_at": "2026-03-19T10:00:00Z",
+                    "last_run_at": null,
+                    "next_run_at": "2026-03-19T10:01:00Z",
+                    "run_count": 0
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.system_event_list(false).await.unwrap();
+        assert_eq!(resp.events.len(), 2);
+        assert_eq!(resp.events[0].id, "job-1");
+        assert_eq!(resp.events[0].payload.kind(), "system_event");
+        assert_eq!(resp.events[1].id, "job-3");
+        assert_eq!(resp.events[1].payload.kind(), "system_event");
     }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -25,7 +25,7 @@ pub use cli::Cli;
 use cli::{
     ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell, ConfigAction,
     CronAction, CronDeliveryMode, GatewayAction, MemoryAction, ModelsAction, RemindersAction,
-    SessionsAction, SystemAction, SystemHeartbeatAction,
+    SessionsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -1138,16 +1138,45 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
         },
         Command::System { action } => match action {
-            SystemAction::Event {
-                text,
-                mode,
-                context_messages,
-            } => {
-                let result = client
-                    .cron_wake(&text, mode.as_str(), context_messages)
-                    .await?;
-                println!("{}", render(&result, format));
-            }
+            SystemAction::Event { action } => match action {
+                SystemEventAction::Inject {
+                    text,
+                    mode,
+                    context_messages,
+                } => {
+                    let result = client
+                        .cron_wake(&text, mode.as_str(), context_messages)
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+                SystemEventAction::Schedule {
+                    text,
+                    at,
+                    name,
+                    session_target,
+                    delivery_mode,
+                    webhook_url,
+                } => {
+                    let at = DateTime::parse_from_rfc3339(&at)
+                        .with_context(|| format!("invalid --at timestamp: {at}"))?
+                        .with_timezone(&Utc);
+                    let result = client
+                        .cron_add_system_event(
+                            name.as_deref(),
+                            &text,
+                            at,
+                            &session_target,
+                            delivery_mode.as_str(),
+                            webhook_url.as_deref(),
+                        )
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+                SystemEventAction::List { include_disabled } => {
+                    let result = client.system_event_list(include_disabled).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
             SystemAction::Heartbeat { action } => match action {
                 SystemHeartbeatAction::Presence | SystemHeartbeatAction::Last => {
                     let result = heartbeat_presence();

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1649,6 +1649,24 @@ impl fmt::Display for CronListResponse {
     }
 }
 
+/// System event list response (filtered cron jobs with `system_event` payload).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemEventListResponse {
+    pub events: Vec<CronJobSummary>,
+}
+
+impl fmt::Display for SystemEventListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.events.is_empty() {
+            return write!(f, "No system event jobs.");
+        }
+        for job in &self.events {
+            writeln!(f, "  {job}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Cron run history item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CronRunSummary {


### PR DESCRIPTION
## Summary
- Expands `rune system event` from a thin wake alias into a first-class subcommand group: `inject`, `schedule`, and `list`
- `system event inject` — immediate wake (replaces the old flat `system event` command)
- `system event schedule` — schedule a future system event as a cron job with full delivery-mode/session-target support
- `system event list` — list cron jobs filtered to `system_event` payloads only
- Closes a parity gap in PARITY-CONTRACTS.md §6 where system event scheduling and inspection required using `rune cron add/list` instead of the dedicated `system event` surface

Refs #74

## Changes
- `cli.rs`: `SystemAction::Event` becomes a subcommand group with new `SystemEventAction` enum (`Inject`, `Schedule`, `List`)
- `client.rs`: new `system_event_list()` method that filters cron list by payload kind
- `lib.rs`: updated handler to dispatch new subcommands
- `output.rs`: new `SystemEventListResponse` type with human + JSON rendering

## Test plan
- [x] 7 new CLI parse tests covering inject, inject defaults, schedule, schedule defaults, list, list with --include-disabled
- [x] 1 new client integration test (wiremock) validating system_event_list filters agent_turn jobs out
- [x] All 191 tests pass (`cargo test -p rune-cli`)
- [x] `cargo check` clean