### PR TITLE
feat(cli): add `rune message send` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -113,6 +113,11 @@ pub enum Command {
         #[command(subcommand)]
         action: RemindersAction,
     },
+    /// Send and manage messages across channel adapters.
+    Message {
+        #[command(subcommand)]
+        action: MessageAction,
+    },
     /// Generate shell completion scripts.
     Completion {
         #[command(subcommand)]
@@ -459,6 +464,25 @@ pub enum RemindersAction {
     Cancel {
         /// Reminder ID to cancel.
         id: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MessageAction {
+    /// Send a message through a channel adapter.
+    Send {
+        /// Target channel adapter (e.g. "telegram", "discord", "slack").
+        #[arg(long)]
+        channel: String,
+        /// Message body text.
+        #[arg(long)]
+        text: String,
+        /// Optional session ID to associate the message with.
+        #[arg(long)]
+        session: Option<String>,
+        /// Optional thread/reply-to ID for threaded messaging.
+        #[arg(long)]
+        thread: Option<String>,
     },
 }
 
@@ -1877,5 +1901,87 @@ mod tests {
         // clap global flags can appear before or after the subcommand.
         let cli = Cli::try_parse_from(["rune", "gateway", "status", "--yolo"]).unwrap();
         assert!(cli.yolo);
+    }
+
+    // ── Message family (#74) ─────────────────────────────────────────
+
+    #[test]
+    fn parse_message_send() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "send",
+            "--channel",
+            "telegram",
+            "--text",
+            "Hello from Rune",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Send {
+                        channel,
+                        text,
+                        session,
+                        thread,
+                    },
+            } => {
+                assert_eq!(channel, "telegram");
+                assert_eq!(text, "Hello from Rune");
+                assert!(session.is_none());
+                assert!(thread.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_send_with_session_and_thread() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "send",
+            "--channel",
+            "discord",
+            "--text",
+            "threaded reply",
+            "--session",
+            "sess-42",
+            "--thread",
+            "thread-99",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Send {
+                        channel,
+                        text,
+                        session,
+                        thread,
+                    },
+            } => {
+                assert_eq!(channel, "discord");
+                assert_eq!(text, "threaded reply");
+                assert_eq!(session.as_deref(), Some("sess-42"));
+                assert_eq!(thread.as_deref(), Some("thread-99"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_send_requires_channel_and_text() {
+        // Missing --text
+        assert!(
+            Cli::try_parse_from(["rune", "message", "send", "--channel", "telegram"]).is_err()
+        );
+        // Missing --channel
+        assert!(
+            Cli::try_parse_from(["rune", "message", "send", "--text", "hello"]).is_err()
+        );
+        // Missing both
+        assert!(Cli::try_parse_from(["rune", "message", "send"]).is_err());
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -15,7 +15,7 @@ use crate::output::{
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport, SystemEventListResponse,
     GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
     HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
-    ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
+    MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
     SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
 };
 
@@ -841,6 +841,57 @@ impl GatewayClient {
                 format!("Gateway returned HTTP {}", resp.status())
             },
         })
+    }
+
+    /// `POST /messages/send`
+    pub async fn message_send(
+        &self,
+        channel: &str,
+        text: &str,
+        session: Option<&str>,
+        thread: Option<&str>,
+    ) -> Result<MessageSendResponse> {
+        let mut body = json!({
+            "channel": channel,
+            "text": text,
+        });
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        if let Some(t) = thread {
+            body["thread"] = json!(t);
+        }
+        let resp = self
+            .http
+            .post(self.url("/messages/send"))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/send")?;
+            Ok(MessageSendResponse {
+                success: true,
+                channel: channel.to_string(),
+                message_id: v["id"].as_str().map(String::from),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or("Message sent")
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageSendResponse {
+                success: false,
+                channel: channel.to_string(),
+                message_id: None,
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
     }
 
     /// `GET /sessions`

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -24,8 +24,8 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 pub use cli::Cli;
 use cli::{
     ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell, ConfigAction,
-    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, ModelsAction, RemindersAction,
-    SessionsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
+    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction, ModelsAction,
+    RemindersAction, SessionsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -1195,6 +1195,24 @@ pub async fn run(cli: Cli) -> Result<()> {
                     println!("{}", render(&result, format));
                 }
             },
+        },
+        Command::Message { action } => match action {
+            MessageAction::Send {
+                channel,
+                text,
+                session,
+                thread,
+            } => {
+                let result = client
+                    .message_send(
+                        &channel,
+                        &text,
+                        session.as_deref(),
+                        thread.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1705,6 +1705,26 @@ impl fmt::Display for CronRunsResponse {
     }
 }
 
+/// Response for `message send`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageSendResponse {
+    pub success: bool,
+    pub channel: String,
+    pub message_id: Option<String>,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageSendResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} [{}] {}", self.channel, self.detail)?;
+        if let Some(ref id) = self.message_id {
+            write!(f, " (id={id})")?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -2508,6 +2528,52 @@ mod tests {
         };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("[cancelled]"));
+    }
+
+    // ── Message family (#74) ─────────────────────────────────────────
+
+    #[test]
+    fn render_message_send_success() {
+        let r = MessageSendResponse {
+            success: true,
+            channel: "telegram".into(),
+            message_id: Some("msg-42".into()),
+            detail: "Message sent".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.starts_with('✓'));
+        assert!(out.contains("[telegram]"));
+        assert!(out.contains("(id=msg-42)"));
+    }
+
+    #[test]
+    fn render_message_send_failure() {
+        let r = MessageSendResponse {
+            success: false,
+            channel: "discord".into(),
+            message_id: None,
+            detail: "Gateway returned HTTP 503".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.starts_with('✗'));
+        assert!(out.contains("[discord]"));
+        assert!(out.contains("503"));
+        assert!(!out.contains("(id="));
+    }
+
+    #[test]
+    fn render_message_send_json() {
+        let r = MessageSendResponse {
+            success: true,
+            channel: "slack".into(),
+            message_id: Some("msg-99".into()),
+            detail: "Message sent".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["channel"], "slack");
+        assert_eq!(v["message_id"], "msg-99");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds the `message` CLI family with `send` subcommand: `rune message send --channel <adapter> --text <body> [--session <id>] [--thread <id>]`
- Gateway client calls `POST /messages/send` with channel, text, and optional session/thread fields
- `MessageSendResponse` output type with human (✓/✗ icon) and JSON rendering
- 6 new tests: 3 CLI parse tests (happy path, full options, required-arg validation) + 3 output render tests (success, failure, JSON)

## Context
Closes the **message send** gap from issue #74's parity inventory. The `message` family (send, read, edit, delete, react, pin, search, broadcast, thread, voice) now has its first concrete subcommand. Follow-on slices can extend `MessageAction` with additional verbs.

## Test plan
- [x] `cargo check -p rune-cli` — clean
- [x] `cargo test -p rune-cli` — 197/197 pass (6 new)
- [x] CLI parse: `rune message send --channel telegram --text "hello"` parses correctly
- [x] CLI parse: `--session` and `--thread` optional flags accepted
- [x] CLI parse: missing `--channel` or `--text` rejected
- [x] Output: success/failure human rendering with ✓/✗ icons
- [x] Output: JSON round-trip serialization