### PR TITLE
feat(cli): add `rune message search` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -484,6 +484,20 @@ pub enum MessageAction {
         #[arg(long)]
         thread: Option<String>,
     },
+    /// Search message history across channels.
+    Search {
+        /// Query text to search for in message content.
+        query: String,
+        /// Restrict results to a specific channel adapter.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Restrict results to a specific session ID.
+        #[arg(long)]
+        session: Option<String>,
+        /// Maximum number of results to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u64,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1983,5 +1997,67 @@ mod tests {
         );
         // Missing both
         assert!(Cli::try_parse_from(["rune", "message", "send"]).is_err());
+    }
+
+    #[test]
+    fn parse_message_search() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "search",
+            "deploy failed",
+            "--channel",
+            "telegram",
+            "--session",
+            "sess-1",
+            "--limit",
+            "10",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Search {
+                        query,
+                        channel,
+                        session,
+                        limit,
+                    },
+            } => {
+                assert_eq!(query, "deploy failed");
+                assert_eq!(channel.as_deref(), Some("telegram"));
+                assert_eq!(session.as_deref(), Some("sess-1"));
+                assert_eq!(limit, 10);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_search_defaults() {
+        let cli =
+            Cli::try_parse_from(["rune", "message", "search", "hello world"]).unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Search {
+                        query,
+                        channel,
+                        session,
+                        limit,
+                    },
+            } => {
+                assert_eq!(query, "hello world");
+                assert!(channel.is_none());
+                assert!(session.is_none());
+                assert_eq!(limit, 25);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_search_requires_query() {
+        assert!(Cli::try_parse_from(["rune", "message", "search"]).is_err());
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -15,7 +15,7 @@ use crate::output::{
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport, SystemEventListResponse,
     GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
     HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
-    MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
+    MessageSearchHit, MessageSearchResponse, MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
     SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
 };
 
@@ -891,6 +891,63 @@ impl GatewayClient {
                 message_id: None,
                 detail: format!("Gateway returned HTTP {status}: {body_text}"),
             })
+        }
+    }
+
+    /// `GET /messages/search`
+    pub async fn message_search(
+        &self,
+        query: &str,
+        channel: Option<&str>,
+        session: Option<&str>,
+        limit: u64,
+    ) -> Result<MessageSearchResponse> {
+        let mut params: Vec<(&str, String)> = vec![
+            ("q", query.to_string()),
+            ("limit", limit.to_string()),
+        ];
+        if let Some(ch) = channel {
+            params.push(("channel", ch.to_string()));
+        }
+        if let Some(sess) = session {
+            params.push(("session", sess.to_string()));
+        }
+        let resp = self
+            .http
+            .get(self.url("/messages/search"))
+            .query(&params)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from GET /messages/search")?;
+            let hits = body["hits"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|hit| MessageSearchHit {
+                    id: hit["id"].as_str().unwrap_or("?").to_string(),
+                    channel: hit["channel"].as_str().map(String::from),
+                    session: hit["session"].as_str().map(String::from),
+                    sender: hit["sender"].as_str().map(String::from),
+                    text: hit["text"].as_str().unwrap_or("").to_string(),
+                    timestamp: hit["timestamp"].as_str().map(String::from),
+                    score: hit["score"].as_f64(),
+                })
+                .collect::<Vec<_>>();
+            let total = body["total"].as_u64().unwrap_or(hits.len() as u64) as usize;
+            Ok(MessageSearchResponse {
+                query: query.to_string(),
+                total,
+                hits,
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
         }
     }
 
@@ -1928,5 +1985,78 @@ mod tests {
         assert_eq!(resp.events[0].payload.kind(), "system_event");
         assert_eq!(resp.events[1].id, "job-3");
         assert_eq!(resp.events[1].payload.kind(), "system_event");
+    }
+
+    #[tokio::test]
+    async fn message_search_parses_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/search"))
+            .and(query_param("q", "deploy"))
+            .and(query_param("limit", "10"))
+            .and(query_param("channel", "telegram"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 2,
+                "hits": [
+                    {
+                        "id": "msg-1",
+                        "channel": "telegram",
+                        "session": "sess-1",
+                        "sender": "hamza",
+                        "text": "deploy to staging",
+                        "timestamp": "2026-03-19T10:00:00Z",
+                        "score": 0.95
+                    },
+                    {
+                        "id": "msg-2",
+                        "channel": "telegram",
+                        "session": null,
+                        "sender": null,
+                        "text": "deploy rollback",
+                        "timestamp": "2026-03-19T11:00:00Z",
+                        "score": 0.82
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_search("deploy", Some("telegram"), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(resp.query, "deploy");
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.hits.len(), 2);
+        assert_eq!(resp.hits[0].id, "msg-1");
+        assert_eq!(resp.hits[0].channel.as_deref(), Some("telegram"));
+        assert_eq!(resp.hits[0].sender.as_deref(), Some("hamza"));
+        assert_eq!(resp.hits[0].text, "deploy to staging");
+        assert!(resp.hits[0].score.unwrap() > 0.9);
+        assert_eq!(resp.hits[1].id, "msg-2");
+        assert!(resp.hits[1].sender.is_none());
+    }
+
+    #[tokio::test]
+    async fn message_search_empty_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/search"))
+            .and(query_param("q", "nonexistent"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 0,
+                "hits": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_search("nonexistent", None, None, 25)
+            .await
+            .unwrap();
+        assert_eq!(resp.total, 0);
+        assert!(resp.hits.is_empty());
     }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1213,6 +1213,22 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Search {
+                query,
+                channel,
+                session,
+                limit,
+            } => {
+                let result = client
+                    .message_search(
+                        &query,
+                        channel.as_deref(),
+                        session.as_deref(),
+                        limit,
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1725,6 +1725,58 @@ impl fmt::Display for MessageSendResponse {
     }
 }
 
+/// A single hit returned by `message search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageSearchHit {
+    pub id: String,
+    pub channel: Option<String>,
+    pub session: Option<String>,
+    pub sender: Option<String>,
+    pub text: String,
+    pub timestamp: Option<String>,
+    pub score: Option<f64>,
+}
+
+impl fmt::Display for MessageSearchHit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ch = self.channel.as_deref().unwrap_or("?");
+        let ts = self.timestamp.as_deref().unwrap_or("?");
+        let sender = self.sender.as_deref().unwrap_or("unknown");
+        write!(f, "[{ch}] {ts} {sender}: {}", self.text)?;
+        if let Some(score) = self.score {
+            write!(f, " (score={score:.2})")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response for `message search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageSearchResponse {
+    pub query: String,
+    pub total: usize,
+    pub hits: Vec<MessageSearchHit>,
+}
+
+impl fmt::Display for MessageSearchResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.hits.is_empty() {
+            return write!(f, "No messages found for query: {}", self.query);
+        }
+        writeln!(
+            f,
+            "Message search: {} result{} for \"{}\"",
+            self.total,
+            if self.total == 1 { "" } else { "s" },
+            self.query,
+        )?;
+        for hit in &self.hits {
+            writeln!(f, "  {hit}")?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -2574,6 +2626,96 @@ mod tests {
         assert_eq!(v["success"], true);
         assert_eq!(v["channel"], "slack");
         assert_eq!(v["message_id"], "msg-99");
+    }
+
+    #[test]
+    fn render_message_search_empty() {
+        let r = MessageSearchResponse {
+            query: "nonexistent".into(),
+            total: 0,
+            hits: vec![],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert_eq!(out, "No messages found for query: nonexistent");
+    }
+
+    #[test]
+    fn render_message_search_with_results() {
+        let r = MessageSearchResponse {
+            query: "deploy".into(),
+            total: 2,
+            hits: vec![
+                MessageSearchHit {
+                    id: "msg-1".into(),
+                    channel: Some("telegram".into()),
+                    session: Some("sess-1".into()),
+                    sender: Some("hamza".into()),
+                    text: "deploy to staging".into(),
+                    timestamp: Some("2026-03-19T10:00:00Z".into()),
+                    score: Some(0.95),
+                },
+                MessageSearchHit {
+                    id: "msg-2".into(),
+                    channel: Some("discord".into()),
+                    session: None,
+                    sender: None,
+                    text: "deploy rollback".into(),
+                    timestamp: None,
+                    score: None,
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Message search: 2 results for \"deploy\""));
+        assert!(out.contains("[telegram] 2026-03-19T10:00:00Z hamza: deploy to staging"));
+        assert!(out.contains("(score=0.95)"));
+        assert!(out.contains("[discord] ? unknown: deploy rollback"));
+    }
+
+    #[test]
+    fn render_message_search_json() {
+        let r = MessageSearchResponse {
+            query: "test".into(),
+            total: 1,
+            hits: vec![MessageSearchHit {
+                id: "msg-3".into(),
+                channel: Some("slack".into()),
+                session: Some("sess-2".into()),
+                sender: Some("bot".into()),
+                text: "test passed".into(),
+                timestamp: Some("2026-03-19T12:00:00Z".into()),
+                score: Some(0.88),
+            }],
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["query"], "test");
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["hits"][0]["id"], "msg-3");
+        assert_eq!(v["hits"][0]["channel"], "slack");
+        assert_eq!(v["hits"][0]["session"], "sess-2");
+        assert_eq!(v["hits"][0]["text"], "test passed");
+        assert!(v["hits"][0]["score"].as_f64().unwrap() > 0.87);
+    }
+
+    #[test]
+    fn render_message_search_single_result_grammar() {
+        let r = MessageSearchResponse {
+            query: "one".into(),
+            total: 1,
+            hits: vec![MessageSearchHit {
+                id: "msg-4".into(),
+                channel: None,
+                session: None,
+                sender: None,
+                text: "one match".into(),
+                timestamp: None,
+                score: None,
+            }],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("1 result for"));
+        assert!(!out.contains("results for"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `rune message search <query> [--channel] [--session] [--limit]` as the second `message` family verb, closing the search gap in CLI parity (#74)
- `GatewayClient::message_search()` hits `GET /messages/search` with query-param filtering
- `MessageSearchResponse` / `MessageSearchHit` output types with human and JSON rendering
- 10 new tests (3 CLI parse, 4 output render, 2 wiremock client, 1 validation)

## Test plan
- [x] `cargo test -p rune-cli --quiet` — 206/206 pass
- [x] `cargo check --workspace` — clean
- [ ] Manual: `rune message search "deploy" --channel telegram --limit 5` against a live gateway