### PR TITLE
feat(cli): add `rune message broadcast` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -498,6 +498,18 @@ pub enum MessageAction {
         #[arg(long, default_value_t = 25)]
         limit: u64,
     },
+    /// Broadcast a message to multiple channel adapters simultaneously.
+    Broadcast {
+        /// Message body text.
+        #[arg(long)]
+        text: String,
+        /// Comma-separated list of target channels (default: all enabled channels).
+        #[arg(long, value_delimiter = ',')]
+        channels: Vec<String>,
+        /// Optional session ID to associate the broadcast with.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2059,5 +2071,93 @@ mod tests {
     #[test]
     fn message_search_requires_query() {
         assert!(Cli::try_parse_from(["rune", "message", "search"]).is_err());
+    }
+
+    #[test]
+    fn parse_message_broadcast() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "broadcast",
+            "--text",
+            "System maintenance in 10 minutes",
+            "--channels",
+            "telegram,discord,slack",
+            "--session",
+            "sess-99",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Broadcast {
+                        text,
+                        channels,
+                        session,
+                    },
+            } => {
+                assert_eq!(text, "System maintenance in 10 minutes");
+                assert_eq!(channels, vec!["telegram", "discord", "slack"]);
+                assert_eq!(session.as_deref(), Some("sess-99"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_broadcast_no_channels() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "broadcast",
+            "--text",
+            "Hello everyone",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Broadcast {
+                        text,
+                        channels,
+                        session,
+                    },
+            } => {
+                assert_eq!(text, "Hello everyone");
+                assert!(channels.is_empty());
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_broadcast_requires_text() {
+        assert!(Cli::try_parse_from(["rune", "message", "broadcast"]).is_err());
+    }
+
+    #[test]
+    fn parse_message_broadcast_single_channel() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "broadcast",
+            "--text",
+            "alert",
+            "--channels",
+            "telegram",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Broadcast {
+                        channels, ..
+                    },
+            } => {
+                assert_eq!(channels, vec!["telegram"]);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -951,6 +951,64 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /messages/broadcast`
+    pub async fn message_broadcast(
+        &self,
+        text: &str,
+        channels: &[String],
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageBroadcastResponse> {
+        use crate::output::{MessageBroadcastChannelResult, MessageBroadcastResponse};
+
+        let mut body = json!({
+            "text": text,
+        });
+        if !channels.is_empty() {
+            body["channels"] = json!(channels);
+        }
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .post(self.url("/messages/broadcast"))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/broadcast")?;
+            let results = v["results"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|r| MessageBroadcastChannelResult {
+                    channel: r["channel"].as_str().unwrap_or("?").to_string(),
+                    success: r["success"].as_bool().unwrap_or(false),
+                    message_id: r["id"].as_str().map(String::from),
+                    detail: r["detail"]
+                        .as_str()
+                        .unwrap_or("sent")
+                        .to_string(),
+                })
+                .collect::<Vec<_>>();
+            let succeeded = results.iter().filter(|r| r.success).count();
+            Ok(MessageBroadcastResponse {
+                total: results.len(),
+                succeeded,
+                failed: results.len() - succeeded,
+                results,
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
+        }
+    }
+
     /// `GET /sessions`
     pub async fn sessions_list(
         &self,
@@ -2058,5 +2116,110 @@ mod tests {
             .unwrap();
         assert_eq!(resp.total, 0);
         assert!(resp.hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn message_broadcast_parses_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/broadcast"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "channel": "telegram",
+                        "success": true,
+                        "id": "msg-1",
+                        "detail": "Message sent"
+                    },
+                    {
+                        "channel": "discord",
+                        "success": true,
+                        "id": "msg-2",
+                        "detail": "Message sent"
+                    },
+                    {
+                        "channel": "slack",
+                        "success": false,
+                        "id": null,
+                        "detail": "Channel not configured"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_broadcast(
+                "System maintenance",
+                &["telegram".into(), "discord".into(), "slack".into()],
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.total, 3);
+        assert_eq!(resp.succeeded, 2);
+        assert_eq!(resp.failed, 1);
+        assert!(resp.results[0].success);
+        assert_eq!(resp.results[0].channel, "telegram");
+        assert_eq!(resp.results[0].message_id.as_deref(), Some("msg-1"));
+        assert!(!resp.results[2].success);
+        assert_eq!(resp.results[2].detail, "Channel not configured");
+    }
+
+    #[tokio::test]
+    async fn message_broadcast_with_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/broadcast"))
+            .and(body_json(json!({
+                "text": "hello all",
+                "channels": ["telegram"],
+                "session": "sess-42"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "channel": "telegram",
+                        "success": true,
+                        "id": "msg-10",
+                        "detail": "Message sent"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_broadcast("hello all", &["telegram".into()], Some("sess-42"))
+            .await
+            .unwrap();
+        assert_eq!(resp.total, 1);
+        assert_eq!(resp.succeeded, 1);
+        assert_eq!(resp.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn message_broadcast_empty_channels_omits_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/broadcast"))
+            .and(body_json(json!({
+                "text": "broadcast to all"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_broadcast("broadcast to all", &[], None)
+            .await
+            .unwrap();
+        assert_eq!(resp.total, 0);
+        assert_eq!(resp.succeeded, 0);
     }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1229,6 +1229,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Broadcast {
+                text,
+                channels,
+                session,
+            } => {
+                let result = client
+                    .message_broadcast(&text, &channels, session.as_deref())
+                    .await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1777,6 +1777,51 @@ impl fmt::Display for MessageSearchResponse {
     }
 }
 
+/// Per-channel result within a broadcast.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageBroadcastChannelResult {
+    pub channel: String,
+    pub success: bool,
+    pub message_id: Option<String>,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageBroadcastChannelResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} [{}] {}", self.channel, self.detail)?;
+        if let Some(id) = &self.message_id {
+            write!(f, " (id: {id})")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response for `message broadcast`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageBroadcastResponse {
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub results: Vec<MessageBroadcastChannelResult>,
+}
+
+impl fmt::Display for MessageBroadcastResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Broadcast: {}/{} channel{} succeeded",
+            self.succeeded,
+            self.total,
+            if self.total == 1 { "" } else { "s" },
+        )?;
+        for result in &self.results {
+            writeln!(f, "  {result}")?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -2738,5 +2783,100 @@ mod tests {
         assert_eq!(v["outcome_at"], "2026-04-01T09:01:00Z");
         assert_eq!(v["last_error"], "timeout");
         assert_eq!(v["target"], "isolated");
+    }
+
+    #[test]
+    fn render_message_broadcast_success() {
+        let r = MessageBroadcastResponse {
+            total: 2,
+            succeeded: 2,
+            failed: 0,
+            results: vec![
+                MessageBroadcastChannelResult {
+                    channel: "telegram".into(),
+                    success: true,
+                    message_id: Some("msg-1".into()),
+                    detail: "Message sent".into(),
+                },
+                MessageBroadcastChannelResult {
+                    channel: "discord".into(),
+                    success: true,
+                    message_id: Some("msg-2".into()),
+                    detail: "Message sent".into(),
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("2/2 channels succeeded"));
+        assert!(out.contains("✓ [telegram]"));
+        assert!(out.contains("✓ [discord]"));
+    }
+
+    #[test]
+    fn render_message_broadcast_partial_failure() {
+        let r = MessageBroadcastResponse {
+            total: 2,
+            succeeded: 1,
+            failed: 1,
+            results: vec![
+                MessageBroadcastChannelResult {
+                    channel: "telegram".into(),
+                    success: true,
+                    message_id: Some("msg-1".into()),
+                    detail: "Message sent".into(),
+                },
+                MessageBroadcastChannelResult {
+                    channel: "slack".into(),
+                    success: false,
+                    message_id: None,
+                    detail: "Channel not configured".into(),
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("1/2 channels succeeded"));
+        assert!(out.contains("✓ [telegram]"));
+        assert!(out.contains("✗ [slack]"));
+    }
+
+    #[test]
+    fn render_message_broadcast_json() {
+        let r = MessageBroadcastResponse {
+            total: 1,
+            succeeded: 1,
+            failed: 0,
+            results: vec![MessageBroadcastChannelResult {
+                channel: "telegram".into(),
+                success: true,
+                message_id: Some("msg-10".into()),
+                detail: "Message sent".into(),
+            }],
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["succeeded"], 1);
+        assert_eq!(v["failed"], 0);
+        assert_eq!(v["results"][0]["channel"], "telegram");
+        assert!(v["results"][0]["success"].as_bool().unwrap());
+        assert_eq!(v["results"][0]["message_id"], "msg-10");
+    }
+
+    #[test]
+    fn render_message_broadcast_single_channel_grammar() {
+        let r = MessageBroadcastResponse {
+            total: 1,
+            succeeded: 1,
+            failed: 0,
+            results: vec![MessageBroadcastChannelResult {
+                channel: "telegram".into(),
+                success: true,
+                message_id: None,
+                detail: "sent".into(),
+            }],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("1/1 channel succeeded"));
+        assert!(!out.contains("channels"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `rune message broadcast` CLI subcommand for sending a message to multiple channel adapters simultaneously
- Accepts `--text` (required), `--channels` (comma-delimited, optional — defaults to all enabled), and `--session` (optional)
- Gateway client hits `POST /messages/broadcast` and returns per-channel success/failure breakdown
- Closes the `broadcast` gap in the `message` family for CLI parity sweep (#74)

## Changes
- `cli.rs`: `MessageAction::Broadcast` variant with clap args
- `client.rs`: `GatewayClient::message_broadcast` method
- `output.rs`: `MessageBroadcastResponse` + `MessageBroadcastChannelResult` types with human/JSON rendering
- `lib.rs`: dispatch wiring

## Test plan
- [x] 4 CLI parse tests (full args, no channels, requires text, single channel)
- [x] 3 client wiremock tests (multi-channel result parsing, session passthrough, empty channels)
- [x] 4 output render tests (success, partial failure, JSON, singular grammar)
- [x] All 217 rune-cli tests pass