### PR TITLE
feat(cli): add `rune message react` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -510,6 +510,24 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Add or remove an emoji reaction on a message.
+    React {
+        /// ID of the message to react to.
+        #[arg(long)]
+        message_id: String,
+        /// Emoji to add (e.g. "👍", ":thumbsup:", "heart").
+        #[arg(long)]
+        emoji: String,
+        /// Remove the reaction instead of adding it.
+        #[arg(long)]
+        remove: bool,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2159,5 +2177,97 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_message_react() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "react",
+            "--message-id",
+            "msg-42",
+            "--emoji",
+            "👍",
+            "--channel",
+            "telegram",
+            "--session",
+            "sess-7",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::React {
+                        message_id,
+                        emoji,
+                        remove,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-42");
+                assert_eq!(emoji, "👍");
+                assert!(!remove);
+                assert_eq!(channel.as_deref(), Some("telegram"));
+                assert_eq!(session.as_deref(), Some("sess-7"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_react_remove() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "react",
+            "--message-id",
+            "msg-99",
+            "--emoji",
+            "heart",
+            "--remove",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::React {
+                        message_id,
+                        emoji,
+                        remove,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-99");
+                assert_eq!(emoji, "heart");
+                assert!(remove);
+                assert!(channel.is_none());
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_react_requires_message_id_and_emoji() {
+        assert!(Cli::try_parse_from(["rune", "message", "react"]).is_err());
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "react",
+            "--message-id",
+            "msg-1",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "react",
+            "--emoji",
+            "👍",
+        ])
+        .is_err());
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1009,6 +1009,72 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /messages/react`
+    pub async fn message_react(
+        &self,
+        message_id: &str,
+        emoji: &str,
+        remove: bool,
+        channel: Option<&str>,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageReactResponse> {
+        use crate::output::MessageReactResponse;
+
+        let mut body = json!({
+            "message_id": message_id,
+            "emoji": emoji,
+        });
+        if remove {
+            body["remove"] = json!(true);
+        }
+        if let Some(ch) = channel {
+            body["channel"] = json!(ch);
+        }
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .post(self.url("/messages/react"))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/react")?;
+            Ok(MessageReactResponse {
+                success: true,
+                message_id: v["message_id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                emoji: v["emoji"].as_str().unwrap_or(emoji).to_string(),
+                removed: v["removed"].as_bool().unwrap_or(remove),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or(if remove {
+                        "Reaction removed"
+                    } else {
+                        "Reaction added"
+                    })
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageReactResponse {
+                success: false,
+                message_id: message_id.to_string(),
+                emoji: emoji.to_string(),
+                removed: remove,
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     /// `GET /sessions`
     pub async fn sessions_list(
         &self,
@@ -2221,5 +2287,112 @@ mod tests {
             .unwrap();
         assert_eq!(resp.total, 0);
         assert_eq!(resp.succeeded, 0);
+    }
+
+    #[tokio::test]
+    async fn message_react_add() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/react"))
+            .and(body_json(json!({
+                "message_id": "msg-42",
+                "emoji": "👍"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-42",
+                "emoji": "👍",
+                "removed": false,
+                "detail": "Reaction added"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_react("msg-42", "👍", false, None, None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-42");
+        assert_eq!(resp.emoji, "👍");
+        assert!(!resp.removed);
+        assert_eq!(resp.detail, "Reaction added");
+    }
+
+    #[tokio::test]
+    async fn message_react_remove() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/react"))
+            .and(body_json(json!({
+                "message_id": "msg-99",
+                "emoji": "heart",
+                "remove": true,
+                "channel": "discord"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-99",
+                "emoji": "heart",
+                "removed": true,
+                "detail": "Reaction removed"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_react("msg-99", "heart", true, Some("discord"), None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert!(resp.removed);
+        assert_eq!(resp.detail, "Reaction removed");
+    }
+
+    #[tokio::test]
+    async fn message_react_with_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/react"))
+            .and(body_json(json!({
+                "message_id": "msg-5",
+                "emoji": ":thumbsup:",
+                "session": "sess-7"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-5",
+                "emoji": ":thumbsup:",
+                "removed": false,
+                "detail": "Reaction added"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_react("msg-5", ":thumbsup:", false, None, Some("sess-7"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.emoji, ":thumbsup:");
+    }
+
+    #[tokio::test]
+    async fn message_react_gateway_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/react"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Message not found"))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_react("msg-missing", "👍", false, None, None)
+            .await
+            .unwrap();
+        assert!(!resp.success);
+        assert!(resp.detail.contains("404"));
+        assert!(resp.detail.contains("Message not found"));
     }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1239,6 +1239,24 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::React {
+                message_id,
+                emoji,
+                remove,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_react(
+                        &message_id,
+                        &emoji,
+                        remove,
+                        channel.as_deref(),
+                        session.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1822,6 +1822,32 @@ impl fmt::Display for MessageBroadcastResponse {
     }
 }
 
+/// Response for `message react`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageReactResponse {
+    pub success: bool,
+    pub message_id: String,
+    pub emoji: String,
+    pub removed: bool,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageReactResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        let verb = if self.removed { "removed" } else { "added" };
+        write!(
+            f,
+            "{icon} {verb} {} on message {}",
+            self.emoji, self.message_id,
+        )?;
+        if !self.detail.is_empty() {
+            write!(f, ": {}", self.detail)?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -2878,5 +2904,84 @@ mod tests {
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("1/1 channel succeeded"));
         assert!(!out.contains("channels"));
+    }
+
+    #[test]
+    fn render_message_react_add_success() {
+        let r = MessageReactResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            emoji: "👍".into(),
+            removed: false,
+            detail: "Reaction added".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("added"));
+        assert!(out.contains("👍"));
+        assert!(out.contains("msg-42"));
+    }
+
+    #[test]
+    fn render_message_react_remove_success() {
+        let r = MessageReactResponse {
+            success: true,
+            message_id: "msg-99".into(),
+            emoji: "heart".into(),
+            removed: true,
+            detail: "Reaction removed".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("removed"));
+        assert!(out.contains("heart"));
+        assert!(out.contains("msg-99"));
+    }
+
+    #[test]
+    fn render_message_react_failure() {
+        let r = MessageReactResponse {
+            success: false,
+            message_id: "msg-1".into(),
+            emoji: "👎".into(),
+            removed: false,
+            detail: "Gateway returned HTTP 404: Message not found".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✗"));
+        assert!(out.contains("added"));
+        assert!(out.contains("404"));
+    }
+
+    #[test]
+    fn render_message_react_json() {
+        let r = MessageReactResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            emoji: "👍".into(),
+            removed: false,
+            detail: "Reaction added".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v["success"].as_bool().unwrap());
+        assert_eq!(v["message_id"], "msg-42");
+        assert_eq!(v["emoji"], "👍");
+        assert!(!v["removed"].as_bool().unwrap());
+        assert_eq!(v["detail"], "Reaction added");
+    }
+
+    #[test]
+    fn render_message_react_empty_detail() {
+        let r = MessageReactResponse {
+            success: true,
+            message_id: "msg-1".into(),
+            emoji: "fire".into(),
+            removed: false,
+            detail: String::new(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓ added fire on message msg-1"));
+        assert!(!out.contains(":"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `rune message react --message-id <ID> --emoji <EMOJI> [--remove] [--channel <ADAPTER>] [--session <ID>]` as a first-class CLI surface
- Gateway client method hitting `POST /messages/react` with add/remove semantics
- Human + JSON output rendering with success/failure indicators
- 12 new tests: 3 CLI parse, 4 client wiremock, 5 output render

Closes the `react` gap in the `message` family parity table (issue #74).

## Test plan
- [x] `cargo test -p rune-cli --quiet` — 229/229 pass
- [x] `cargo clippy -p rune-cli -- -D warnings` — zero warnings