### PR TITLE
feat(cli): add `rune message pin` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -528,6 +528,21 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Pin or unpin a message in a channel.
+    Pin {
+        /// ID of the message to pin or unpin.
+        #[arg(long)]
+        message_id: String,
+        /// Unpin the message instead of pinning it.
+        #[arg(long)]
+        unpin: bool,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2248,6 +2263,75 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_message_pin() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "pin",
+            "--message-id",
+            "msg-50",
+            "--channel",
+            "telegram",
+            "--session",
+            "sess-3",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Pin {
+                        message_id,
+                        unpin,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-50");
+                assert!(!unpin);
+                assert_eq!(channel.as_deref(), Some("telegram"));
+                assert_eq!(session.as_deref(), Some("sess-3"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_unpin() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "pin",
+            "--message-id",
+            "msg-77",
+            "--unpin",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Pin {
+                        message_id,
+                        unpin,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-77");
+                assert!(unpin);
+                assert!(channel.is_none());
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_pin_requires_message_id() {
+        assert!(Cli::try_parse_from(["rune", "message", "pin"]).is_err());
+        assert!(Cli::try_parse_from(["rune", "message", "pin", "--unpin"]).is_err());
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1075,6 +1075,68 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /messages/pin`
+    pub async fn message_pin(
+        &self,
+        message_id: &str,
+        unpin: bool,
+        channel: Option<&str>,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessagePinResponse> {
+        use crate::output::MessagePinResponse;
+
+        let mut body = json!({
+            "message_id": message_id,
+        });
+        if unpin {
+            body["unpin"] = json!(true);
+        }
+        if let Some(ch) = channel {
+            body["channel"] = json!(ch);
+        }
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .post(self.url("/messages/pin"))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/pin")?;
+            Ok(MessagePinResponse {
+                success: true,
+                message_id: v["message_id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                pinned: !v["unpinned"].as_bool().unwrap_or(unpin),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or(if unpin {
+                        "Message unpinned"
+                    } else {
+                        "Message pinned"
+                    })
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessagePinResponse {
+                success: false,
+                message_id: message_id.to_string(),
+                pinned: !unpin,
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     /// `GET /sessions`
     pub async fn sessions_list(
         &self,
@@ -2389,6 +2451,105 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let resp = client
             .message_react("msg-missing", "👍", false, None, None)
+            .await
+            .unwrap();
+        assert!(!resp.success);
+        assert!(resp.detail.contains("404"));
+        assert!(resp.detail.contains("Message not found"));
+    }
+
+    #[tokio::test]
+    async fn message_pin_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/pin"))
+            .and(body_json(json!({
+                "message_id": "msg-50"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-50",
+                "detail": "Message pinned"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_pin("msg-50", false, None, None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-50");
+        assert!(resp.pinned);
+        assert_eq!(resp.detail, "Message pinned");
+    }
+
+    #[tokio::test]
+    async fn message_unpin_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/pin"))
+            .and(body_json(json!({
+                "message_id": "msg-77",
+                "unpin": true
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-77",
+                "unpinned": true,
+                "detail": "Message unpinned"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_pin("msg-77", true, None, None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-77");
+        assert!(!resp.pinned);
+        assert_eq!(resp.detail, "Message unpinned");
+    }
+
+    #[tokio::test]
+    async fn message_pin_with_channel_and_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/pin"))
+            .and(body_json(json!({
+                "message_id": "msg-10",
+                "channel": "telegram",
+                "session": "sess-5"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message_id": "msg-10",
+                "detail": "Message pinned"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_pin("msg-10", false, Some("telegram"), Some("sess-5"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert!(resp.pinned);
+    }
+
+    #[tokio::test]
+    async fn message_pin_gateway_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/pin"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Message not found"))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_pin("msg-missing", false, None, None)
             .await
             .unwrap();
         assert!(!resp.success);

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1257,6 +1257,22 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Pin {
+                message_id,
+                unpin,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_pin(
+                        &message_id,
+                        unpin,
+                        channel.as_deref(),
+                        session.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1848,6 +1848,27 @@ impl fmt::Display for MessageReactResponse {
     }
 }
 
+/// Response from a message pin/unpin operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessagePinResponse {
+    pub success: bool,
+    pub message_id: String,
+    pub pinned: bool,
+    pub detail: String,
+}
+
+impl fmt::Display for MessagePinResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        let verb = if self.pinned { "pinned" } else { "unpinned" };
+        write!(f, "{icon} {verb} message {}", self.message_id)?;
+        if !self.detail.is_empty() {
+            write!(f, ": {}", self.detail)?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -2982,6 +3003,76 @@ mod tests {
         };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓ added fire on message msg-1"));
+        assert!(!out.contains(":"));
+    }
+
+    // ── MessagePinResponse ──────────────────────────────────────────
+
+    #[test]
+    fn message_pin_response_human_pin() {
+        let r = MessagePinResponse {
+            success: true,
+            message_id: "msg-50".into(),
+            pinned: true,
+            detail: "Message pinned".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓ pinned message msg-50"));
+        assert!(out.contains("Message pinned"));
+    }
+
+    #[test]
+    fn message_pin_response_human_unpin() {
+        let r = MessagePinResponse {
+            success: true,
+            message_id: "msg-77".into(),
+            pinned: false,
+            detail: "Message unpinned".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓ unpinned message msg-77"));
+        assert!(out.contains("Message unpinned"));
+    }
+
+    #[test]
+    fn message_pin_response_human_failure() {
+        let r = MessagePinResponse {
+            success: false,
+            message_id: "msg-99".into(),
+            pinned: true,
+            detail: "Gateway returned HTTP 404: Message not found".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✗ pinned message msg-99"));
+        assert!(out.contains("404"));
+    }
+
+    #[test]
+    fn message_pin_response_json() {
+        let r = MessagePinResponse {
+            success: true,
+            message_id: "msg-50".into(),
+            pinned: true,
+            detail: "Message pinned".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["message_id"], "msg-50");
+        assert_eq!(v["pinned"], true);
+        assert_eq!(v["detail"], "Message pinned");
+    }
+
+    #[test]
+    fn message_pin_response_empty_detail() {
+        let r = MessagePinResponse {
+            success: true,
+            message_id: "msg-1".into(),
+            pinned: true,
+            detail: String::new(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓ pinned message msg-1"));
         assert!(!out.contains(":"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `rune message pin --message-id <ID> [--unpin] [--channel <ADAPTER>] [--session <ID>]` as a first-class CLI surface
- Gateway client method → `POST /messages/pin` with pin/unpin semantics
- `MessagePinResponse` output type with human + JSON rendering
- 12 new tests (3 CLI parse, 4 wiremock client, 5 output render)

## Test plan
- [x] `cargo test -p rune-cli --quiet` — 241/241 pass
- [x] `cargo clippy -p rune-cli -- -D warnings` — zero warnings
- [ ] Integration test against live gateway (deferred — no gateway route exists yet)