### PR TITLE
feat(cli): add `rune message thread` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -555,6 +555,45 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// List or reply to message threads.
+    Thread {
+        #[command(subcommand)]
+        action: MessageThreadAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MessageThreadAction {
+    /// List messages within a thread.
+    List {
+        /// Thread ID to list messages from.
+        #[arg(long)]
+        thread_id: String,
+        /// Channel adapter the thread belongs to.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Session ID the thread belongs to.
+        #[arg(long)]
+        session: Option<String>,
+        /// Maximum number of messages to return.
+        #[arg(long, default_value_t = 50)]
+        limit: u64,
+    },
+    /// Reply to an existing thread.
+    Reply {
+        /// Thread ID to reply to.
+        #[arg(long)]
+        thread_id: String,
+        /// Channel adapter the thread belongs to.
+        #[arg(long)]
+        channel: String,
+        /// Reply message text.
+        #[arg(long)]
+        text: String,
+        /// Session ID the thread belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2442,6 +2481,190 @@ mod tests {
             "rune",
             "message",
             "delete",
+            "--channel",
+            "telegram",
+        ])
+        .is_err());
+    }
+
+    // ── Message thread (#74) ────────────────────────────────────────
+
+    #[test]
+    fn parse_message_thread_list() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "list",
+            "--thread-id",
+            "thr-42",
+            "--channel",
+            "telegram",
+            "--session",
+            "sess-7",
+            "--limit",
+            "10",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Thread {
+                        action:
+                            MessageThreadAction::List {
+                                thread_id,
+                                channel,
+                                session,
+                                limit,
+                            },
+                    },
+            } => {
+                assert_eq!(thread_id, "thr-42");
+                assert_eq!(channel.as_deref(), Some("telegram"));
+                assert_eq!(session.as_deref(), Some("sess-7"));
+                assert_eq!(limit, 10);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_thread_list_defaults() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "list",
+            "--thread-id",
+            "thr-1",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Thread {
+                        action:
+                            MessageThreadAction::List {
+                                thread_id,
+                                channel,
+                                session,
+                                limit,
+                            },
+                    },
+            } => {
+                assert_eq!(thread_id, "thr-1");
+                assert!(channel.is_none());
+                assert!(session.is_none());
+                assert_eq!(limit, 50);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_thread_list_requires_thread_id() {
+        assert!(
+            Cli::try_parse_from(["rune", "message", "thread", "list"]).is_err()
+        );
+    }
+
+    #[test]
+    fn parse_message_thread_reply() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "reply",
+            "--thread-id",
+            "thr-42",
+            "--channel",
+            "telegram",
+            "--text",
+            "Thanks for the update",
+            "--session",
+            "sess-7",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Thread {
+                        action:
+                            MessageThreadAction::Reply {
+                                thread_id,
+                                channel,
+                                text,
+                                session,
+                            },
+                    },
+            } => {
+                assert_eq!(thread_id, "thr-42");
+                assert_eq!(channel, "telegram");
+                assert_eq!(text, "Thanks for the update");
+                assert_eq!(session.as_deref(), Some("sess-7"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_thread_reply_without_session() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "reply",
+            "--thread-id",
+            "thr-99",
+            "--channel",
+            "discord",
+            "--text",
+            "reply text",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Thread {
+                        action:
+                            MessageThreadAction::Reply {
+                                thread_id,
+                                channel,
+                                text,
+                                session,
+                            },
+                    },
+            } => {
+                assert_eq!(thread_id, "thr-99");
+                assert_eq!(channel, "discord");
+                assert_eq!(text, "reply text");
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_thread_reply_requires_thread_id_channel_text() {
+        assert!(
+            Cli::try_parse_from(["rune", "message", "thread", "reply"]).is_err()
+        );
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "reply",
+            "--thread-id",
+            "thr-1",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "thread",
+            "reply",
+            "--thread-id",
+            "thr-1",
             "--channel",
             "telegram",
         ])

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1186,6 +1186,113 @@ impl GatewayClient {
         }
     }
 
+    /// `GET /messages/threads/{id}`
+    pub async fn message_thread_list(
+        &self,
+        thread_id: &str,
+        channel: Option<&str>,
+        session: Option<&str>,
+        limit: u64,
+    ) -> Result<crate::output::MessageThreadListResponse> {
+        use crate::output::{MessageThreadListResponse, ThreadMessage};
+
+        let mut params: Vec<(&str, String)> = vec![("limit", limit.to_string())];
+        if let Some(ch) = channel {
+            params.push(("channel", ch.to_string()));
+        }
+        if let Some(s) = session {
+            params.push(("session", s.to_string()));
+        }
+        let resp = self
+            .http
+            .get(self.url(&format!("/messages/threads/{thread_id}")))
+            .query(&params)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from GET /messages/threads/{id}")?;
+            let messages = body["messages"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .map(|m| ThreadMessage {
+                            id: m["id"].as_str().unwrap_or("").to_string(),
+                            sender: m["sender"].as_str().map(ToString::to_string),
+                            text: m["text"].as_str().unwrap_or("").to_string(),
+                            timestamp: m["timestamp"].as_str().map(ToString::to_string),
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let total = body["total"]
+                .as_u64()
+                .unwrap_or(messages.len() as u64) as usize;
+            Ok(MessageThreadListResponse {
+                thread_id: thread_id.to_string(),
+                total,
+                messages,
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GET /messages/threads/{thread_id} returned HTTP {status}: {body_text}");
+        }
+    }
+
+    /// `POST /messages/threads/{id}/reply`
+    pub async fn message_thread_reply(
+        &self,
+        thread_id: &str,
+        channel: &str,
+        text: &str,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageThreadReplyResponse> {
+        use crate::output::MessageThreadReplyResponse;
+
+        let mut body = json!({
+            "channel": channel,
+            "text": text,
+        });
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .post(self.url(&format!("/messages/threads/{thread_id}/reply")))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/threads/{id}/reply")?;
+            Ok(MessageThreadReplyResponse {
+                success: true,
+                thread_id: thread_id.to_string(),
+                message_id: v["id"].as_str().map(ToString::to_string),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or("Reply sent")
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageThreadReplyResponse {
+                success: false,
+                thread_id: thread_id.to_string(),
+                message_id: None,
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     /// `GET /sessions`
     pub async fn sessions_list(
         &self,
@@ -2671,5 +2778,139 @@ mod tests {
         assert!(!resp.success);
         assert!(resp.detail.contains("404"));
         assert!(resp.detail.contains("Message not found"));
+    }
+
+    #[tokio::test]
+    async fn message_thread_list_parses_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/threads/thr-42"))
+            .and(query_param("limit", "10"))
+            .and(query_param("channel", "telegram"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 2,
+                "messages": [
+                    {
+                        "id": "msg-1",
+                        "sender": "hamza",
+                        "text": "initial message",
+                        "timestamp": "2026-03-19T10:00:00Z"
+                    },
+                    {
+                        "id": "msg-2",
+                        "sender": "bot",
+                        "text": "follow-up reply",
+                        "timestamp": "2026-03-19T10:05:00Z"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_thread_list("thr-42", Some("telegram"), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(resp.thread_id, "thr-42");
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.messages.len(), 2);
+        assert_eq!(resp.messages[0].id, "msg-1");
+        assert_eq!(resp.messages[0].sender.as_deref(), Some("hamza"));
+        assert_eq!(resp.messages[1].text, "follow-up reply");
+    }
+
+    #[tokio::test]
+    async fn message_thread_list_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/threads/thr-empty"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 0,
+                "messages": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_thread_list("thr-empty", None, None, 50)
+            .await
+            .unwrap();
+        assert_eq!(resp.total, 0);
+        assert!(resp.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn message_thread_reply_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/threads/thr-42/reply"))
+            .and(body_json(json!({
+                "channel": "telegram",
+                "text": "Thanks!"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-new-1",
+                "detail": "Reply sent"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_thread_reply("thr-42", "telegram", "Thanks!", None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.thread_id, "thr-42");
+        assert_eq!(resp.message_id.as_deref(), Some("msg-new-1"));
+        assert_eq!(resp.detail, "Reply sent");
+    }
+
+    #[tokio::test]
+    async fn message_thread_reply_with_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/threads/thr-99/reply"))
+            .and(body_json(json!({
+                "channel": "discord",
+                "text": "noted",
+                "session": "sess-7"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-new-2",
+                "detail": "Reply sent"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_thread_reply("thr-99", "discord", "noted", Some("sess-7"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.thread_id, "thr-99");
+        assert_eq!(resp.message_id.as_deref(), Some("msg-new-2"));
+    }
+
+    #[tokio::test]
+    async fn message_thread_reply_gateway_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages/threads/thr-missing/reply"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Thread not found"))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_thread_reply("thr-missing", "telegram", "hello", None)
+            .await
+            .unwrap();
+        assert!(!resp.success);
+        assert!(resp.detail.contains("404"));
+        assert!(resp.detail.contains("Thread not found"));
     }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -24,8 +24,9 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 pub use cli::Cli;
 use cli::{
     ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell, ConfigAction,
-    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction, ModelsAction,
-    RemindersAction, SessionsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
+    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
+    MessageThreadAction, ModelsAction, RemindersAction, SessionsAction, SystemAction,
+    SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -1283,6 +1284,40 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Thread { action } => match action {
+                MessageThreadAction::List {
+                    thread_id,
+                    channel,
+                    session,
+                    limit,
+                } => {
+                    let result = client
+                        .message_thread_list(
+                            &thread_id,
+                            channel.as_deref(),
+                            session.as_deref(),
+                            limit,
+                        )
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+                MessageThreadAction::Reply {
+                    thread_id,
+                    channel,
+                    text,
+                    session,
+                } => {
+                    let result = client
+                        .message_thread_reply(
+                            &thread_id,
+                            &channel,
+                            &text,
+                            session.as_deref(),
+                        )
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+            },
         },
         Command::Reminders { action } => match action {
             RemindersAction::Add {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1889,6 +1889,70 @@ impl fmt::Display for MessageDeleteResponse {
     }
 }
 
+/// A single message within a thread listing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadMessage {
+    pub id: String,
+    pub sender: Option<String>,
+    pub text: String,
+    pub timestamp: Option<String>,
+}
+
+impl fmt::Display for ThreadMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let sender = self.sender.as_deref().unwrap_or("unknown");
+        let ts = self.timestamp.as_deref().unwrap_or("?");
+        write!(f, "{ts} {sender}: {}", self.text)
+    }
+}
+
+/// Response for `message thread list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageThreadListResponse {
+    pub thread_id: String,
+    pub total: usize,
+    pub messages: Vec<ThreadMessage>,
+}
+
+impl fmt::Display for MessageThreadListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.messages.is_empty() {
+            return write!(f, "No messages in thread {}", self.thread_id);
+        }
+        writeln!(
+            f,
+            "Thread {}: {} message{}",
+            self.thread_id,
+            self.total,
+            if self.total == 1 { "" } else { "s" },
+        )?;
+        for msg in &self.messages {
+            writeln!(f, "  {msg}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response for `message thread reply`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageThreadReplyResponse {
+    pub success: bool,
+    pub thread_id: String,
+    pub message_id: Option<String>,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageThreadReplyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} thread {}: {}", self.thread_id, self.detail)?;
+        if let Some(ref id) = self.message_id {
+            write!(f, " (id={id})")?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -3141,5 +3205,130 @@ mod tests {
         assert_eq!(v["message_id"], "msg-42");
         assert_eq!(v["channel"], "telegram");
         assert_eq!(v["detail"], "Message deleted");
+    }
+
+    // ── MessageThreadListResponse ──────────────────────────────────
+
+    #[test]
+    fn render_message_thread_list_empty() {
+        let r = MessageThreadListResponse {
+            thread_id: "thr-1".into(),
+            total: 0,
+            messages: vec![],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert_eq!(out, "No messages in thread thr-1");
+    }
+
+    #[test]
+    fn render_message_thread_list_with_messages() {
+        let r = MessageThreadListResponse {
+            thread_id: "thr-42".into(),
+            total: 2,
+            messages: vec![
+                ThreadMessage {
+                    id: "msg-1".into(),
+                    sender: Some("hamza".into()),
+                    text: "initial message".into(),
+                    timestamp: Some("2026-03-19T10:00:00Z".into()),
+                },
+                ThreadMessage {
+                    id: "msg-2".into(),
+                    sender: None,
+                    text: "follow-up".into(),
+                    timestamp: None,
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Thread thr-42: 2 messages"));
+        assert!(out.contains("2026-03-19T10:00:00Z hamza: initial message"));
+        assert!(out.contains("? unknown: follow-up"));
+    }
+
+    #[test]
+    fn render_message_thread_list_single_grammar() {
+        let r = MessageThreadListResponse {
+            thread_id: "thr-99".into(),
+            total: 1,
+            messages: vec![ThreadMessage {
+                id: "msg-1".into(),
+                sender: Some("bot".into()),
+                text: "only one".into(),
+                timestamp: Some("2026-03-19T12:00:00Z".into()),
+            }],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("1 message"));
+        assert!(!out.contains("messages"));
+    }
+
+    #[test]
+    fn render_message_thread_list_json() {
+        let r = MessageThreadListResponse {
+            thread_id: "thr-42".into(),
+            total: 1,
+            messages: vec![ThreadMessage {
+                id: "msg-1".into(),
+                sender: Some("hamza".into()),
+                text: "hello thread".into(),
+                timestamp: Some("2026-03-19T10:00:00Z".into()),
+            }],
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["thread_id"], "thr-42");
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["messages"][0]["id"], "msg-1");
+        assert_eq!(v["messages"][0]["sender"], "hamza");
+        assert_eq!(v["messages"][0]["text"], "hello thread");
+    }
+
+    // ── MessageThreadReplyResponse ─────────────────────────────────
+
+    #[test]
+    fn render_message_thread_reply_success() {
+        let r = MessageThreadReplyResponse {
+            success: true,
+            thread_id: "thr-42".into(),
+            message_id: Some("msg-new-1".into()),
+            detail: "Reply sent".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.starts_with('✓'));
+        assert!(out.contains("thread thr-42"));
+        assert!(out.contains("Reply sent"));
+        assert!(out.contains("(id=msg-new-1)"));
+    }
+
+    #[test]
+    fn render_message_thread_reply_failure() {
+        let r = MessageThreadReplyResponse {
+            success: false,
+            thread_id: "thr-99".into(),
+            message_id: None,
+            detail: "Gateway returned HTTP 404: Thread not found".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.starts_with('✗'));
+        assert!(out.contains("thr-99"));
+        assert!(out.contains("404"));
+        assert!(!out.contains("(id="));
+    }
+
+    #[test]
+    fn render_message_thread_reply_json() {
+        let r = MessageThreadReplyResponse {
+            success: true,
+            thread_id: "thr-42".into(),
+            message_id: Some("msg-new-1".into()),
+            detail: "Reply sent".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["thread_id"], "thr-42");
+        assert_eq!(v["message_id"], "msg-new-1");
+        assert_eq!(v["detail"], "Reply sent");
     }
 }


### PR DESCRIPTION
## Summary

- Adds first-class `rune message thread` CLI surface with `list` and `reply` subcommands
- Closes the `thread` gap in the `message` family parity table (issue #74)
- Gateway client integration: `GET /messages/threads/{id}` and `POST /messages/threads/{id}/reply`
- Human + JSON output rendering via `MessageThreadListResponse` and `MessageThreadReplyResponse`

## What changed

| File | Change |
|------|--------|
| `cli.rs` | `MessageAction::Thread` variant + `MessageThreadAction` enum with `List` / `Reply` |
| `client.rs` | `message_thread_list()` and `message_thread_reply()` gateway methods |
| `output.rs` | `ThreadMessage`, `MessageThreadListResponse`, `MessageThreadReplyResponse` with Display impls |
| `lib.rs` | Execution wiring for `MessageThreadAction` through the run loop |

## Test plan

- [x] 6 CLI parse tests (list defaults, list with all args, list requires thread-id, reply with/without session, reply requires all required args)
- [x] 5 wiremock client tests (list with results, list empty, reply success, reply with session, reply gateway error)
- [x] 7 output render tests (list empty, list with messages, list single grammar, list JSON, reply success, reply failure, reply JSON)
- [x] 268/268 rune-cli tests pass
- [x] Zero clippy warnings