### PR TITLE
feat(cli): add `rune message read` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -510,6 +510,18 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Read/fetch a single message by ID from a channel adapter.
+    Read {
+        /// ID of the message to read.
+        #[arg(long)]
+        message_id: String,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: String,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
     /// Delete a message by ID from a channel adapter.
     Delete {
         /// ID of the message to delete.
@@ -2481,6 +2493,89 @@ mod tests {
             "rune",
             "message",
             "delete",
+            "--channel",
+            "telegram",
+        ])
+        .is_err());
+    }
+
+    // ── Message read (#74) ──────────────────────────────────────────
+
+    #[test]
+    fn parse_message_read() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "read",
+            "--message-id",
+            "msg-42",
+            "--channel",
+            "telegram",
+            "--session",
+            "sess-7",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Read {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-42");
+                assert_eq!(channel, "telegram");
+                assert_eq!(session.as_deref(), Some("sess-7"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_read_without_session() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "read",
+            "--message-id",
+            "msg-99",
+            "--channel",
+            "discord",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Read {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-99");
+                assert_eq!(channel, "discord");
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_read_requires_message_id_and_channel() {
+        assert!(Cli::try_parse_from(["rune", "message", "read"]).is_err());
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "read",
+            "--message-id",
+            "msg-1",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "read",
             "--channel",
             "telegram",
         ])

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1186,6 +1186,66 @@ impl GatewayClient {
         }
     }
 
+    /// `GET /messages/{id}` — read/fetch a single message by ID.
+    pub async fn message_read(
+        &self,
+        message_id: &str,
+        channel: &str,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageReadResponse> {
+        use crate::output::MessageReadResponse;
+
+        let mut params: Vec<(&str, &str)> = vec![("channel", channel)];
+        if let Some(s) = session {
+            params.push(("session", s));
+        }
+        let resp = self
+            .http
+            .get(self.url(&format!("/messages/{message_id}")))
+            .query(&params)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from GET /messages/{id}")?;
+            Ok(MessageReadResponse {
+                success: true,
+                message_id: v["id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                channel: v["channel"]
+                    .as_str()
+                    .unwrap_or(channel)
+                    .to_string(),
+                sender: v["sender"].as_str().map(ToString::to_string),
+                text: v["text"].as_str().map(ToString::to_string),
+                timestamp: v["timestamp"].as_str().map(ToString::to_string),
+                thread_id: v["thread_id"].as_str().map(ToString::to_string),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or("Message retrieved")
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageReadResponse {
+                success: false,
+                message_id: message_id.to_string(),
+                channel: channel.to_string(),
+                sender: None,
+                text: None,
+                timestamp: None,
+                thread_id: None,
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     /// `GET /messages/threads/{id}`
     pub async fn message_thread_list(
         &self,
@@ -2773,6 +2833,84 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let resp = client
             .message_delete("msg-missing", "telegram", None)
+            .await
+            .unwrap();
+        assert!(!resp.success);
+        assert!(resp.detail.contains("404"));
+        assert!(resp.detail.contains("Message not found"));
+    }
+
+    #[tokio::test]
+    async fn message_read_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/msg-42"))
+            .and(query_param("channel", "telegram"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-42",
+                "channel": "telegram",
+                "sender": "alice",
+                "text": "Hello world",
+                "timestamp": "2026-03-19T12:00:00Z",
+                "detail": "Message retrieved"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_read("msg-42", "telegram", None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-42");
+        assert_eq!(resp.channel, "telegram");
+        assert_eq!(resp.sender.as_deref(), Some("alice"));
+        assert_eq!(resp.text.as_deref(), Some("Hello world"));
+        assert_eq!(resp.timestamp.as_deref(), Some("2026-03-19T12:00:00Z"));
+        assert!(resp.thread_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn message_read_with_session_and_thread() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/msg-77"))
+            .and(query_param("channel", "discord"))
+            .and(query_param("session", "sess-5"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-77",
+                "channel": "discord",
+                "sender": "bob",
+                "text": "threaded message",
+                "timestamp": "2026-03-19T14:00:00Z",
+                "thread_id": "thr-10"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_read("msg-77", "discord", Some("sess-5"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-77");
+        assert_eq!(resp.thread_id.as_deref(), Some("thr-10"));
+    }
+
+    #[tokio::test]
+    async fn message_read_gateway_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/messages/msg-missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Message not found"))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_read("msg-missing", "telegram", None)
             .await
             .unwrap();
         assert!(!resp.success);

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1274,6 +1274,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Read {
+                message_id,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_read(&message_id, &channel, session.as_deref())
+                    .await?;
+                println!("{}", render(&result, format));
+            }
             MessageAction::Delete {
                 message_id,
                 channel,

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1889,6 +1889,35 @@ impl fmt::Display for MessageDeleteResponse {
     }
 }
 
+/// Response for `message read` — fetch a single message by ID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageReadResponse {
+    pub success: bool,
+    pub message_id: String,
+    pub channel: String,
+    pub sender: Option<String>,
+    pub text: Option<String>,
+    pub timestamp: Option<String>,
+    pub thread_id: Option<String>,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.success {
+            return write!(f, "✗ message {}: {}", self.message_id, self.detail);
+        }
+        let sender = self.sender.as_deref().unwrap_or("unknown");
+        let ts = self.timestamp.as_deref().unwrap_or("?");
+        let text = self.text.as_deref().unwrap_or("");
+        write!(f, "[{}] {} {sender}: {text}", self.channel, ts)?;
+        if let Some(ref tid) = self.thread_id {
+            write!(f, " (thread={tid})")?;
+        }
+        write!(f, " (id={})", self.message_id)
+    }
+}
+
 /// A single message within a thread listing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadMessage {
@@ -3205,6 +3234,100 @@ mod tests {
         assert_eq!(v["message_id"], "msg-42");
         assert_eq!(v["channel"], "telegram");
         assert_eq!(v["detail"], "Message deleted");
+    }
+
+    // ── MessageReadResponse ──────────────────────────────────────────
+
+    #[test]
+    fn render_message_read_success_human() {
+        let r = MessageReadResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            channel: "telegram".into(),
+            sender: Some("alice".into()),
+            text: Some("Hello world".into()),
+            timestamp: Some("2026-03-19T12:00:00Z".into()),
+            thread_id: None,
+            detail: "Message retrieved".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("[telegram]"));
+        assert!(out.contains("alice"));
+        assert!(out.contains("Hello world"));
+        assert!(out.contains("(id=msg-42)"));
+    }
+
+    #[test]
+    fn render_message_read_success_with_thread() {
+        let r = MessageReadResponse {
+            success: true,
+            message_id: "msg-77".into(),
+            channel: "discord".into(),
+            sender: Some("bob".into()),
+            text: Some("threaded msg".into()),
+            timestamp: Some("2026-03-19T14:00:00Z".into()),
+            thread_id: Some("thr-10".into()),
+            detail: "Message retrieved".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("(thread=thr-10)"));
+        assert!(out.contains("bob"));
+    }
+
+    #[test]
+    fn render_message_read_failure_human() {
+        let r = MessageReadResponse {
+            success: false,
+            message_id: "msg-404".into(),
+            channel: "telegram".into(),
+            sender: None,
+            text: None,
+            timestamp: None,
+            thread_id: None,
+            detail: "Gateway returned HTTP 404: not found".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.starts_with("✗"));
+        assert!(out.contains("msg-404"));
+        assert!(out.contains("404"));
+    }
+
+    #[test]
+    fn render_message_read_json() {
+        let r = MessageReadResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            channel: "telegram".into(),
+            sender: Some("alice".into()),
+            text: Some("Hello world".into()),
+            timestamp: Some("2026-03-19T12:00:00Z".into()),
+            thread_id: None,
+            detail: "Message retrieved".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v["success"].as_bool().unwrap());
+        assert_eq!(v["message_id"], "msg-42");
+        assert_eq!(v["channel"], "telegram");
+        assert_eq!(v["sender"], "alice");
+        assert_eq!(v["text"], "Hello world");
+    }
+
+    #[test]
+    fn render_message_read_success_no_sender() {
+        let r = MessageReadResponse {
+            success: true,
+            message_id: "msg-50".into(),
+            channel: "slack".into(),
+            sender: None,
+            text: Some("system message".into()),
+            timestamp: None,
+            thread_id: None,
+            detail: "Message retrieved".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("unknown"));
+        assert!(out.contains("system message"));
     }
 
     // ── MessageThreadListResponse ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `rune message read --message-id <ID> --channel <CH> [--session <S>]` — fetch a single message by ID from the gateway via `GET /messages/{id}`
- `MessageAction::Read` variant, `GatewayClient::message_read()`, `MessageReadResponse` output type with human + JSON rendering
- 11 new tests (3 CLI parse, 5 output render, 3 wiremock client); 279/279 pass, zero clippy warnings

## Test plan
- [x] `cargo test -p rune-cli --quiet` — 279/279 pass
- [x] `cargo clippy -p rune-cli -- -D warnings` — zero warnings
- [ ] Manual smoke test against a running gateway (optional)