### PR TITLE
feat(cli): add `rune message edit` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -552,6 +552,21 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Edit an existing message's text content.
+    Edit {
+        /// ID of the message to edit.
+        #[arg(long)]
+        message_id: String,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: String,
+        /// New message body text.
+        #[arg(long)]
+        text: String,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
     /// Pin or unpin a message in a channel.
     Pin {
         /// ID of the message to pin or unpin.
@@ -2326,6 +2341,113 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_message_edit() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "edit",
+            "--message-id",
+            "msg-42",
+            "--channel",
+            "telegram",
+            "--text",
+            "Updated text",
+            "--session",
+            "sess-7",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Edit {
+                        message_id,
+                        channel,
+                        text,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-42");
+                assert_eq!(channel, "telegram");
+                assert_eq!(text, "Updated text");
+                assert_eq!(session.as_deref(), Some("sess-7"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_edit_without_session() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "edit",
+            "--message-id",
+            "msg-99",
+            "--channel",
+            "discord",
+            "--text",
+            "Fixed typo",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Edit {
+                        message_id,
+                        channel,
+                        text,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-99");
+                assert_eq!(channel, "discord");
+                assert_eq!(text, "Fixed typo");
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_edit_requires_message_id_channel_and_text() {
+        // Missing --text
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "edit",
+            "--message-id",
+            "msg-1",
+            "--channel",
+            "telegram",
+        ])
+        .is_err());
+        // Missing --channel
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "edit",
+            "--message-id",
+            "msg-1",
+            "--text",
+            "hello",
+        ])
+        .is_err());
+        // Missing --message-id
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "edit",
+            "--channel",
+            "telegram",
+            "--text",
+            "hello",
+        ])
+        .is_err());
+        // Missing all
+        assert!(Cli::try_parse_from(["rune", "message", "edit"]).is_err());
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1076,6 +1076,59 @@ impl GatewayClient {
     }
 
     /// `POST /messages/pin`
+    /// `PATCH /messages/{id}` — edit the text content of an existing message.
+    pub async fn message_edit(
+        &self,
+        message_id: &str,
+        channel: &str,
+        text: &str,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageEditResponse> {
+        use crate::output::MessageEditResponse;
+
+        let mut body = json!({
+            "channel": channel,
+            "text": text,
+        });
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .patch(self.url(&format!("/messages/{message_id}")))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from PATCH /messages/{id}")?;
+            Ok(MessageEditResponse {
+                success: true,
+                message_id: v["id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                channel: channel.to_string(),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or("Message edited")
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageEditResponse {
+                success: false,
+                message_id: message_id.to_string(),
+                channel: channel.to_string(),
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     pub async fn message_pin(
         &self,
         message_id: &str,
@@ -2667,6 +2720,79 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let resp = client
             .message_react("msg-missing", "👍", false, None, None)
+            .await
+            .unwrap();
+        assert!(!resp.success);
+        assert!(resp.detail.contains("404"));
+        assert!(resp.detail.contains("Message not found"));
+    }
+
+    #[tokio::test]
+    async fn message_edit_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/messages/msg-42"))
+            .and(body_json(json!({
+                "channel": "telegram",
+                "text": "Updated text"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-42",
+                "detail": "Message edited"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_edit("msg-42", "telegram", "Updated text", None)
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-42");
+        assert_eq!(resp.channel, "telegram");
+        assert_eq!(resp.detail, "Message edited");
+    }
+
+    #[tokio::test]
+    async fn message_edit_with_session() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/messages/msg-99"))
+            .and(body_json(json!({
+                "channel": "discord",
+                "text": "Fixed typo",
+                "session": "sess-7"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg-99",
+                "detail": "Message edited"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_edit("msg-99", "discord", "Fixed typo", Some("sess-7"))
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message_id, "msg-99");
+        assert_eq!(resp.channel, "discord");
+    }
+
+    #[tokio::test]
+    async fn message_edit_gateway_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/messages/msg-missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Message not found"))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .message_edit("msg-missing", "telegram", "new text", None)
             .await
             .unwrap();
         assert!(!resp.success);

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1258,6 +1258,22 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::Edit {
+                message_id,
+                channel,
+                text,
+                session,
+            } => {
+                let result = client
+                    .message_edit(
+                        &message_id,
+                        &channel,
+                        &text,
+                        session.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
             MessageAction::Pin {
                 message_id,
                 unpin,

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1869,6 +1869,26 @@ impl fmt::Display for MessagePinResponse {
     }
 }
 
+/// Result of editing a message's text content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageEditResponse {
+    pub success: bool,
+    pub message_id: String,
+    pub channel: String,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageEditResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(
+            f,
+            "{icon} message {} on {}: {}",
+            self.message_id, self.channel, self.detail,
+        )
+    }
+}
+
 /// Result of deleting a message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageDeleteResponse {
@@ -3117,6 +3137,54 @@ mod tests {
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓ added fire on message msg-1"));
         assert!(!out.contains(":"));
+    }
+
+    // ── MessageEditResponse ──────────────────────────────────────────
+
+    #[test]
+    fn message_edit_response_human_success() {
+        let r = MessageEditResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            channel: "telegram".into(),
+            detail: "Message edited".into(),
+        };
+        let out = r.to_string();
+        assert!(out.contains("✓"));
+        assert!(out.contains("msg-42"));
+        assert!(out.contains("telegram"));
+        assert!(out.contains("Message edited"));
+    }
+
+    #[test]
+    fn message_edit_response_human_failure() {
+        let r = MessageEditResponse {
+            success: false,
+            message_id: "msg-99".into(),
+            channel: "discord".into(),
+            detail: "Gateway returned HTTP 404: Message not found".into(),
+        };
+        let out = r.to_string();
+        assert!(out.contains("✗"));
+        assert!(out.contains("msg-99"));
+        assert!(out.contains("discord"));
+        assert!(out.contains("404"));
+    }
+
+    #[test]
+    fn message_edit_response_json() {
+        let r = MessageEditResponse {
+            success: true,
+            message_id: "msg-42".into(),
+            channel: "telegram".into(),
+            detail: "Message edited".into(),
+        };
+        let json_out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&json_out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["message_id"], "msg-42");
+        assert_eq!(v["channel"], "telegram");
+        assert_eq!(v["detail"], "Message edited");
     }
 
     // ── MessagePinResponse ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `rune message edit --message-id <id> --channel <ch> --text <new>` to the CLI surface, closing the last CRUD gap in the `message` family for #74.
- `MessageAction::Edit` variant with required `--message-id`, `--channel`, `--text` and optional `--session`.
- `GatewayClient::message_edit` calls `PATCH /messages/{id}` with channel, text, and optional session.
- `MessageEditResponse` struct with human-readable (`✓`/`✗`) and JSON output.
- 9 new tests: 3 CLI parse validation, 3 client wiremock, 3 output Display/JSON.

## Test plan
- [x] `cargo check -p rune-cli` — clean
- [x] `cargo test -p rune-cli` — 288 tests pass (0 failures)
- [x] All 3 CLI parse tests validate required/optional args and error cases
- [x] All 3 wiremock tests cover success, session passthrough, and gateway error
- [x] All 3 output tests cover human success, human failure, and JSON rendering