### PR TITLE
feat(config): first-use acknowledgment for bypass modes (#64)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -216,17 +216,21 @@ fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
         "starting rune gateway"
     );
 
-    let unrestricted = config.approval.mode.is_yolo() || !config.security.sandbox;
-    if unrestricted {
-        let warning = if config.approval.mode.is_yolo() && !config.security.sandbox {
-            "WARNING: Rune is starting in unrestricted mode (--yolo + --no-sandbox). All approvals are auto-bypassed and sandbox boundaries are disabled. Use only in trusted environments."
-        } else if config.approval.mode.is_yolo() {
-            "WARNING: Rune is starting with approval bypass enabled (--yolo). Use only in trusted environments."
+    // First-use vs. acknowledged bypass warning (issue #64).
+    if let Some(posture) = rune_config::BypassPosture::detect(config) {
+        let ack = rune_config::BypassAcknowledgment::from_home()
+            .unwrap_or_else(|| {
+                rune_config::BypassAcknowledgment::new(std::path::Path::new("/tmp/.rune-config"))
+            });
+
+        if ack.is_acknowledged() {
+            let reminder = posture.acknowledged_reminder();
+            info!(bypass = reminder, "trusted-environment bypass active (previously acknowledged)");
         } else {
-            "WARNING: Rune is starting with sandbox disabled (--no-sandbox). Workspace boundary enforcement is off. Use only in trusted environments."
-        };
-        eprintln!("{warning}");
-        warn!(warning = warning, "trusted-environment bypass active");
+            let warning = posture.first_use_warning();
+            eprintln!("{warning}");
+            warn!(warning = %warning, "trusted-environment bypass active — NOT YET ACKNOWLEDGED");
+        }
     }
 }
 

--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -49,6 +49,14 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_sandbox: bool,
 
+    /// Skip the interactive first-use confirmation prompt for bypass modes.
+    ///
+    /// When `--yolo` or `--no-sandbox` is used for the first time, Rune
+    /// normally requires an interactive acknowledgment.  Pass `--accept-risk`
+    /// to auto-acknowledge (useful in CI/scripts).
+    #[arg(long, global = true)]
+    pub accept_risk: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -2038,6 +2046,26 @@ mod tests {
         // clap global flags can appear before or after the subcommand.
         let cli = Cli::try_parse_from(["rune", "gateway", "status", "--yolo"]).unwrap();
         assert!(cli.yolo);
+    }
+
+    #[test]
+    fn parse_accept_risk_flag() {
+        let cli = Cli::try_parse_from(["rune", "--yolo", "--accept-risk", "status"]).unwrap();
+        assert!(cli.yolo);
+        assert!(cli.accept_risk);
+    }
+
+    #[test]
+    fn accept_risk_defaults_to_false() {
+        let cli = Cli::try_parse_from(["rune", "--yolo", "status"]).unwrap();
+        assert!(!cli.accept_risk);
+    }
+
+    #[test]
+    fn accept_risk_works_without_bypass_flags() {
+        let cli = Cli::try_parse_from(["rune", "--accept-risk", "status"]).unwrap();
+        assert!(cli.accept_risk);
+        assert!(!cli.yolo);
     }
 
     // ── Message family (#74) ─────────────────────────────────────────

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -777,9 +777,71 @@ async fn init_workspace(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Check bypass acknowledgment and prompt for first-use confirmation when
+/// `--yolo` or `--no-sandbox` is active.  Returns `Ok(())` when the operator
+/// has acknowledged (or `--accept-risk` was passed), or `Err` if they decline.
+fn confirm_bypass_if_needed(cli: &Cli) -> Result<()> {
+    use rune_config::{BypassAcknowledgment, BypassPosture};
+    use std::io::{BufRead, IsTerminal, Write};
+
+    // Build a minimal config to detect the posture.  The env vars have
+    // already been set by `apply_global_cli_environment`.
+    let mut probe = rune_config::AppConfig::default();
+    probe.apply_cli_overrides(cli.yolo, cli.no_sandbox);
+
+    let posture = match BypassPosture::detect(&probe) {
+        Some(p) => p,
+        None => return Ok(()), // standard mode, nothing to confirm
+    };
+
+    let ack = BypassAcknowledgment::from_home()
+        .unwrap_or_else(|| BypassAcknowledgment::new(std::path::Path::new("/tmp/.rune-config")));
+
+    if ack.is_acknowledged() {
+        // Already acknowledged — emit a brief reminder on stderr.
+        eprintln!("{}", posture.acknowledged_reminder());
+        return Ok(());
+    }
+
+    // First use: show the full warning.
+    eprintln!("{}", posture.first_use_warning());
+
+    if cli.accept_risk {
+        // Non-interactive acknowledgment (CI/scripts).
+        eprintln!("--accept-risk passed; acknowledging bypass risk automatically.");
+        ack.record().ok(); // best-effort persistence
+        return Ok(());
+    }
+
+    // Interactive confirmation — only if stdin is a TTY.
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "Bypass mode requires acknowledgment. \
+             Pass --accept-risk in non-interactive contexts."
+        );
+    }
+
+    eprint!("Type YES to acknowledge and continue: ");
+    std::io::stderr().flush().ok();
+
+    let mut input = String::new();
+    std::io::stdin().lock().read_line(&mut input)?;
+
+    if input.trim() == "YES" {
+        ack.record().ok(); // best-effort persistence
+        Ok(())
+    } else {
+        anyhow::bail!("Bypass not acknowledged — aborting.");
+    }
+}
+
 /// Execute the parsed CLI command against the configured gateway and print output.
 pub async fn run(cli: Cli) -> Result<()> {
     apply_global_cli_environment(&cli);
+
+    // First-use bypass confirmation (issue #64).
+    confirm_bypass_if_needed(&cli)?;
+
     let format = OutputFormat::from_json_flag(cli.json);
     let client = GatewayClient::new(&cli.gateway_url);
 

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use figment::{
     Figment,
@@ -1113,6 +1114,127 @@ pub enum ConfigError {
     Load(#[from] Box<figment::Error>),
     #[error("path validation failed: {path} — {reason}")]
     PathValidation { path: String, reason: String },
+}
+
+// ── First-use bypass acknowledgment (issue #64) ─────────────────────
+
+/// Sentinel file name written to `config_dir` once the operator acknowledges
+/// the risks of running in an unrestricted startup posture.
+const BYPASS_ACK_SENTINEL: &str = ".yolo-acknowledged";
+
+/// Manages the persistent first-use acknowledgment for unrestricted bypass
+/// modes (`--yolo`, `--no-sandbox`).
+///
+/// When `--yolo` or `--no-sandbox` is used for the first time, the operator
+/// must explicitly confirm the risk.  After acknowledgment, a sentinel file
+/// is written so the warning is not repeated on subsequent starts.
+pub struct BypassAcknowledgment {
+    sentinel_path: PathBuf,
+}
+
+impl BypassAcknowledgment {
+    /// Create an acknowledgment tracker rooted in the given config directory.
+    pub fn new(config_dir: &Path) -> Self {
+        Self {
+            sentinel_path: config_dir.join(BYPASS_ACK_SENTINEL),
+        }
+    }
+
+    /// Resolve from `$HOME/.rune/config` (standalone default).
+    pub fn from_home() -> Option<Self> {
+        home_dir().map(|h| Self::new(&h.join(".rune").join("config")))
+    }
+
+    /// Whether the operator has previously acknowledged the bypass risk.
+    pub fn is_acknowledged(&self) -> bool {
+        self.sentinel_path.exists()
+    }
+
+    /// Record that the operator has acknowledged the bypass risk.
+    ///
+    /// Creates the parent directory if needed.  Returns `Ok(())` on success
+    /// or if the sentinel already exists.
+    pub fn record(&self) -> std::io::Result<()> {
+        if self.is_acknowledged() {
+            return Ok(());
+        }
+        if let Some(parent) = self.sentinel_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(
+            &self.sentinel_path,
+            format!(
+                "Bypass risk acknowledged at {:?}\n",
+                SystemTime::now()
+            ),
+        )
+    }
+
+    /// Remove a previously recorded acknowledgment.
+    ///
+    /// Useful for testing or when the operator wants to re-enable the
+    /// first-use warning.
+    pub fn revoke(&self) -> std::io::Result<()> {
+        if self.sentinel_path.exists() {
+            std::fs::remove_file(&self.sentinel_path)?;
+        }
+        Ok(())
+    }
+
+    /// Path to the sentinel file (exposed for diagnostics / testing).
+    pub fn sentinel_path(&self) -> &Path {
+        &self.sentinel_path
+    }
+}
+
+/// Describes the bypass posture for warning messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassPosture {
+    /// Both approval bypass and sandbox disabled.
+    FullUnrestricted,
+    /// Only approval bypass (--yolo).
+    YoloOnly,
+    /// Only sandbox disabled (--no-sandbox).
+    NoSandboxOnly,
+}
+
+impl BypassPosture {
+    /// Detect the active bypass posture from config, or `None` if standard.
+    pub fn detect(config: &AppConfig) -> Option<Self> {
+        match (config.approval.mode.is_yolo(), !config.security.sandbox) {
+            (true, true) => Some(Self::FullUnrestricted),
+            (true, false) => Some(Self::YoloOnly),
+            (false, true) => Some(Self::NoSandboxOnly),
+            (false, false) => None,
+        }
+    }
+
+    /// Full warning message shown on first use.
+    pub fn first_use_warning(self) -> &'static str {
+        match self {
+            Self::FullUnrestricted => "\
+WARNING: Rune is starting in unrestricted mode (--yolo + --no-sandbox).
+All tool approvals are auto-bypassed and sandbox boundaries are disabled.
+Only use this in trusted environments (local dev, air-gapped infra).",
+            Self::YoloOnly => "\
+WARNING: Rune is starting with approval bypass enabled (--yolo).
+All tool calls will be auto-approved without operator confirmation.
+Only use this in trusted environments.",
+            Self::NoSandboxOnly => "\
+WARNING: Rune is starting with sandbox disabled (--no-sandbox).
+Workspace boundary enforcement is off — agents can access the full filesystem.
+Only use this in trusted environments.",
+        }
+    }
+
+    /// Brief reminder shown on subsequent starts after acknowledgment.
+    pub fn acknowledged_reminder(self) -> &'static str {
+        match self {
+            Self::FullUnrestricted => "Bypass active: yolo + no-sandbox (previously acknowledged)",
+            Self::YoloOnly => "Bypass active: yolo mode (previously acknowledged)",
+            Self::NoSandboxOnly => "Bypass active: no-sandbox (previously acknowledged)",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2436,5 +2558,94 @@ mode = "auto-exec"
         // trust_spells is untouched by CLI flags
         assert!(config.security.trust_spells);
         assert_eq!(config.security.posture(), "unrestricted");
+    }
+
+    // ── Bypass acknowledgment tests (#64) ────────────────────────────
+
+    #[test]
+    fn bypass_ack_not_acknowledged_initially() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ack = BypassAcknowledgment::new(tmp.path());
+        assert!(!ack.is_acknowledged());
+    }
+
+    #[test]
+    fn bypass_ack_record_and_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ack = BypassAcknowledgment::new(tmp.path());
+        ack.record().unwrap();
+        assert!(ack.is_acknowledged());
+        // Sentinel file exists on disk.
+        assert!(ack.sentinel_path().exists());
+    }
+
+    #[test]
+    fn bypass_ack_record_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ack = BypassAcknowledgment::new(tmp.path());
+        ack.record().unwrap();
+        ack.record().unwrap(); // should not fail
+        assert!(ack.is_acknowledged());
+    }
+
+    #[test]
+    fn bypass_ack_revoke() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ack = BypassAcknowledgment::new(tmp.path());
+        ack.record().unwrap();
+        assert!(ack.is_acknowledged());
+        ack.revoke().unwrap();
+        assert!(!ack.is_acknowledged());
+    }
+
+    #[test]
+    fn bypass_ack_creates_parent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("deep").join("nested").join("config");
+        let ack = BypassAcknowledgment::new(&nested);
+        ack.record().unwrap();
+        assert!(ack.is_acknowledged());
+    }
+
+    // ── BypassPosture detection tests (#64) ──────────────────────────
+
+    #[test]
+    fn bypass_posture_detect_standard() {
+        let config = AppConfig::default();
+        assert!(BypassPosture::detect(&config).is_none());
+    }
+
+    #[test]
+    fn bypass_posture_detect_yolo_only() {
+        let mut config = AppConfig::default();
+        config.approval.mode = ApprovalMode::Yolo;
+        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::YoloOnly));
+    }
+
+    #[test]
+    fn bypass_posture_detect_no_sandbox_only() {
+        let mut config = AppConfig::default();
+        config.security.sandbox = false;
+        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::NoSandboxOnly));
+    }
+
+    #[test]
+    fn bypass_posture_detect_full_unrestricted() {
+        let mut config = AppConfig::default();
+        config.approval.mode = ApprovalMode::Yolo;
+        config.security.sandbox = false;
+        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::FullUnrestricted));
+    }
+
+    #[test]
+    fn bypass_posture_warning_messages_not_empty() {
+        for posture in [
+            BypassPosture::FullUnrestricted,
+            BypassPosture::YoloOnly,
+            BypassPosture::NoSandboxOnly,
+        ] {
+            assert!(!posture.first_use_warning().is_empty());
+            assert!(!posture.acknowledged_reminder().is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds **first-use confirmation semantics** for `--yolo` / `--no-sandbox` startup modes, closing the gap identified in issue #64's acceptance criteria: "First-use warning displayed once, not on every startup"
- `BypassAcknowledgment` persists a sentinel file (`~/.rune/config/.yolo-acknowledged`) after the operator confirms the risk
- `BypassPosture` enum provides structured detection, full first-use warnings, and brief post-acknowledgment reminders
- `--accept-risk` flag enables non-interactive acknowledgment for CI/scripting
- Gateway startup banner now distinguishes first-use (full warning) from subsequent starts (brief reminder)

## What this does NOT do (follow-on slices)

- Runtime tool-call auto-approval execution semantics
- Audit trail entries with `decision: auto-approved (yolo mode)`
- Channel-triggered session enforcement
- `--trust-spells` flag

## Test plan

- [x] 14 new tests across rune-config (acknowledgment persistence, posture detection) and rune-cli (flag parsing)
- [x] `cargo test -p rune-config` — 68 passed
- [x] `cargo test -p rune-cli` — 291 passed
- [x] `cargo clippy -p rune-config -p rune-cli --bin rune-gateway` — clean

Closes acceptance criteria item: "First-use warning displayed once, not on every startup" from #64.