### PR TITLE
feat(cli): add `rune agents list/show/status` subcommands (#73)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -91,6 +91,11 @@ pub enum Command {
         #[command(subcommand)]
         action: SessionsAction,
     },
+    /// Inspect and manage subagent sessions.
+    Agents {
+        #[command(subcommand)]
+        action: AgentsAction,
+    },
     /// Inspect configured channel adapters.
     Channels {
         #[command(subcommand)]
@@ -297,6 +302,29 @@ pub enum SessionsAction {
     /// Show the first-class status card for a specific session.
     Status {
         /// Session ID to inspect.
+        id: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AgentsAction {
+    /// List active subagent sessions.
+    List {
+        /// Only include agents active within the last N minutes.
+        #[arg(long = "active")]
+        active_minutes: Option<u64>,
+        /// Maximum number of agents to return.
+        #[arg(long, default_value_t = 100)]
+        limit: u64,
+    },
+    /// Show details for a specific subagent session.
+    Show {
+        /// Subagent session ID to inspect.
+        id: String,
+    },
+    /// Show the first-class status card for a specific subagent session.
+    Status {
+        /// Subagent session ID to inspect.
         id: String,
     },
 }
@@ -1731,6 +1759,63 @@ mod tests {
             Command::Sessions {
                 action: SessionsAction::Status { id },
             } => assert_eq!(id, "abc-123"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_agents_list() {
+        let cli = Cli::try_parse_from(["rune", "agents", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Agents {
+                action: AgentsAction::List {
+                    active_minutes: None,
+                    limit: 100
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_agents_list_with_filters() {
+        let cli = Cli::try_parse_from([
+            "rune", "agents", "list", "--active", "15", "--limit", "50",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Agents {
+                action:
+                    AgentsAction::List {
+                        active_minutes,
+                        limit,
+                    },
+            } => {
+                assert_eq!(active_minutes, Some(15));
+                assert_eq!(limit, 50);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_agents_show() {
+        let cli = Cli::try_parse_from(["rune", "agents", "show", "agent-abc"]).unwrap();
+        match &cli.command {
+            Command::Agents {
+                action: AgentsAction::Show { id },
+            } => assert_eq!(id, "agent-abc"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_agents_status() {
+        let cli = Cli::try_parse_from(["rune", "agents", "status", "agent-abc"]).unwrap();
+        match &cli.command {
+            Command::Agents {
+                action: AgentsAction::Status { id },
+            } => assert_eq!(id, "agent-abc"),
             other => panic!("unexpected command: {other:?}"),
         }
     }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -9,7 +9,8 @@ use serde_json::json;
 use toml_edit::{DocumentMut, Item, Table, Value};
 
 use crate::output::{
-    ActionResult, ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
+    ActionResult, AgentDetailResponse, AgentListResponse, AgentSummary,
+    ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport, SystemEventListResponse,
@@ -1749,6 +1750,89 @@ impl GatewayClient {
         }
     }
 
+    /// `GET /sessions?kind=subagent` — list subagent sessions.
+    pub async fn agents_list(
+        &self,
+        active_minutes: Option<u64>,
+        limit: u64,
+    ) -> Result<AgentListResponse> {
+        let mut query: Vec<(&str, String)> = vec![
+            ("kind", "subagent".to_string()),
+            ("limit", limit.to_string()),
+        ];
+        if let Some(active_minutes) = active_minutes {
+            query.push(("active", active_minutes.to_string()));
+        }
+
+        let resp = self
+            .http
+            .get(self.url("/sessions"))
+            .query(&query)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /sessions?kind=subagent")?;
+            let agents = body
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|v| AgentSummary {
+                    id: v["id"].as_str().unwrap_or("?").to_string(),
+                    status: v["status"].as_str().unwrap_or("unknown").to_string(),
+                    parent_session_id: v["requester_session_id"].as_str().map(String::from),
+                    created_at: v["created_at"].as_str().map(String::from),
+                    turn_count: v["turn_count"].as_u64().map(|n| n as u32),
+                    usage_prompt_tokens: v["usage_prompt_tokens"].as_u64(),
+                    usage_completion_tokens: v["usage_completion_tokens"].as_u64(),
+                    latest_model: v["latest_model"].as_str().map(String::from),
+                })
+                .collect();
+            Ok(AgentListResponse { agents })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /sessions/:id` — show subagent session detail (re-uses session endpoint).
+    pub async fn agents_show(&self, id: &str) -> Result<AgentDetailResponse> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/sessions/{id}")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /sessions/:id")?;
+            Ok(AgentDetailResponse {
+                id: v["id"].as_str().unwrap_or("?").to_string(),
+                status: v["status"].as_str().unwrap_or("unknown").to_string(),
+                parent_session_id: v["requester_session_id"]
+                    .as_str()
+                    .map(String::from),
+                created_at: v["created_at"].as_str().map(String::from),
+                turn_count: v["turn_count"].as_u64().map(|n| n as u32),
+                latest_model: v["latest_model"].as_str().map(String::from),
+                usage_prompt_tokens: v["usage_prompt_tokens"].as_u64(),
+                usage_completion_tokens: v["usage_completion_tokens"].as_u64(),
+                last_turn_started_at: v["last_turn_started_at"].as_str().map(String::from),
+                last_turn_ended_at: v["last_turn_ended_at"].as_str().map(String::from),
+            })
+        } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("Agent session '{id}' not found.");
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
     /// Run doctor checks: config validation + gateway connectivity + model provider reachability.
     pub async fn doctor(&self) -> Result<DoctorReport> {
         let mut checks = Vec::new();
@@ -2549,6 +2633,74 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let response = client.sessions_show("session-1").await.unwrap();
         assert_eq!(response.channel.as_deref(), Some("telegram:ops"));
+    }
+
+    #[tokio::test]
+    async fn agents_list_parses_subagent_sessions() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sessions"))
+            .and(query_param("kind", "subagent"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "sub-1",
+                    "kind": "subagent",
+                    "status": "running",
+                    "requester_session_id": "parent-abc",
+                    "turn_count": 2
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.agents_list(None, 100).await.unwrap();
+        assert_eq!(resp.agents.len(), 1);
+        assert_eq!(resp.agents[0].id, "sub-1");
+        assert_eq!(
+            resp.agents[0].parent_session_id.as_deref(),
+            Some("parent-abc")
+        );
+    }
+
+    #[tokio::test]
+    async fn agents_show_parses_detail() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sessions/sub-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "sub-1",
+                "kind": "subagent",
+                "status": "running",
+                "requester_session_id": "parent-abc",
+                "created_at": "2026-03-19T00:00:00Z",
+                "turn_count": 2,
+                "latest_model": "gpt-5",
+                "usage_prompt_tokens": 100,
+                "usage_completion_tokens": 50
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.agents_show("sub-1").await.unwrap();
+        assert_eq!(resp.id, "sub-1");
+        assert_eq!(resp.parent_session_id.as_deref(), Some("parent-abc"));
+        assert_eq!(resp.latest_model.as_deref(), Some("gpt-5"));
+    }
+
+    #[tokio::test]
+    async fn agents_show_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sessions/nonexistent"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let err = client.agents_show("nonexistent").await.unwrap_err();
+        assert!(err.to_string().contains("not found"));
     }
 
     #[test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -23,8 +23,8 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 
 pub use cli::Cli;
 use cli::{
-    ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell, ConfigAction,
-    CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
+    AgentsAction, ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell,
+    ConfigAction, CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
     MessageTagAction, MessageThreadAction, MessageVoiceAction, ModelsAction, RemindersAction,
     SessionsAction,
     SystemAction, SystemEventAction, SystemHeartbeatAction,
@@ -1098,6 +1098,23 @@ pub async fn run(cli: Cli) -> Result<()> {
                 println!("{}", render(&result, format));
             }
             SessionsAction::Status { id } => {
+                let result = client.session_status(&id).await?;
+                println!("{}", render(&result, format));
+            }
+        },
+        Command::Agents { action } => match action {
+            AgentsAction::List {
+                active_minutes,
+                limit,
+            } => {
+                let result = client.agents_list(active_minutes, limit).await?;
+                println!("{}", render(&result, format));
+            }
+            AgentsAction::Show { id } => {
+                let result = client.agents_show(&id).await?;
+                println!("{}", render(&result, format));
+            }
+            AgentsAction::Status { id } => {
                 let result = client.session_status(&id).await?;
                 println!("{}", render(&result, format));
             }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -197,6 +197,104 @@ impl fmt::Display for SessionDetailResponse {
     }
 }
 
+/// Subagent summary for `rune agents list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSummary {
+    pub id: String,
+    pub status: String,
+    pub parent_session_id: Option<String>,
+    pub created_at: Option<String>,
+    pub turn_count: Option<u32>,
+    pub usage_prompt_tokens: Option<u64>,
+    pub usage_completion_tokens: Option<u64>,
+    pub latest_model: Option<String>,
+}
+
+impl fmt::Display for AgentSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} [{}]", self.id, self.status)?;
+        if let Some(ref parent) = self.parent_session_id {
+            write!(f, " parent={parent}")?;
+        }
+        if let Some(turns) = self.turn_count {
+            write!(f, " turns={turns}")?;
+        }
+        if let Some(ref model) = self.latest_model {
+            write!(f, " model={model}")?;
+        }
+        if let (Some(prompt), Some(completion)) =
+            (self.usage_prompt_tokens, self.usage_completion_tokens)
+        {
+            write!(f, " tokens={}/{}", prompt, completion)?;
+        }
+        Ok(())
+    }
+}
+
+/// Agent list response for `rune agents list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentListResponse {
+    pub agents: Vec<AgentSummary>,
+}
+
+impl fmt::Display for AgentListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.agents.is_empty() {
+            return write!(f, "No active subagent sessions.");
+        }
+        for a in &self.agents {
+            writeln!(f, "  {a}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Detailed subagent view for `rune agents show`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDetailResponse {
+    pub id: String,
+    pub status: String,
+    pub parent_session_id: Option<String>,
+    pub created_at: Option<String>,
+    pub turn_count: Option<u32>,
+    pub latest_model: Option<String>,
+    pub usage_prompt_tokens: Option<u64>,
+    pub usage_completion_tokens: Option<u64>,
+    pub last_turn_started_at: Option<String>,
+    pub last_turn_ended_at: Option<String>,
+}
+
+impl fmt::Display for AgentDetailResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Agent: {}", self.id)?;
+        writeln!(f, "  Status:  {}", self.status)?;
+        if let Some(ref parent) = self.parent_session_id {
+            writeln!(f, "  Parent:  {parent}")?;
+        }
+        if let Some(ref t) = self.created_at {
+            writeln!(f, "  Created: {t}")?;
+        }
+        if let Some(n) = self.turn_count {
+            writeln!(f, "  Turns:   {n}")?;
+        }
+        if let Some(ref model) = self.latest_model {
+            writeln!(f, "  Model:   {model}")?;
+        }
+        if let (Some(prompt), Some(completion)) =
+            (self.usage_prompt_tokens, self.usage_completion_tokens)
+        {
+            writeln!(f, "  Tokens:  {prompt}/{completion}")?;
+        }
+        if let Some(ref started_at) = self.last_turn_started_at {
+            writeln!(f, "  Last started: {started_at}")?;
+        }
+        if let Some(ref ended_at) = self.last_turn_ended_at {
+            writeln!(f, "  Last ended:   {ended_at}")?;
+        }
+        Ok(())
+    }
+}
+
 /// First-class `/status` / `session_status` parity card for an individual session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionStatusCard {
@@ -2285,6 +2383,54 @@ mod tests {
     fn render_session_list_empty() {
         let l = SessionListResponse { sessions: vec![] };
         assert_eq!(render(&l, OutputFormat::Human), "No active sessions.");
+    }
+
+    #[test]
+    fn render_agent_list_empty() {
+        let l = AgentListResponse { agents: vec![] };
+        assert_eq!(
+            render(&l, OutputFormat::Human),
+            "No active subagent sessions."
+        );
+    }
+
+    #[test]
+    fn render_agent_list_with_entry() {
+        let l = AgentListResponse {
+            agents: vec![AgentSummary {
+                id: "sub-1".into(),
+                status: "running".into(),
+                parent_session_id: Some("parent-abc".into()),
+                created_at: Some("2026-03-19T00:00:00Z".into()),
+                turn_count: Some(3),
+                usage_prompt_tokens: Some(100),
+                usage_completion_tokens: Some(50),
+                latest_model: Some("gpt-5".into()),
+            }],
+        };
+        let out = render(&l, OutputFormat::Human);
+        assert!(out.contains("sub-1"));
+        assert!(out.contains("parent=parent-abc"));
+        assert!(out.contains("turns=3"));
+    }
+
+    #[test]
+    fn render_agent_detail() {
+        let detail = AgentDetailResponse {
+            id: "sub-1".into(),
+            status: "running".into(),
+            parent_session_id: Some("parent-abc".into()),
+            created_at: Some("2026-03-19T00:00:00Z".into()),
+            turn_count: Some(3),
+            latest_model: Some("gpt-5".into()),
+            usage_prompt_tokens: Some(100),
+            usage_completion_tokens: Some(50),
+            last_turn_started_at: None,
+            last_turn_ended_at: None,
+        };
+        let out = render(&detail, OutputFormat::Human);
+        assert!(out.contains("Agent: sub-1"));
+        assert!(out.contains("Parent:  parent-abc"));
     }
 
     #[test]

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -481,6 +481,7 @@ pub struct SessionsListQuery {
     #[serde(rename = "active")]
     pub active_minutes: Option<u64>,
     pub channel: Option<String>,
+    pub kind: Option<String>,
     pub limit: Option<usize>,
 }
 
@@ -854,7 +855,10 @@ pub struct SessionResponse {
 #[derive(Serialize)]
 pub struct SessionListItem {
     pub id: String,
+    pub kind: String,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requester_session_id: Option<String>,
     pub channel: Option<String>,
     pub created_at: String,
     pub turn_count: u32,
@@ -874,6 +878,7 @@ pub async fn list_sessions(
         .active_minutes
         .map(|minutes| Utc::now() - chrono::Duration::minutes(minutes as i64));
     let channel_filter = query.channel.as_deref();
+    let kind_filter = query.kind.as_deref();
 
     let rows = state
         .session_repo
@@ -884,6 +889,11 @@ pub async fn list_sessions(
     let mut items = Vec::new();
     for row in rows
         .into_iter()
+        .filter(|row| {
+            kind_filter
+                .map(|kind| row.kind.eq_ignore_ascii_case(kind))
+                .unwrap_or(true)
+        })
         .filter(|row| {
             channel_filter
                 .map(|channel| row.channel_ref.as_deref() == Some(channel))
@@ -903,7 +913,9 @@ pub async fn list_sessions(
         let aggregate = aggregate_turns(&turns);
         items.push(SessionListItem {
             id: row.id.to_string(),
+            kind: row.kind,
             status: row.status,
+            requester_session_id: row.requester_session_id.map(|id| id.to_string()),
             channel: row.channel_ref,
             created_at: row.created_at.to_rfc3339(),
             turn_count: aggregate.turn_count,

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4688,6 +4688,101 @@ async fn list_sessions_filters_by_channel_and_activity() {
     assert_eq!(items[0]["channel"], "telegram");
 }
 
+// ── Agents (subagent kind filter) tests ───────────────────────────────────────
+
+#[tokio::test]
+async fn list_sessions_filters_by_kind_subagent() {
+    let app = build_test_app(None);
+
+    // Create a direct session.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"kind":"direct"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let parent_json = body_json(response).await;
+    let parent_id = parent_json["id"].as_str().unwrap().to_string();
+
+    // Create a subagent session linked to the parent.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "kind": "subagent",
+                        "requester_session_id": parent_id,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // List all sessions (should return 2).
+    let response = app
+        .clone()
+        .oneshot(Request::get("/sessions").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let all_sessions = body_json(response).await;
+    assert_eq!(all_sessions.as_array().unwrap().len(), 2);
+
+    // Filter by kind=subagent (should return 1).
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/sessions?kind=subagent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["kind"], "subagent");
+    assert!(items[0]["requester_session_id"].is_string());
+}
+
+#[tokio::test]
+async fn list_sessions_includes_kind_field() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"kind":"direct"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(Request::get("/sessions").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["kind"], "direct");
+}
+
 // ── Reminder route tests ──────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `rune agents list`, `rune agents show <id>`, and `rune agents status <id>` CLI subcommands that provide first-class inspection of subagent sessions
- Adds `kind` query parameter to `GET /sessions` for server-side session type filtering
- Surfaces `kind` and `requester_session_id` (parent linkage) in `SessionListItem` API responses
- Introduces `AgentSummary`, `AgentListResponse`, `AgentDetailResponse` output types with parent session display

This is the narrowest useful slice of #73 — it materially advances the acceptance criterion: *"Operator can inspect full delegation tree"* and *"`rune agents list` shows active agent sessions"*.

## Test plan

- [x] CLI parse tests for `agents list`, `agents list --active 15 --limit 50`, `agents show`, `agents status`
- [x] Client mock tests: `agents_list_parses_subagent_sessions`, `agents_show_parses_detail`, `agents_show_not_found`
- [x] Gateway route integration tests: `list_sessions_filters_by_kind_subagent`, `list_sessions_includes_kind_field`
- [x] Output display tests: `render_agent_list_empty`, `render_agent_list_with_entry`, `render_agent_detail`
- [x] `cargo check --workspace` clean
- [x] All 314 rune-cli tests pass
- [x] All gateway route tests pass

## Follow-on risks

- `agents status` re-uses `session_status` — a dedicated subagent status card with parent/child tree view is a follow-on
- spawn/steer/kill semantics are not in scope here (next slices of #73)
- No `agents tree` command yet for full delegation tree visualization

Closes no issue (partial progress on #73).