### PR TITLE
feat(cli): add session inspect parity — kind/parent filters, tree view (#73)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -282,7 +282,7 @@ pub enum CronAction {
 
 #[derive(Debug, Subcommand)]
 pub enum SessionsAction {
-    /// List sessions with optional activity/channel filters.
+    /// List sessions with optional activity/channel/kind filters.
     List {
         /// Only include sessions active within the last N minutes.
         #[arg(long = "active")]
@@ -290,6 +290,12 @@ pub enum SessionsAction {
         /// Only include sessions for the given channel reference.
         #[arg(long)]
         channel: Option<String>,
+        /// Filter by session kind (e.g. "direct", "subagent", "scheduled").
+        #[arg(long)]
+        kind: Option<String>,
+        /// Only show children of this parent/requester session ID.
+        #[arg(long)]
+        parent: Option<String>,
         /// Maximum number of sessions to return.
         #[arg(long, default_value_t = 100)]
         limit: u64,
@@ -302,6 +308,11 @@ pub enum SessionsAction {
     /// Show the first-class status card for a specific session.
     Status {
         /// Session ID to inspect.
+        id: String,
+    },
+    /// Show the delegation tree rooted at a session (parent → children → grandchildren).
+    Tree {
+        /// Session ID to use as tree root.
         id: String,
     },
 }
@@ -1698,16 +1709,25 @@ mod tests {
     #[test]
     fn parse_sessions_list() {
         let cli = Cli::try_parse_from(["rune", "sessions", "list"]).unwrap();
-        assert!(matches!(
-            cli.command,
+        match cli.command {
             Command::Sessions {
-                action: SessionsAction::List {
-                    active_minutes: None,
-                    channel: None,
-                    limit: 100
-                }
+                action:
+                    SessionsAction::List {
+                        active_minutes,
+                        channel,
+                        kind,
+                        parent,
+                        limit,
+                    },
+            } => {
+                assert_eq!(active_minutes, None);
+                assert_eq!(channel, None);
+                assert_eq!(kind, None);
+                assert_eq!(parent, None);
+                assert_eq!(limit, 100);
             }
-        ));
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 
     #[test]
@@ -1731,11 +1751,40 @@ mod tests {
                         active_minutes,
                         channel,
                         limit,
+                        ..
                     },
             } => {
                 assert_eq!(active_minutes, Some(30));
                 assert_eq!(channel.as_deref(), Some("telegram"));
                 assert_eq!(limit, 25);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sessions_list_kind_filter() {
+        let cli =
+            Cli::try_parse_from(["rune", "sessions", "list", "--kind", "subagent"]).unwrap();
+        match cli.command {
+            Command::Sessions {
+                action: SessionsAction::List { kind, .. },
+            } => {
+                assert_eq!(kind.as_deref(), Some("subagent"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sessions_list_parent_filter() {
+        let cli =
+            Cli::try_parse_from(["rune", "sessions", "list", "--parent", "abc-123"]).unwrap();
+        match cli.command {
+            Command::Sessions {
+                action: SessionsAction::List { parent, .. },
+            } => {
+                assert_eq!(parent.as_deref(), Some("abc-123"));
             }
             other => panic!("unexpected command: {other:?}"),
         }
@@ -1758,6 +1807,17 @@ mod tests {
         match &cli.command {
             Command::Sessions {
                 action: SessionsAction::Status { id },
+            } => assert_eq!(id, "abc-123"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sessions_tree() {
+        let cli = Cli::try_parse_from(["rune", "sessions", "tree", "abc-123"]).unwrap();
+        match &cli.command {
+            Command::Sessions {
+                action: SessionsAction::Tree { id },
             } => assert_eq!(id, "abc-123"),
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -17,7 +17,8 @@ use crate::output::{
     GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
     HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
     MessageSearchHit, MessageSearchResponse, MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
-    SessionListResponse, SessionStatusCard, SessionSummary, StatusResponse,
+    SessionListResponse, SessionStatusCard, SessionSummary, SessionTreeNode,
+    SessionTreeResponse, StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -337,7 +338,7 @@ impl GatewayClient {
 
     /// Aggregate persisted session-turn token usage. Monetary cost is intentionally not derived yet.
     pub async fn gateway_usage_cost(&self) -> Result<GatewayUsageCostResponse> {
-        let sessions = self.sessions_list(None, None, 500).await?;
+        let sessions = self.sessions_list(None, None, None, None, 500).await?;
         let mut total_turns = 0usize;
         let mut prompt_tokens = 0u64;
         let mut completion_tokens = 0u64;
@@ -1652,6 +1653,8 @@ impl GatewayClient {
         &self,
         active_minutes: Option<u64>,
         channel: Option<&str>,
+        kind: Option<&str>,
+        parent: Option<&str>,
         limit: u64,
     ) -> Result<SessionListResponse> {
         let mut query: Vec<(&str, String)> = vec![("limit", limit.to_string())];
@@ -1660,6 +1663,12 @@ impl GatewayClient {
         }
         if let Some(channel) = channel {
             query.push(("channel", channel.to_string()));
+        }
+        if let Some(kind) = kind {
+            query.push(("kind", kind.to_string()));
+        }
+        if let Some(parent) = parent {
+            query.push(("parent", parent.to_string()));
         }
 
         let resp = self
@@ -1679,8 +1688,10 @@ impl GatewayClient {
                 .iter()
                 .map(|v| SessionSummary {
                     id: v["id"].as_str().unwrap_or("?").to_string(),
+                    kind: v["kind"].as_str().unwrap_or("direct").to_string(),
                     status: v["status"].as_str().unwrap_or("unknown").to_string(),
                     channel: v["channel"].as_str().map(String::from),
+                    requester_session_id: v["requester_session_id"].as_str().map(String::from),
                     created_at: v["created_at"].as_str().map(String::from),
                     turn_count: v["turn_count"].as_u64().map(|n| n as u32),
                     usage_prompt_tokens: v["usage_prompt_tokens"].as_u64(),
@@ -1710,11 +1721,13 @@ impl GatewayClient {
                 .context("invalid JSON from /sessions/:id")?;
             Ok(SessionDetailResponse {
                 id: v["id"].as_str().unwrap_or("?").to_string(),
+                kind: v["kind"].as_str().unwrap_or("direct").to_string(),
                 status: v["status"].as_str().unwrap_or("unknown").to_string(),
                 channel: v["channel"]
                     .as_str()
                     .map(String::from)
                     .or_else(|| v["channel_ref"].as_str().map(String::from)),
+                requester_session_id: v["requester_session_id"].as_str().map(String::from),
                 created_at: v["created_at"].as_str().map(String::from),
                 turn_count: v["turn_count"].as_u64().map(|n| n as u32),
                 latest_model: v["latest_model"].as_str().map(String::from),
@@ -1828,6 +1841,28 @@ impl GatewayClient {
             })
         } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
             bail!("Agent session '{id}' not found.");
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /sessions/:id/tree`
+    pub async fn sessions_tree(&self, id: &str) -> Result<SessionTreeResponse> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/sessions/{id}/tree")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let root: SessionTreeNode = resp
+                .json()
+                .await
+                .context("invalid JSON from /sessions/:id/tree")?;
+            Ok(SessionTreeResponse { root })
+        } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("Session '{id}' not found.");
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2556,7 +2591,7 @@ mod tests {
             .await;
 
         let client = GatewayClient::new(&server.uri());
-        let resp = client.sessions_list(None, None, 100).await.unwrap();
+        let resp = client.sessions_list(None, None, None, None, 100).await.unwrap();
         assert_eq!(resp.sessions.len(), 2);
         assert_eq!(resp.sessions[0].id, "s1");
         assert_eq!(resp.sessions[1].channel, None);

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -927,7 +927,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             let gateway = client.status().await?;
             let health = client.health().await?;
             let cron = client.cron_status().await?;
-            let sessions = client.sessions_list(None, None, 5).await?;
+            let sessions = client.sessions_list(None, None, None, None, 5).await?;
             let channels = channel_details();
             let models = model_provider_details();
             let memory = memory::status().await?;
@@ -1086,10 +1086,18 @@ pub async fn run(cli: Cli) -> Result<()> {
             SessionsAction::List {
                 active_minutes,
                 channel,
+                kind,
+                parent,
                 limit,
             } => {
                 let result = client
-                    .sessions_list(active_minutes, channel.as_deref(), limit)
+                    .sessions_list(
+                        active_minutes,
+                        channel.as_deref(),
+                        kind.as_deref(),
+                        parent.as_deref(),
+                        limit,
+                    )
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1099,6 +1107,10 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
             SessionsAction::Status { id } => {
                 let result = client.session_status(&id).await?;
+                println!("{}", render(&result, format));
+            }
+            SessionsAction::Tree { id } => {
+                let result = client.sessions_tree(&id).await?;
                 println!("{}", render(&result, format));
             }
         },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -103,8 +103,11 @@ impl fmt::Display for DoctorReport {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionSummary {
     pub id: String,
+    #[serde(default = "default_kind")]
+    pub kind: String,
     pub status: String,
     pub channel: Option<String>,
+    pub requester_session_id: Option<String>,
     pub created_at: Option<String>,
     pub turn_count: Option<u32>,
     pub usage_prompt_tokens: Option<u64>,
@@ -112,11 +115,21 @@ pub struct SessionSummary {
     pub latest_model: Option<String>,
 }
 
+fn default_kind() -> String {
+    "direct".to_string()
+}
+
 impl fmt::Display for SessionSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} [{}]", self.id, self.status)?;
+        if self.kind != "direct" {
+            write!(f, " kind={}", self.kind)?;
+        }
         if let Some(ref ch) = self.channel {
             write!(f, " ({ch})")?;
+        }
+        if let Some(ref parent) = self.requester_session_id {
+            write!(f, " parent={parent}")?;
         }
         if let Some(turns) = self.turn_count {
             write!(f, " turns={turns}")?;
@@ -155,8 +168,11 @@ impl fmt::Display for SessionListResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionDetailResponse {
     pub id: String,
+    #[serde(default = "default_kind")]
+    pub kind: String,
     pub status: String,
     pub channel: Option<String>,
+    pub requester_session_id: Option<String>,
     pub created_at: Option<String>,
     pub turn_count: Option<u32>,
     pub latest_model: Option<String>,
@@ -169,9 +185,13 @@ pub struct SessionDetailResponse {
 impl fmt::Display for SessionDetailResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Session: {}", self.id)?;
+        writeln!(f, "  Kind:    {}", self.kind)?;
         writeln!(f, "  Status:  {}", self.status)?;
         if let Some(ref ch) = self.channel {
             writeln!(f, "  Channel: {ch}")?;
+        }
+        if let Some(ref parent) = self.requester_session_id {
+            writeln!(f, "  Parent:  {parent}")?;
         }
         if let Some(ref t) = self.created_at {
             writeln!(f, "  Created: {t}")?;
@@ -194,6 +214,67 @@ impl fmt::Display for SessionDetailResponse {
             writeln!(f, "  Last ended:   {ended_at}")?;
         }
         Ok(())
+    }
+}
+
+/// A single node in a session delegation tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTreeNode {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub channel: Option<String>,
+    pub created_at: Option<String>,
+    pub turn_count: Option<u32>,
+    pub children: Vec<SessionTreeNode>,
+}
+
+/// Session delegation tree response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTreeResponse {
+    pub root: SessionTreeNode,
+}
+
+impl SessionTreeNode {
+    fn fmt_tree(&self, f: &mut fmt::Formatter<'_>, prefix: &str, is_last: bool) -> fmt::Result {
+        let connector = if prefix.is_empty() {
+            ""
+        } else if is_last {
+            "└── "
+        } else {
+            "├── "
+        };
+        write!(f, "{prefix}{connector}{} [{}]", self.id, self.status)?;
+        if self.kind != "direct" {
+            write!(f, " kind={}", self.kind)?;
+        }
+        if let Some(ref ch) = self.channel {
+            write!(f, " ({ch})")?;
+        }
+        if let Some(turns) = self.turn_count {
+            write!(f, " turns={turns}")?;
+        }
+        writeln!(f)?;
+
+        let child_prefix = if prefix.is_empty() {
+            String::new()
+        } else if is_last {
+            format!("{prefix}    ")
+        } else {
+            format!("{prefix}│   ")
+        };
+
+        for (i, child) in self.children.iter().enumerate() {
+            let last = i == self.children.len() - 1;
+            child.fmt_tree(f, &child_prefix, last)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for SessionTreeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.root.fmt_tree(f, "", false)
     }
 }
 
@@ -2963,8 +3044,10 @@ mod tests {
                 total: 2,
                 sample: vec![SessionSummary {
                     id: "session-1".into(),
+                    kind: "direct".into(),
                     status: "running".into(),
                     channel: Some("telegram".into()),
+                    requester_session_id: None,
                     created_at: None,
                     turn_count: Some(1),
                     usage_prompt_tokens: Some(10),

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -482,6 +482,8 @@ pub struct SessionsListQuery {
     pub active_minutes: Option<u64>,
     pub channel: Option<String>,
     pub kind: Option<String>,
+    /// Filter by parent/requester session ID (returns children of this session).
+    pub parent: Option<Uuid>,
     pub limit: Option<usize>,
 }
 
@@ -879,6 +881,7 @@ pub async fn list_sessions(
         .map(|minutes| Utc::now() - chrono::Duration::minutes(minutes as i64));
     let channel_filter = query.channel.as_deref();
     let kind_filter = query.kind.as_deref();
+    let parent_filter = query.parent;
 
     let rows = state
         .session_repo
@@ -902,6 +905,11 @@ pub async fn list_sessions(
         .filter(|row| {
             active_cutoff
                 .map(|cutoff| row.last_activity_at >= cutoff)
+                .unwrap_or(true)
+        })
+        .filter(|row| {
+            parent_filter
+                .map(|parent_id| row.requester_session_id == Some(parent_id))
                 .unwrap_or(true)
         })
     {
@@ -1139,6 +1147,101 @@ pub async fn get_session_status(
         subagent_last_note,
         unresolved,
     }))
+}
+
+/// A single node in a session delegation tree.
+#[derive(Serialize)]
+pub struct SessionTreeNode {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    pub created_at: String,
+    pub turn_count: u32,
+    pub children: Vec<SessionTreeNode>,
+}
+
+/// `GET /sessions/{id}/tree` — return the delegation tree rooted at a session.
+pub async fn get_session_tree(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<SessionTreeNode>, GatewayError> {
+    let root = state
+        .session_engine
+        .get_session(id)
+        .await
+        .map_err(|e| GatewayError::SessionNotFound(e.to_string()))?;
+
+    // Fetch all sessions and build the tree in-memory.
+    let all_rows = state
+        .session_repo
+        .list(500, 0)
+        .await
+        .map_err(|e| GatewayError::Internal(e.to_string()))?;
+
+    // Build parent -> children index.
+    let mut children_map: std::collections::HashMap<Uuid, Vec<&rune_store::models::SessionRow>> =
+        std::collections::HashMap::new();
+    for row in &all_rows {
+        if let Some(parent_id) = row.requester_session_id {
+            children_map.entry(parent_id).or_default().push(row);
+        }
+    }
+
+    // Collect all session IDs in the subtree for turn-count lookup.
+    fn collect_ids(
+        session_id: Uuid,
+        children_map: &std::collections::HashMap<Uuid, Vec<&rune_store::models::SessionRow>>,
+        out: &mut Vec<Uuid>,
+    ) {
+        out.push(session_id);
+        if let Some(kids) = children_map.get(&session_id) {
+            for child in kids {
+                collect_ids(child.id, children_map, out);
+            }
+        }
+    }
+    let mut subtree_ids = Vec::new();
+    collect_ids(root.id, &children_map, &mut subtree_ids);
+
+    // Pre-compute turn counts.
+    let mut turn_counts = std::collections::HashMap::new();
+    for sid in &subtree_ids {
+        let turns = state
+            .turn_repo
+            .list_by_session(*sid)
+            .await
+            .map_err(|e| GatewayError::Internal(e.to_string()))?;
+        turn_counts.insert(*sid, turns.len() as u32);
+    }
+
+    fn build_node(
+        row: &rune_store::models::SessionRow,
+        children_map: &std::collections::HashMap<Uuid, Vec<&rune_store::models::SessionRow>>,
+        turn_counts: &std::collections::HashMap<Uuid, u32>,
+    ) -> SessionTreeNode {
+        let children = children_map
+            .get(&row.id)
+            .map(|kids| {
+                kids.iter()
+                    .map(|child| build_node(child, children_map, turn_counts))
+                    .collect()
+            })
+            .unwrap_or_default();
+        SessionTreeNode {
+            id: row.id.to_string(),
+            kind: row.kind.clone(),
+            status: row.status.clone(),
+            channel: row.channel_ref.clone(),
+            created_at: row.created_at.to_rfc3339(),
+            turn_count: turn_counts.get(&row.id).copied().unwrap_or(0),
+            children,
+        }
+    }
+
+    let tree = build_node(&root, &children_map, &turn_counts);
+    Ok(Json(tree))
 }
 
 /// `PATCH /sessions/{id}` — update session metadata fields used by operator surfaces.

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -259,6 +259,7 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
                 .delete(routes::delete_session),
         )
         .route("/sessions/{id}/status", get(routes::get_session_status))
+        .route("/sessions/{id}/tree", get(routes::get_session_tree))
         .route("/sessions/{id}/messages", post(routes::send_message))
         .route("/sessions/{id}/transcript", get(routes::get_transcript))
         .route(


### PR DESCRIPTION
## Summary

Surfaces subagent relationships in the existing session CLI, closing the "inspect full delegation tree" acceptance criterion from #73.

- **Gateway**: Add `parent` query filter to `GET /sessions`, new `GET /sessions/{id}/tree` endpoint for delegation tree
- **CLI**: `--kind`/`--parent` filters on `sessions list`, new `sessions tree <id>` for tree visualization, `kind`/`requester_session_id` in list/show output
- **Output**: SessionSummary and SessionDetailResponse now display subagent kind and parent linkage

## Test plan

- [x] All 317 rune-cli tests pass (including 4 new parse tests for --kind, --parent, tree)
- [x] All 67 rune-gateway tests pass
- [x] `cargo check --workspace` clean
- [ ] Manual: `rune sessions list --kind subagent` filters correctly
- [ ] Manual: `rune sessions list --parent <id>` returns children
- [ ] Manual: `rune sessions tree <id>` renders tree