### PR TITLE
feat(cli): add `rune message ack` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -650,6 +650,18 @@ pub enum MessageAction {
         #[command(subcommand)]
         action: MessageTagAction,
     },
+    /// Acknowledge (mark as read/received) a message.
+    Ack {
+        /// ID of the message to acknowledge.
+        #[arg(long)]
+        message_id: String,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: String,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -3292,5 +3304,76 @@ mod tests {
                 }
             }
         ));
+    }
+
+    #[test]
+    fn parse_message_ack_minimal() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "ack",
+            "--message-id",
+            "msg-42",
+            "--channel",
+            "telegram",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Ack {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-42");
+                assert_eq!(channel, "telegram");
+                assert!(session.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_ack_with_session() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "ack",
+            "--message-id",
+            "msg-99",
+            "--channel",
+            "discord",
+            "--session",
+            "sess-abc",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::Ack {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-99");
+                assert_eq!(channel, "discord");
+                assert_eq!(session.as_deref(), Some("sess-abc"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_ack_requires_message_id_and_channel() {
+        assert!(
+            Cli::try_parse_from(["rune", "message", "ack", "--message-id", "msg-1"]).is_err()
+        );
+        assert!(
+            Cli::try_parse_from(["rune", "message", "ack", "--channel", "slack"]).is_err()
+        );
+        assert!(Cli::try_parse_from(["rune", "message", "ack"]).is_err());
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1574,6 +1574,60 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /messages/{id}/ack` — acknowledge (mark as read/received) a message.
+    pub async fn message_ack(
+        &self,
+        message_id: &str,
+        channel: &str,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageAckResponse> {
+        use crate::output::MessageAckResponse;
+
+        let mut body = json!({
+            "channel": channel,
+        });
+        if let Some(s) = session {
+            body["session"] = json!(s);
+        }
+        let resp = self
+            .http
+            .post(self.url(&format!("/messages/{message_id}/ack")))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /messages/{id}/ack")?;
+            Ok(MessageAckResponse {
+                success: true,
+                message_id: v["message_id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                channel: v["channel"]
+                    .as_str()
+                    .unwrap_or(channel)
+                    .to_string(),
+                detail: v["detail"]
+                    .as_str()
+                    .unwrap_or("Message acknowledged")
+                    .to_string(),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Ok(MessageAckResponse {
+                success: false,
+                message_id: message_id.to_string(),
+                channel: channel.to_string(),
+                detail: format!("Gateway returned HTTP {status}: {body_text}"),
+            })
+        }
+    }
+
     /// `GET /tts/status`
     pub async fn message_voice_status(
         &self,

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1516,6 +1516,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                     println!("{}", render(&result, format));
                 }
             },
+            MessageAction::Ack {
+                message_id,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_ack(&message_id, &channel, session.as_deref())
+                    .await?;
+                println!("{}", render(&result, format));
+            }
             MessageAction::Tag { action } => match action {
                 MessageTagAction::Add {
                     message_id,

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -2361,6 +2361,30 @@ impl fmt::Display for MessageTagListResponse {
     }
 }
 
+/// Response for `message ack` — acknowledge (mark as read/received) a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageAckResponse {
+    pub success: bool,
+    pub message_id: String,
+    pub channel: String,
+    pub detail: String,
+}
+
+impl fmt::Display for MessageAckResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(
+            f,
+            "{icon} acknowledged message {} on {}",
+            self.message_id, self.channel,
+        )?;
+        if !self.detail.is_empty() {
+            write!(f, ": {}", self.detail)?;
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {

--- a/docs/parity/CLI-MATRIX.md
+++ b/docs/parity/CLI-MATRIX.md
@@ -58,7 +58,7 @@
 
 | OpenClaw family | Rune equivalent | Status | Subcommand coverage | Tracking |
 |-----------------|----------------|--------|---------------------|----------|
-| `message` | `rune message` | **Partial** | `send`, `read`, `edit`, `delete`, `react`, `pin`, `search`, `broadcast`, `thread list/reply`, `voice send/status` shipped | #74 |
+| `message` | `rune message` | **Partial** | `send`, `read`, `edit`, `delete`, `react`, `pin`, `search`, `broadcast`, `thread list/reply`, `voice send/status`, `tag`, `ack` shipped | #74 |
 | `agent` | — | **Not started** | Direct agent-turn invocation | #70 |
 | `agents` | — | **Not started** | Agent listing/management | #70 |
 | `acp` | — | **Not started** | ACP bridge/client | #70 |
@@ -132,6 +132,7 @@ The `message` family is the most actively developed #74 artifact. Current verb c
 | `thread` | `rune message thread list/reply` | **Shipped** | #151 |
 | `voice` | `rune message voice send/status` | **Shipped** | #155 |
 | `tag` | `rune message tag add/remove/list` | **Shipped** | — |
+| `ack` | `rune message ack` | **Shipped** | — |
 | `reactions` | — | **Not started** | Listing reactions on a message |
 | `poll` | — | **Not started** | Poll creation/management |
 | `channel` | — | **Not started** | Channel-scoped message operations |


### PR DESCRIPTION
## Summary
- Adds `rune message ack --message-id <id> --channel <ch> [--session <s>]` to acknowledge (mark as read/received) a message
- Wires through `GatewayClient::message_ack()` → `POST /messages/{id}/ack` with `MessageAckResponse` output type
- Updates CLI-MATRIX.md to mark `ack` as shipped in the message family

## Changes
| File | What |
|------|------|
| `cli.rs` | `MessageAction::Ack` variant + 3 parsing tests |
| `client.rs` | `message_ack()` HTTP client method |
| `lib.rs` | Dispatch branch |
| `output.rs` | `MessageAckResponse` struct + `Display` impl |
| `CLI-MATRIX.md` | `ack` marked shipped |

## Test plan
- [x] `cargo check -p rune-cli` passes
- [x] `cargo test -p rune-cli` — 327/327 pass (3 new `message_ack` tests)
- [ ] Manual: `rune message ack --message-id msg-1 --channel telegram` against a running gateway

Closes the `ack` breadth-verb gap in the message family for #74.