### PR TITLE
feat(cli): add `rune message list-reactions` subcommand (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -662,6 +662,19 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
+    /// List emoji reactions on a message.
+    #[command(name = "list-reactions")]
+    ListReactions {
+        /// ID of the message to list reactions for.
+        #[arg(long)]
+        message_id: String,
+        /// Channel adapter the message belongs to.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -3375,5 +3388,76 @@ mod tests {
             Cli::try_parse_from(["rune", "message", "ack", "--channel", "slack"]).is_err()
         );
         assert!(Cli::try_parse_from(["rune", "message", "ack"]).is_err());
+    }
+
+    // ── Message list-reactions (#74) ────────────────────────────────
+
+    #[test]
+    fn parse_message_list_reactions_minimal() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "list-reactions",
+            "--message-id",
+            "msg-42",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::ListReactions {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-42");
+                assert_eq!(channel, None);
+                assert_eq!(session, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_list_reactions_with_channel_and_session() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "message",
+            "list-reactions",
+            "--message-id",
+            "msg-99",
+            "--channel",
+            "discord",
+            "--session",
+            "sess-7",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Message {
+                action:
+                    MessageAction::ListReactions {
+                        message_id,
+                        channel,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "msg-99");
+                assert_eq!(channel.as_deref(), Some("discord"));
+                assert_eq!(session.as_deref(), Some("sess-7"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_list_reactions_requires_message_id() {
+        assert!(
+            Cli::try_parse_from(["rune", "message", "list-reactions"]).is_err()
+        );
+        assert!(
+            Cli::try_parse_from(["rune", "message", "list-reactions", "--channel", "slack"])
+                .is_err()
+        );
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1574,6 +1574,69 @@ impl GatewayClient {
         }
     }
 
+    /// `GET /messages/{id}/reactions` — list emoji reactions on a message.
+    pub async fn message_list_reactions(
+        &self,
+        message_id: &str,
+        channel: Option<&str>,
+        session: Option<&str>,
+    ) -> Result<crate::output::MessageReactionListResponse> {
+        use crate::output::{MessageReactionListResponse, ReactionDetail};
+
+        let mut params: Vec<(&str, &str)> = vec![];
+        if let Some(ch) = channel {
+            params.push(("channel", ch));
+        }
+        if let Some(s) = session {
+            params.push(("session", s));
+        }
+        let resp = self
+            .http
+            .get(self.url(&format!("/messages/{message_id}/reactions")))
+            .query(&params)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+        if resp.status().is_success() {
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from GET /messages/{id}/reactions")?;
+            let reactions = v["reactions"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .map(|r| ReactionDetail {
+                            emoji: r["emoji"].as_str().unwrap_or("?").to_string(),
+                            count: r["count"].as_u64().unwrap_or(1),
+                            users: r["users"]
+                                .as_array()
+                                .map(|u| {
+                                    u.iter()
+                                        .filter_map(|v| v.as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(MessageReactionListResponse {
+                message_id: v["message_id"]
+                    .as_str()
+                    .unwrap_or(message_id)
+                    .to_string(),
+                reactions,
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GET /messages/{message_id}/reactions returned HTTP {status}: {body_text}"
+            );
+        }
+    }
+
     /// `POST /messages/{id}/ack` — acknowledge (mark as read/received) a message.
     pub async fn message_ack(
         &self,

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1526,6 +1526,20 @@ pub async fn run(cli: Cli) -> Result<()> {
                     .await?;
                 println!("{}", render(&result, format));
             }
+            MessageAction::ListReactions {
+                message_id,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_list_reactions(
+                        &message_id,
+                        channel.as_deref(),
+                        session.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
             MessageAction::Tag { action } => match action {
                 MessageTagAction::Add {
                     message_id,

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -2385,6 +2385,50 @@ impl fmt::Display for MessageAckResponse {
     }
 }
 
+/// A single reaction on a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReactionDetail {
+    pub emoji: String,
+    pub count: u64,
+    pub users: Vec<String>,
+}
+
+/// Response for `message list-reactions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageReactionListResponse {
+    pub message_id: String,
+    pub reactions: Vec<ReactionDetail>,
+}
+
+impl fmt::Display for MessageReactionListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.reactions.is_empty() {
+            return write!(f, "No reactions on message {}", self.message_id);
+        }
+        write!(
+            f,
+            "Message {}: {} reaction{}",
+            self.message_id,
+            self.reactions.len(),
+            if self.reactions.len() == 1 { "" } else { "s" },
+        )?;
+        for r in &self.reactions {
+            if r.users.is_empty() {
+                write!(f, "\n  {} ×{}", r.emoji, r.count)?;
+            } else {
+                write!(
+                    f,
+                    "\n  {} ×{} ({})",
+                    r.emoji,
+                    r.count,
+                    r.users.join(", "),
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
 /// One-shot reminder detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReminderSummary {
@@ -4019,6 +4063,79 @@ mod tests {
         assert_eq!(v["message_id"], "msg-42");
         assert_eq!(v["tags"][0], "urgent");
         assert_eq!(v["tags"][1], "followup");
+    }
+
+    // ── MessageReactionListResponse ─────────────────────────────────
+
+    #[test]
+    fn render_message_reaction_list_empty() {
+        let r = MessageReactionListResponse {
+            message_id: "msg-42".into(),
+            reactions: vec![],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert_eq!(out, "No reactions on message msg-42");
+    }
+
+    #[test]
+    fn render_message_reaction_list_with_reactions() {
+        let r = MessageReactionListResponse {
+            message_id: "msg-42".into(),
+            reactions: vec![
+                ReactionDetail {
+                    emoji: "👍".into(),
+                    count: 3,
+                    users: vec!["alice".into(), "bob".into(), "carol".into()],
+                },
+                ReactionDetail {
+                    emoji: "❤️".into(),
+                    count: 1,
+                    users: vec!["dave".into()],
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Message msg-42: 2 reactions"));
+        assert!(out.contains("👍 ×3"));
+        assert!(out.contains("alice, bob, carol"));
+        assert!(out.contains("❤️ ×1"));
+        assert!(out.contains("dave"));
+    }
+
+    #[test]
+    fn render_message_reaction_list_single_grammar() {
+        let r = MessageReactionListResponse {
+            message_id: "msg-99".into(),
+            reactions: vec![ReactionDetail {
+                emoji: "🎉".into(),
+                count: 5,
+                users: vec![],
+            }],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("1 reaction"));
+        assert!(!out.contains("reactions"));
+        assert!(out.contains("🎉 ×5"));
+        // No users → no parenthetical
+        assert!(!out.contains("("));
+    }
+
+    #[test]
+    fn render_message_reaction_list_json() {
+        let r = MessageReactionListResponse {
+            message_id: "msg-42".into(),
+            reactions: vec![ReactionDetail {
+                emoji: "👍".into(),
+                count: 2,
+                users: vec!["alice".into(), "bob".into()],
+            }],
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["message_id"], "msg-42");
+        assert_eq!(v["reactions"][0]["emoji"], "👍");
+        assert_eq!(v["reactions"][0]["count"], 2);
+        assert_eq!(v["reactions"][0]["users"][0], "alice");
     }
 
     // ── MessageThreadListResponse ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `rune message list-reactions --message-id <id> [--channel <ch>] [--session <s>]` CLI surface
- Gateway client method `GET /messages/{id}/reactions` with structured `ReactionDetail` (emoji, count, users)
- Human-readable and JSON output rendering via `MessageReactionListResponse`
- Dispatch wiring in `lib.rs`
- 7 new tests (3 CLI parse, 4 output render); 334 total pass

## Closes gap
The `message` family had `react` (add/remove) but no way to **list** existing reactions. This slice adds the read-side complement, advancing #74 message-family parity.

## Test plan
- [x] `cargo check -p rune-cli` — clean
- [x] `cargo test -p rune-cli` — 334 pass, 0 fail
- [ ] Manual smoke test against live gateway (deferred to integration)