### PR TITLE
feat(cli): add `rune sessions export` subcommand (#73)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -315,6 +315,11 @@ pub enum SessionsAction {
         /// Session ID to use as tree root.
         id: String,
     },
+    /// Export a session as a JSON bundle (detail + transcript).
+    Export {
+        /// Session ID to export.
+        id: String,
+    },
     /// Delete a single session and its transcript history.
     Delete {
         /// Session ID to delete.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1882,6 +1882,28 @@ impl GatewayClient {
         }
     }
 
+    /// `GET /sessions/:id/transcript` — fetch full session transcript.
+    pub async fn sessions_transcript(&self, id: &str) -> Result<Vec<crate::output::TranscriptEntry>> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/sessions/{id}/transcript")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let entries: Vec<crate::output::TranscriptEntry> = resp
+                .json()
+                .await
+                .context("invalid JSON from /sessions/:id/transcript")?;
+            Ok(entries)
+        } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("Session '{id}' not found.");
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
     /// `GET /sessions?kind=subagent` — list subagent sessions.
     pub async fn agents_list(
         &self,

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1113,6 +1113,19 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.sessions_tree(&id).await?;
                 println!("{}", render(&result, format));
             }
+            SessionsAction::Export { id } => {
+                use crate::output::SessionExportBundle;
+
+                let session = client.sessions_show(&id).await?;
+                let transcript = client.sessions_transcript(&id).await?;
+                let bundle = SessionExportBundle {
+                    session,
+                    transcript,
+                };
+                // Export always emits JSON for machine consumption,
+                // but respects --json flag for human-readable summary.
+                println!("{}", render(&bundle, format));
+            }
             SessionsAction::Delete { id } => {
                 let result = client.session_delete(&id).await?;
                 println!("{}", render(&result, format));

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1705,6 +1705,78 @@ impl fmt::Display for SessionCleanupResponse {
     }
 }
 
+// ── Session export ────────────────────────────────────────────────────────────
+
+/// A single transcript entry returned by the gateway.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptEntry {
+    pub id: String,
+    pub turn_id: Option<String>,
+    pub seq: i32,
+    pub kind: String,
+    pub payload: serde_json::Value,
+    pub created_at: String,
+}
+
+impl fmt::Display for TranscriptEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let turn = self.turn_id.as_deref().unwrap_or("-");
+        write!(f, "  [{:>3}] {:<20} turn={}", self.seq, self.kind, turn)?;
+        // For user/assistant messages show a content preview.
+        match self.kind.as_str() {
+            "user_message" => {
+                if let Some(msg) = self.payload["message"].as_str() {
+                    let preview: String = msg.chars().take(80).collect();
+                    write!(f, "  {preview}")?;
+                    if msg.len() > 80 {
+                        write!(f, "…")?;
+                    }
+                }
+            }
+            "assistant_message" => {
+                if let Some(content) = self.payload["content"].as_str() {
+                    let preview: String = content.chars().take(80).collect();
+                    write!(f, "  {preview}")?;
+                    if content.len() > 80 {
+                        write!(f, "…")?;
+                    }
+                }
+            }
+            "tool_request" => {
+                if let Some(name) = self.payload["tool_name"].as_str() {
+                    write!(f, "  tool={name}")?;
+                }
+            }
+            "tool_result" => {
+                let is_err = self.payload["is_error"].as_bool().unwrap_or(false);
+                if is_err {
+                    write!(f, "  (error)")?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+/// Full session export bundle: session detail + transcript.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionExportBundle {
+    pub session: SessionDetailResponse,
+    pub transcript: Vec<TranscriptEntry>,
+}
+
+impl fmt::Display for SessionExportBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.session)?;
+        writeln!(f, "  Transcript ({} items):", self.transcript.len())?;
+        for entry in &self.transcript {
+            writeln!(f, "{entry}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Scheduler status response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CronStatusResponse {


### PR DESCRIPTION
## Summary
- Adds `rune sessions export <id>` subcommand that bundles session detail + full transcript into a single JSON document via the existing `GET /sessions/{id}/transcript` gateway endpoint.
- Supports both `--json` (structured JSON bundle) and human-readable mode (compact transcript preview with message/tool previews).
- Adds `TranscriptEntry`, `SessionExportBundle` output types, and `sessions_transcript()` client method.

Closes a parity gap: the gateway transcript endpoint existed but had no CLI surface.

Ref: #73

## Test plan
- [x] `cargo check --package rune-cli` — clean
- [x] `cargo clippy --package rune-cli -- -D warnings` — clean
- [x] `cargo test --package rune-cli` — 334 passed
- [x] `cargo test --package rune-gateway` — 113 passed