### PR TITLE
docs: backup/restore CLI workflow contract (#70)

### DIFF
--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -542,7 +542,7 @@ Not recommended as default deployment targets for the parity-first container arc
 
 ## 12. Backup and restore expectations
 
-Container deployment must make backup/restore straightforward.
+Container deployment must make backup/restore straightforward. See [PROTOCOLS.md §15.4](../parity/PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full behavioral contract and CLI workflow spec.
 
 ## 12.1 What must be backup-friendly
 

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -476,7 +476,7 @@ See [DEPLOYMENT.md §5.1](../operator/DEPLOYMENT.md#51-local--docker-path-equiva
 
 - missing mounts/config fail fast and clearly
 - read-only or degraded storage modes surface explicit errors
-- backup/restore workflows are documented and testable
+- backup/restore workflows are documented and testable (see [PROTOCOLS.md §15.4](PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full contract and CLI workflow spec)
 
 #### Read-only filesystem detection
 
@@ -505,8 +505,8 @@ See [PROTOCOLS.md §3.7](PROTOCOLS.md#secrets-never-logged-invariant) for the fu
 ### Minimum parity evidence
 
 - local Docker deployment with mounted state
-- backup workflow documentation naming included durable-state domains and exclusions
-- restore workflow documentation naming prerequisites and post-restore verification checks
+- backup workflow documentation naming included durable-state domains and exclusions (see [PROTOCOLS.md §15.4.5](PROTOCOLS.md#1545-cli-workflow-contract))
+- restore workflow documentation naming prerequisites and post-restore verification checks (see [PROTOCOLS.md §15.4.5](PROTOCOLS.md#1545-cli-workflow-contract))
 - restart-preservation documentation naming which state must survive container restart and which post-restart checks operators should run
 - restart durability tests
 - PostgreSQL-backed Azure-hosted mode tests

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -1265,6 +1265,38 @@ The project should provide enough operator-facing documentation and/or commands 
 - what preconditions are required for a clean restore
 - what post-restore checks to run (`doctor`, health/status, scheduler state sanity)
 
+### 15.4.5 CLI workflow contract
+
+The `rune backup` command family is the primary operator interface for snapshot and recovery workflows. These commands must implement the behavioral expectations defined in §15.4.1–§15.4.4.
+
+#### Expected subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `rune backup create [--output <path>]` | Snapshot all durable state domains into a restorable archive |
+| `rune backup restore <archive>` | Restore runtime state from a backup archive |
+| `rune backup list` | List available backup archives in the configured backups directory |
+
+#### `rune backup create` contract
+
+1. **Quiesce coordination** — coordinate with the runtime to ensure database consistency (e.g., WAL checkpoint for embedded PostgreSQL) before capture.
+2. **Scope** — capture all 9 durable domains per §15.4.1: db, sessions, memory, media (when retained), skills, logs (when policy requires), backups staging, config overlays, and secret references (never secret values).
+3. **Output** — write a self-contained archive to `/data/backups` (or `~/.rune/backups/` locally) by default. `--output` overrides the destination path.
+4. **Manifest** — the archive must include a manifest listing included domains, capture timestamp, runtime version, and any excluded domains with reason.
+5. **Secret safety** — secret values must not appear in the archive, its manifest, or any log output during the operation. Secret references (env var names, vault paths) are preserved.
+
+#### `rune backup restore` contract
+
+1. **Precondition** — the runtime should be stopped or in a quiesced state before restore. The command must refuse to overwrite live state without explicit confirmation.
+2. **Target layout** — restore into the same logical path layout that the running mode expects (`~/.rune/*` locally, `/data/*` + `/config` + `/secrets` in Docker).
+3. **Post-restore verification** — on completion, emit a checklist of recommended verification steps: run `rune doctor`, check health/status endpoints, verify scheduler/job state, and inspect recent session/transcript history.
+4. **Partial restore** — where a restore cannot fully recreate a subsystem (e.g., external managed PostgreSQL data, provider-side state), the command must state the limitation explicitly in its output.
+
+#### `rune backup list` contract
+
+1. List archives in the configured backups directory with timestamp, size, and manifest summary.
+2. Indicate whether each archive was created by the current runtime version or an older one.
+
 ## 15.5 Logging and diagnostics contract
 
 Every major action should emit structured events/logs with:

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -143,6 +143,30 @@ Reminders resolve to one of four terminal states: `pending`, `delivered`, `cance
 
 ---
 
+## `backup` command family
+
+Operator surface for durable-state snapshot and recovery workflows.
+
+### Expected subcommands
+
+| Subcommand | Purpose | Status |
+|---|---|---|
+| `rune backup create [--output <path>]` | Snapshot all durable state domains into a restorable archive | Not yet shipped |
+| `rune backup restore <archive>` | Restore runtime state from a backup archive | Not yet shipped |
+| `rune backup list` | List available backup archives in the configured backups directory | Not yet shipped |
+
+### Behavioral contract
+
+The `backup` family implements the workflow contract defined in [PROTOCOLS.md §15.4](../parity/PROTOCOLS.md#154-backup-and-restore-workflow-contract):
+
+- **Create** captures all 9 durable domains (db, sessions, memory, media, skills, logs, backups staging, config, secret references) into a self-contained archive at `/data/backups` (Docker) or `~/.rune/backups/` (local). Secret values are never included.
+- **Restore** requires the runtime to be stopped or quiesced. Restores into the expected path layout and emits post-restore verification steps (`rune doctor`, health/status, scheduler state, transcript inspectability).
+- **List** shows available archives with timestamp, size, and version compatibility.
+
+See [DEPLOYMENT.md §12](../operator/DEPLOYMENT.md#12-backup-and-restore-expectations) for deployment-mode-specific backup strategy guidance.
+
+---
+
 ## Read next
 
 - use [`../parity/PARITY-INVENTORY.md`](../parity/PARITY-INVENTORY.md) when you need the full command/surface census


### PR DESCRIPTION
## Summary

- Adds `rune backup create/restore/list` CLI workflow contract to PROTOCOLS.md §15.4.5, specifying subcommand behavior, quiesce coordination, scope, manifest, secret safety, and post-restore verification steps
- Adds `backup` command family to CLI.md reference with status and behavioral contract summary
- Wires cross-references from PARITY-CONTRACTS.md §11 and DEPLOYMENT.md §12 to the new contract section

Addresses the remaining backup/restore documentation gap from #70.

## Remaining doc gaps (not in this slice)

- Container restart state preservation documentation (separate slice)
- End-to-end backup/restore integration test evidence

## Test plan

- [ ] Verify all internal doc cross-links resolve correctly
- [ ] Confirm PROTOCOLS.md §15.4.5 is reachable from PARITY-CONTRACTS.md and DEPLOYMENT.md anchors