### PR TITLE
fix(ui): mobile admin chrome safe-area & touch-target polish (#60)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/assets/rune-logo-favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Rune Admin</title>
   </head>
   <body>

--- a/ui/src/components/layout/AdminBottomNav.tsx
+++ b/ui/src/components/layout/AdminBottomNav.tsx
@@ -80,10 +80,10 @@ export function AdminBottomNav() {
   return (
     <nav
       aria-label="Admin navigation"
-      className="fixed bottom-0 left-0 right-0 z-40 px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2 lg:hidden"
+      className="fixed bottom-0 left-0 right-0 z-40 pl-[max(0.75rem,env(safe-area-inset-left))] pr-[max(0.75rem,env(safe-area-inset-right))] pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 lg:hidden"
     >
       <div className="mx-auto w-full max-w-lg rounded-2xl border border-primary/20 bg-background/92 shadow-[0_10px_35px_rgba(15,23,42,0.18)] backdrop-blur supports-[backdrop-filter]:bg-background/80">
-        <div className="flex items-center justify-between px-2 py-2">
+        <div className="flex items-center justify-between px-3 py-2.5">
           {navItems.map((item) => {
             const active = isActive(item);
             return (
@@ -93,7 +93,7 @@ export function AdminBottomNav() {
                 search={item.href === "/chat" ? chatLinkSearch : undefined}
                 aria-label={item.label}
                 className={cn(
-                  "relative flex min-h-12 flex-1 flex-col items-center justify-center gap-1 rounded-xl text-xs font-medium transition-all duration-200",
+                  "relative flex min-h-12 min-w-[44px] flex-1 flex-col items-center justify-center gap-1.5 rounded-xl text-xs font-medium transition-all duration-200",
                   designSystem.effects.focusRing,
                   active
                     ? "bg-primary/10 text-primary"
@@ -108,11 +108,11 @@ export function AdminBottomNav() {
                 >
                   {item.icon}
                 </div>
-                <span className="max-w-[54px] truncate text-[10px] leading-none">
+                <span className="max-w-[60px] truncate text-[11px] leading-none">
                   {item.label}
                 </span>
                 {active && (
-                  <div className="absolute inset-x-3 -bottom-1 h-0.5 rounded-full bg-gradient-to-r from-primary to-accent" />
+                  <div className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-gradient-to-r from-primary to-accent" />
                 )}
               </Link>
             );

--- a/ui/src/components/layout/AdminNavbar.tsx
+++ b/ui/src/components/layout/AdminNavbar.tsx
@@ -94,7 +94,7 @@ export function AdminNavbar() {
     <nav
       aria-label="Admin navigation"
       className={cn(
-        "sticky top-0 z-[70] w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+        "sticky top-0 z-[70] w-full border-b bg-background/80 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/60",
         "transition-all duration-300 shadow-lg shadow-primary/20",
         "border-primary"
       )}
@@ -103,7 +103,7 @@ export function AdminNavbar() {
       <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-accent/5 pointer-events-none z-0" />
 
       <div className="relative z-10 mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
+        <div className="flex h-14 items-center justify-between sm:h-16">
           {/* Left: Logo + Admin badge + nav links */}
           <div className="flex items-center gap-4">
             <Link
@@ -114,7 +114,7 @@ export function AdminNavbar() {
               <img
                 src="/assets/rune-logo-icon.svg"
                 alt="Rune"
-                className="h-12 w-auto py-0.5"
+                className="h-10 w-auto py-0.5 sm:h-12"
                 decoding="async"
               />
               <Badge
@@ -184,7 +184,7 @@ export function AdminNavbar() {
               </SheetTrigger>
               <SheetContent
                 side="right"
-                className="inset-y-auto top-16 h-[calc(100dvh-4rem)] w-screen max-w-none border-l-0 bg-background p-0 [&>button]:hidden sm:max-w-none"
+                className="inset-y-auto top-[calc(3.5rem+env(safe-area-inset-top))] h-[calc(100dvh-3.5rem-env(safe-area-inset-top))] w-screen max-w-none border-l-0 bg-background p-0 [&>button]:hidden sm:top-[calc(4rem+env(safe-area-inset-top))] sm:h-[calc(100dvh-4rem-env(safe-area-inset-top))] sm:max-w-none"
               >
                 <SheetHeader className="border-b px-5 pb-4 pt-4">
                   <SheetTitle className="px-0 pt-0">
@@ -199,9 +199,9 @@ export function AdminNavbar() {
                   </SheetTitle>
                 </SheetHeader>
 
-                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-5">
-                  <div className="mx-auto grid w-full max-w-md gap-5 pb-2">
-                    <div className="grid gap-2.5">
+                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 sm:px-5 sm:py-5">
+                  <div className="mx-auto grid w-full max-w-md gap-4 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+                    <div className="grid gap-2">
                       {allItems.map((item) => {
                         const active = isActive(pathname, item);
                         const Icon = item.icon;
@@ -212,7 +212,7 @@ export function AdminNavbar() {
                             search={item.href === "/chat" ? chatLinkSearch : undefined}
                             onClick={() => setMobileMenuOpen(false)}
                             className={cn(
-                              "flex items-center gap-3 rounded-xl border px-4 py-3.5 font-medium transition-all",
+                              "flex min-h-12 items-center gap-3 rounded-xl border px-4 py-3 font-medium transition-all active:scale-[0.98]",
                               active
                                 ? "border-primary/40 bg-primary/10 text-primary"
                                 : "border-border bg-card/70 hover:border-primary/40 hover:bg-primary/10"

--- a/ui/src/routes/_admin.tsx
+++ b/ui/src/routes/_admin.tsx
@@ -10,7 +10,7 @@ function AdminLayout() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-muted/20">
       <AdminNavbar />
-      <main className="mx-auto w-full max-w-7xl px-4 pb-24 pt-6 sm:px-6 lg:px-8 lg:pb-8">
+      <main className="mx-auto w-full max-w-7xl px-4 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pt-6 lg:px-8 lg:pb-8">
         <Outlet />
       </main>
       <AdminBottomNav />


### PR DESCRIPTION
## Summary
- Enables `viewport-fit=cover` so `env(safe-area-inset-*)` CSS values are populated on iOS notched devices
- **Bottom nav**: increased safe-area bottom/horizontal padding, enforced 44px minimum touch-target width, bumped label font from 10px→11px, fixed active indicator clipping at `-bottom-1`
- **Top navbar**: added `safe-area-inset-top` padding for notched phones, reduced mobile bar height to 3.5rem for less chrome, scaled logo down on phone widths
- **Mobile sheet menu**: safe-area-aware positioning and bottom padding, `min-h-12` touch targets with `active:scale` press feedback, tighter gap for better content density
- **Admin layout shell**: dynamic bottom padding (`calc(6rem + safe-area-inset-bottom)`) so content never hides behind the floating bottom nav, reduced top padding on mobile

All changes are UI-only, scoped to the admin shell chrome surfaces. No backend/CLI changes.

## Test plan
- [ ] Verify bottom nav items are comfortably tappable on 320px–375px viewports
- [ ] Confirm safe-area insets render correctly on iPhone with notch/Dynamic Island (Safari or PWA)
- [ ] Open the mobile hamburger menu and verify it fills below the navbar without overlap
- [ ] Check that page content doesn't hide behind the bottom nav on short phones
- [ ] Run `npm run build` and `npm run lint` in `ui/` — both pass clean