### PR TITLE
feat(cli): add  surface (#71)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -106,6 +106,11 @@ pub enum Command {
         #[command(subcommand)]
         action: ModelsAction,
     },
+    /// Inspect installed prompt skills.
+    Skills {
+        #[command(subcommand)]
+        action: SkillsAction,
+    },
     /// Inspect workspace memory files and retrieval state.
     Memory {
         #[command(subcommand)]
@@ -450,6 +455,12 @@ pub enum ModelsAction {
     ImageFallbacks,
     /// Scan locally reachable providers (for example Ollama) for available models.
     Scan,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SkillsAction {
+    /// List installed skills discovered by the gateway.
+    List,
 }
 
 #[derive(Debug, Subcommand)]
@@ -987,6 +998,17 @@ mod tests {
     fn parse_dashboard() {
         let cli = Cli::try_parse_from(["rune", "dashboard"]).unwrap();
         assert!(matches!(cli.command, Command::Dashboard));
+    }
+
+    #[test]
+    fn parse_skills_list() {
+        let cli = Cli::try_parse_from(["rune", "skills", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Skills {
+                action: SkillsAction::List
+            }
+        ));
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -13,12 +13,13 @@ use crate::output::{
     ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
-    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport, SystemEventListResponse,
-    GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
-    HealthResponse, HeartbeatStatusResponse, ModelScanProviderResult, ModelScanResponse,
-    MessageSearchHit, MessageSearchResponse, MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail, SessionDetailResponse,
-    SessionListResponse, SessionStatusCard, SessionSummary, SessionTreeNode,
-    SessionTreeResponse, StatusResponse,
+    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
+    SystemEventListResponse, GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse,
+    GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
+    ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
+    MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
+    SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
+    SessionTreeNode, SessionTreeResponse, SkillListResponse, SkillSummary, StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -194,6 +195,26 @@ impl GatewayClient {
                 })
                 .collect();
             Ok(ModelScanResponse { providers })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /skills`
+    pub async fn skills_list(&self) -> Result<SkillListResponse> {
+        let resp = self
+            .http
+            .get(self.url("/skills"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let skills = resp
+                .json::<Vec<SkillSummary>>()
+                .await
+                .context("invalid JSON from /skills")?;
+            Ok(SkillListResponse { skills })
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2735,6 +2756,44 @@ mod tests {
         assert_eq!(resp.providers[0].provider, "ollama-local");
         assert_eq!(resp.providers[0].models[0].name, "llama3.2:latest");
         assert_eq!(resp.providers[0].models[0].size, Some(12345));
+    }
+
+    #[tokio::test]
+    async fn skills_list_parses_entries() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "name": "alpha",
+                    "description": "First skill",
+                    "enabled": true,
+                    "source_dir": "/data/skills/alpha",
+                    "binary_path": "/data/skills/alpha/run.sh"
+                },
+                {
+                    "name": "beta",
+                    "description": "Second skill",
+                    "enabled": false,
+                    "source_dir": "/data/skills/beta",
+                    "binary_path": null
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.skills_list().await.unwrap();
+        assert_eq!(resp.skills.len(), 2);
+        assert_eq!(resp.skills[0].name, "alpha");
+        assert!(resp.skills[0].enabled);
+        assert_eq!(
+            resp.skills[0].binary_path.as_deref(),
+            Some("/data/skills/alpha/run.sh")
+        );
+        assert_eq!(resp.skills[1].name, "beta");
+        assert!(!resp.skills[1].enabled);
+        assert!(resp.skills[1].binary_path.is_none());
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -27,7 +27,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
     MessageTagAction, MessageThreadAction, MessageVoiceAction, ModelsAction, RemindersAction,
     SessionsAction,
-    SystemAction, SystemEventAction, SystemHeartbeatAction,
+    SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -966,6 +966,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             let target = std::path::Path::new(&path);
             init_workspace(target).await?;
         }
+        Command::Skills { action } => match action {
+            SkillsAction::List => {
+                let result = client.skills_list().await?;
+                println!("{}", render(&result, format));
+            }
+        },
         Command::Completion { action } => match action {
             CompletionAction::Generate { shell } => {
                 print_completion(shell)?;
@@ -2103,7 +2109,7 @@ models = ["gpt-5.4"]
         let script = generate_completion_string(cli::CompletionShell::Bash);
         assert!(!script.is_empty(), "bash completion script must not be empty");
         // The script should reference key top-level subcommands.
-        for cmd in ["gateway", "status", "completion", "config", "doctor"] {
+        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
             assert!(
                 script.contains(cmd),
                 "bash completion missing subcommand `{cmd}`",
@@ -2115,7 +2121,7 @@ models = ["gpt-5.4"]
     fn zsh_completion_contains_subcommands() {
         let script = generate_completion_string(cli::CompletionShell::Zsh);
         assert!(!script.is_empty(), "zsh completion script must not be empty");
-        for cmd in ["gateway", "status", "completion", "config", "doctor"] {
+        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
             assert!(
                 script.contains(cmd),
                 "zsh completion missing subcommand `{cmd}`",
@@ -2127,7 +2133,7 @@ models = ["gpt-5.4"]
     fn fish_completion_contains_subcommands() {
         let script = generate_completion_string(cli::CompletionShell::Fish);
         assert!(!script.is_empty(), "fish completion script must not be empty");
-        for cmd in ["gateway", "status", "completion", "config", "doctor"] {
+        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
             assert!(
                 script.contains(cmd),
                 "fish completion missing subcommand `{cmd}`",

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -505,6 +505,58 @@ impl fmt::Display for TemplateStartResponse {
     }
 }
 
+/// A single installed skill entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillSummary {
+    pub name: String,
+    pub description: String,
+    pub enabled: bool,
+    pub source_dir: String,
+    pub binary_path: Option<String>,
+}
+
+impl fmt::Display for SkillSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "{} [{}]",
+            self.name,
+            if self.enabled { "enabled" } else { "disabled" }
+        )?;
+        writeln!(f, "  Description: {}", self.description)?;
+        writeln!(f, "  Source: {}", self.source_dir)?;
+        write!(
+            f,
+            "  Binary: {}",
+            self.binary_path.as_deref().unwrap_or("-")
+        )
+    }
+}
+
+/// Response for `rune skills list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillListResponse {
+    pub skills: Vec<SkillSummary>,
+}
+
+impl fmt::Display for SkillListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.skills.is_empty() {
+            return write!(f, "No skills found.");
+        }
+
+        for (idx, skill) in self.skills.iter().enumerate() {
+            if idx > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+            write!(f, "{skill}")?;
+        }
+
+        Ok(())
+    }
+}
+
 /// First-class `/status` / `session_status` parity card for an individual session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionStatusCard {
@@ -3050,6 +3102,62 @@ mod tests {
         assert_eq!(parsed["session_id"], "abc-123");
         assert_eq!(parsed["template_slug"], "coding-agent");
         assert_eq!(parsed["mode"], "coder");
+    }
+
+    #[test]
+    fn render_skill_list_empty() {
+        let response = SkillListResponse { skills: vec![] };
+        assert_eq!(render(&response, OutputFormat::Human), "No skills found.");
+    }
+
+    #[test]
+    fn render_skill_list_human() {
+        let response = SkillListResponse {
+            skills: vec![
+                SkillSummary {
+                    name: "alpha".into(),
+                    description: "First skill".into(),
+                    enabled: true,
+                    source_dir: "/data/skills/alpha".into(),
+                    binary_path: Some("/data/skills/alpha/run.sh".into()),
+                },
+                SkillSummary {
+                    name: "beta".into(),
+                    description: "Second skill".into(),
+                    enabled: false,
+                    source_dir: "/data/skills/beta".into(),
+                    binary_path: None,
+                },
+            ],
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("alpha [enabled]"));
+        assert!(out.contains("beta [disabled]"));
+        assert!(out.contains("Description: First skill"));
+        assert!(out.contains("Source: /data/skills/alpha"));
+        assert!(out.contains("Binary: /data/skills/alpha/run.sh"));
+        assert!(out.contains("Binary: -"));
+    }
+
+    #[test]
+    fn render_skill_list_json() {
+        let response = SkillListResponse {
+            skills: vec![SkillSummary {
+                name: "alpha".into(),
+                description: "First skill".into(),
+                enabled: true,
+                source_dir: "/data/skills/alpha".into(),
+                binary_path: Some("/data/skills/alpha/run.sh".into()),
+            }],
+        };
+        let out = render(&response, OutputFormat::Json);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["skills"][0]["name"], "alpha");
+        assert_eq!(parsed["skills"][0]["enabled"], true);
+        assert_eq!(
+            parsed["skills"][0]["binary_path"],
+            "/data/skills/alpha/run.sh"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add a first-class  CLI family entrypoint\n- fetch installed skills from the gateway via \n- render installed skill metadata in both human and JSON output\n\n## What shipped\n- new top-level  command with  subcommand\n-  hitting \n-  /  output models with human + JSON rendering\n- parsing, output, client, and completion coverage for the new surface\n\n## Validation\n- 
running 354 tests
....................................................................................... 87/354
....................................................................................... 174/354
....................................................................................... 261/354
....................................................................................... 348/354
......
test result: ok. 354 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.69s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- \n\n## Follow-on\n- \n- \n- broader plugins/hooks lifecycle parity under #71