### PR TITLE
fix(ui): tighten mobile chat workflow on phone screens (#60)

### DIFF
--- a/ui/src/components/chat/ChatInput.tsx
+++ b/ui/src/components/chat/ChatInput.tsx
@@ -180,7 +180,7 @@ export function ChatInput({
               key={`${attachment.name}-${attachment.size}-${attachment.lastModified}-${index}`}
               file={attachment}
               onRemove={() => handleRemoveAttachment(index)}
-              className="max-w-sm"
+              className="w-full sm:max-w-sm"
             />
           ))}
         </div>
@@ -202,18 +202,7 @@ export function ChatInput({
           onChange={handleFileSelection}
           disabled={disabled}
         />
-        <div className="flex items-end gap-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => attachmentInputRef.current?.click()}
-            disabled={disabled || attachments.length >= maxAttachments}
-            className="mb-1 h-11 w-11 shrink-0 rounded-2xl text-muted-foreground"
-            aria-label="Attach image"
-          >
-            <Paperclip className="h-4 w-4" />
-          </Button>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <textarea
               ref={textareaRef}
@@ -225,21 +214,26 @@ export function ChatInput({
               disabled={disabled}
               rows={1}
               className={cn(
-                "flex-1 resize-none bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed",
+                "flex-1 resize-none bg-transparent px-3 py-2.5 text-[15px] outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed sm:text-sm",
               )}
               style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
             />
-            <div className="flex flex-wrap items-center justify-between gap-2 px-3 pb-1 text-[11px] text-muted-foreground">
+            <div className="flex flex-wrap items-center justify-between gap-2 px-1 pb-1 text-[11px] text-muted-foreground sm:px-3">
               <span className="inline-flex items-center gap-1">
                 <ImagePlus className="h-3 w-3" />
                 Paste or attach images
               </span>
-              <span className="inline-flex items-center gap-1">
+              <span className="hidden items-center gap-1 sm:inline-flex">
                 <CornerDownLeft className="h-3 w-3" />
                 Enter sends · Shift + Enter newline
               </span>
               {attachments.length > 0 && (
-                <span className="w-full text-[10px] text-muted-foreground">
+                <span className="w-full text-[10px] text-muted-foreground sm:hidden">
+                  {attachments.length}/{maxAttachments} image attachment{attachments.length === 1 ? "" : "s"} ready.
+                </span>
+              )}
+              {attachments.length > 0 && (
+                <span className="hidden w-full text-[10px] text-muted-foreground sm:block">
                   {attachments.length}/{maxAttachments} image attachment{attachments.length === 1 ? "" : "s"} queued for this send.
                 </span>
               )}
@@ -251,18 +245,35 @@ export function ChatInput({
               )}
             </div>
           </div>
-          <Button
-            onClick={handleSend}
-            disabled={sendDisabled}
-            size="icon"
-            className="mb-1 h-11 w-11 shrink-0 rounded-2xl"
-          >
-            {disabled ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Send className="h-4 w-4" />
-            )}
-          </Button>
+          <div className="flex items-center justify-between gap-2 sm:mb-1 sm:shrink-0 sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => attachmentInputRef.current?.click()}
+              disabled={disabled || attachments.length >= maxAttachments}
+              className="h-10 rounded-2xl px-3 text-muted-foreground sm:h-11 sm:w-11 sm:px-0"
+              aria-label="Attach image"
+            >
+              <Paperclip className="h-4 w-4" />
+              <span className="ml-1.5 text-xs sm:hidden">Attach</span>
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={sendDisabled}
+              size="sm"
+              className="h-10 min-w-[7rem] flex-1 rounded-2xl px-4 sm:h-11 sm:w-11 sm:flex-none sm:min-w-0 sm:px-0"
+            >
+              {disabled ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <>
+                  <Send className="h-4 w-4" />
+                  <span className="ml-1.5 text-sm sm:hidden">Send</span>
+                </>
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/src/components/chat/ChatSidebar.tsx
+++ b/ui/src/components/chat/ChatSidebar.tsx
@@ -35,6 +35,7 @@ interface ChatSidebarProps {
   selectedToolEntry?: TranscriptEntry | null;
   selectedToolPair?: TranscriptEntry | null;
   onCloseInspector?: () => void;
+  compactHeader?: boolean;
 }
 
 function statusBadgeVariant(
@@ -226,6 +227,7 @@ export function ChatSidebar({
   selectedToolEntry,
   selectedToolPair,
   onCloseInspector,
+  compactHeader = false,
 }: ChatSidebarProps) {
   const [search, setSearch] = useState("");
 
@@ -254,6 +256,11 @@ export function ChatSidebar({
     };
   }, [sessions]);
 
+  const activeSession = useMemo(
+    () => sessions?.find((session) => session.id === activeSessionId),
+    [activeSessionId, sessions],
+  );
+
   if (mode === "inspector") {
     return (
       <div
@@ -278,7 +285,12 @@ export function ChatSidebar({
         className,
       )}
     >
-      <div className="border-b border-border/70 bg-gradient-to-br from-background via-background to-primary/5 px-4 py-4">
+      <div
+        className={cn(
+          "border-b border-border/70 bg-gradient-to-br from-background via-background to-primary/5 px-4 py-4",
+          compactHeader && "px-3 py-3",
+        )}
+      >
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="flex items-center gap-2">
@@ -287,9 +299,13 @@ export function ChatSidebar({
                 Queue
               </Badge>
             </div>
-            <h2 className="mt-3 text-sm font-semibold">Session control</h2>
+            <h2 className="mt-3 text-sm font-semibold">
+              {compactHeader ? "Switch sessions" : "Session control"}
+            </h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              Jump between live work, inspect model context, and open a fresh thread fast.
+              {compactHeader
+                ? "Keep the active thread in view and jump without losing place."
+                : "Jump between live work, inspect model context, and open a fresh thread fast."}
             </p>
           </div>
           <Button
@@ -304,23 +320,37 @@ export function ChatSidebar({
           </Button>
         </div>
 
-        <div className="mt-4 grid grid-cols-3 gap-2">
-          <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
-            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Total</p>
-            <p className="mt-1 text-sm font-semibold">{summary.total}</p>
+        {compactHeader ? (
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+              {summary.total} sessions
+            </span>
+            <span className="rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+              {summary.active} active
+            </span>
+            <span className="rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+              {summary.withModels} models
+            </span>
           </div>
-          <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
-            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Active</p>
-            <p className="mt-1 text-sm font-semibold">{summary.active}</p>
+        ) : (
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
+              <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Total</p>
+              <p className="mt-1 text-sm font-semibold">{summary.total}</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
+              <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Active</p>
+              <p className="mt-1 text-sm font-semibold">{summary.active}</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
+              <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Models</p>
+              <p className="mt-1 text-sm font-semibold">{summary.withModels}</p>
+            </div>
           </div>
-          <div className="rounded-2xl border border-border/70 bg-background/80 px-3 py-2">
-            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Models</p>
-            <p className="mt-1 text-sm font-semibold">{summary.withModels}</p>
-          </div>
-        </div>
+        )}
       </div>
 
-      <div className="px-4 py-3">
+      <div className={cn("px-4 py-3", compactHeader && "px-3 py-2.5")}>
         <div className="relative">
           <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -332,9 +362,32 @@ export function ChatSidebar({
         </div>
       </div>
 
+      {compactHeader && activeSession && (
+        <div className="px-3 pb-2">
+          <div className="rounded-2xl border border-primary/20 bg-primary/5 px-3 py-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                Current session
+              </p>
+              <Badge variant={statusBadgeVariant(activeSession.status)} className="text-[10px]">
+                {activeSession.status}
+              </Badge>
+            </div>
+            <code className="mt-1 block truncate text-xs font-medium text-foreground">
+              {activeSession.id}
+            </code>
+            {activeSession.preview && (
+              <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                {activeSession.preview}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       <Separator />
 
-      <div className="flex-1 overflow-y-auto px-2 pb-2">
+      <div className={cn("flex-1 overflow-y-auto px-2 pb-2", compactHeader && "px-1.5 pb-1.5")}>
         {isLoading ? (
           <div className="space-y-2 p-2">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -355,6 +408,7 @@ export function ChatSidebar({
                   onClick={() => onSelectSession?.(session.id)}
                   className={cn(
                     "group flex w-full flex-col gap-2 rounded-2xl border px-3 py-3 text-left transition-all",
+                    compactHeader && "gap-1.5 px-3 py-2.5",
                     isSessionActive
                       ? "border-primary/40 bg-primary/10 text-foreground shadow-[0_12px_30px_rgba(249,115,22,0.12)]"
                       : "border-border/70 bg-background/70 hover:border-primary/25 hover:bg-primary/5",
@@ -380,7 +434,12 @@ export function ChatSidebar({
                           session.last_activity_at ?? session.updated_at ?? session.created_at,
                         )}
                       </p>
-                      <p className="mt-2 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground/90">
+                      <p
+                        className={cn(
+                          "mt-2 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground/90",
+                          compactHeader && "mt-1.5 line-clamp-3",
+                        )}
+                      >
                         {session.preview}
                       </p>
                     </div>

--- a/ui/src/components/chat/ChatThread.tsx
+++ b/ui/src/components/chat/ChatThread.tsx
@@ -274,16 +274,16 @@ export function ChatThread({
         ref={containerRef}
         onScroll={checkScrollPosition}
         className={cn(
-          "flex h-full flex-col gap-4 overflow-y-auto py-4",
-          focusMode ? "px-4 sm:px-8 lg:px-12" : "px-3 sm:px-4",
+          "flex h-full flex-col gap-3 overflow-y-auto py-3 scroll-pb-28 sm:gap-4 sm:py-4 sm:scroll-pb-6",
+          focusMode ? "px-3 sm:px-8 lg:px-12" : "px-2.5 sm:px-4",
         )}
       >
         {groups.map((group, gi) => {
           if (group.type === "date_divider") {
             return (
-              <div key={`date-${gi}`} className="flex items-center gap-3 px-1 py-1">
+              <div key={`date-${gi}`} className="flex items-center gap-2 px-0.5 py-1 sm:gap-3 sm:px-1">
                 <Separator className="flex-1 bg-border/60" />
-                <span className="rounded-full border border-border/70 bg-background/85 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                <span className="rounded-full border border-border/70 bg-background/85 px-2.5 py-1 text-[9px] font-medium uppercase tracking-[0.16em] text-muted-foreground sm:px-3 sm:text-[10px]">
                   {group.dateLabel}
                 </span>
                 <Separator className="flex-1 bg-border/60" />
@@ -297,10 +297,10 @@ export function ChatThread({
           if (group.type === "message") {
             const entry = group.entries[0];
             return (
-              <div key={entry.id} className="space-y-2">
+              <div key={entry.id} className="space-y-1.5 sm:space-y-2">
                 <div
                   className={cn(
-                    "flex px-1",
+                    "hidden px-1 sm:flex",
                     normalizeTranscriptKind(entry.kind) === "user" ? "justify-end" : "justify-start",
                   )}
                 >
@@ -323,7 +323,7 @@ export function ChatThread({
 
           if (group.type === "tool_pair") {
             return (
-              <div key={`tool-group-${gi}`} className="space-y-2 px-1 sm:px-2">
+              <div key={`tool-group-${gi}`} className="space-y-1.5 px-0.5 sm:space-y-2 sm:px-2">
                 <Badge
                   variant="outline"
                   className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
@@ -356,7 +356,7 @@ export function ChatThread({
           }
 
           return (
-            <div key={`other-${gi}`} className="space-y-2">
+            <div key={`other-${gi}`} className="space-y-1.5 sm:space-y-2">
               <Badge
                 variant="outline"
                 className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
@@ -379,7 +379,7 @@ export function ChatThread({
       </div>
 
       {hasNewMessages && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 sm:bottom-4">
           <Button
             variant="secondary"
             size="sm"

--- a/ui/src/routes/_admin/chat.tsx
+++ b/ui/src/routes/_admin/chat.tsx
@@ -279,8 +279,8 @@ function ChatPage() {
   return (
     <div className="space-y-4">
       <section className="overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-background via-background to-primary/5 shadow-[0_24px_80px_rgba(249,115,22,0.10)]">
-        <div className="grid gap-5 px-5 py-5 sm:px-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:px-8 lg:py-6">
-          <div className="space-y-4">
+        <div className="grid gap-4 px-4 py-4 sm:px-6 sm:py-5 lg:grid-cols-[minmax(0,1fr)_360px] lg:px-8 lg:py-6">
+          <div className="space-y-3 sm:space-y-4">
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline" className="border-primary/25 bg-primary/10 text-primary">
                 <Sparkles className="mr-1 h-3 w-3" />
@@ -313,13 +313,16 @@ function ChatPage() {
               )}
             </div>
 
-            <div className="space-y-2">
+            <div className="space-y-1.5 sm:space-y-2">
               <p className={designSystem.typography.display.eyebrow}>Admin Chat</p>
               <div>
-                <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                <h1 className="text-xl font-semibold tracking-tight sm:text-3xl">
                   Run sessions like an ops console, not a toy inbox.
                 </h1>
-                <p className="mt-2 max-w-2xl text-sm text-muted-foreground sm:text-base">
+                <p className="mt-2 text-sm text-muted-foreground sm:hidden">
+                  Keep the active transcript readable, switch sessions quickly, and reply without leaving the thread.
+                </p>
+                <p className="mt-2 hidden max-w-2xl text-sm text-muted-foreground sm:block sm:text-base">
                   Keep the active transcript, session queue, and runtime signal in one place.
                   Fast switching, live updates, and admin-first context without copying OpenClaw’s layout.
                 </p>
@@ -327,8 +330,8 @@ function ChatPage() {
             </div>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-            <Card className="border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur">
+          <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1 sm:mx-0 sm:grid sm:px-0 sm:pb-0 lg:grid-cols-1 xl:grid-cols-3">
+            <Card className="min-w-[15rem] border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur sm:min-w-0">
               <CardContent className="px-4 py-4">
                 <div className="flex items-center gap-3">
                   <div className="rounded-2xl bg-primary/10 p-2 text-primary">
@@ -346,7 +349,7 @@ function ChatPage() {
               </CardContent>
             </Card>
 
-            <Card className="border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur">
+            <Card className="min-w-[15rem] border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur sm:min-w-0">
               <CardContent className="px-4 py-4">
                 <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
                   Transcript load
@@ -358,7 +361,7 @@ function ChatPage() {
               </CardContent>
             </Card>
 
-            <Card className="border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur">
+            <Card className="min-w-[15rem] border-primary/20 bg-background/75 py-0 shadow-none backdrop-blur sm:min-w-0">
               <CardContent className="px-4 py-4">
                 <div className="flex items-center gap-3">
                   <div className="rounded-2xl bg-accent/10 p-2 text-accent">
@@ -438,7 +441,7 @@ function ChatPage() {
                     Sessions
                   </Button>
                 </SheetTrigger>
-                <SheetContent side="left" className="w-[320px] border-r p-0">
+                <SheetContent side="left" className="w-[min(100vw,24rem)] border-r p-0">
                   <SheetHeader className="border-b px-4 py-4">
                     <SheetTitle>Session queue</SheetTitle>
                   </SheetHeader>
@@ -450,6 +453,7 @@ function ChatPage() {
                     onCreateSession={handleCreateSession}
                     isCreating={createSession.isPending}
                     className="border-r-0"
+                    compactHeader
                   />
                 </SheetContent>
               </Sheet>
@@ -459,11 +463,13 @@ function ChatPage() {
                   <div className="space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
                       <h2 className="text-sm font-semibold sm:text-base">Live transcript</h2>
-                      <Badge variant="outline" className="font-mono text-[10px]">
-                        {activeSessionId}
+                      <Badge variant="outline" className="max-w-[14rem] font-mono text-[10px] sm:max-w-full">
+                        <span className="block truncate">
+                          {activeSessionId}
+                        </span>
                       </Badge>
                     </div>
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground sm:text-xs">
                       {activeSession?.channel && <span>Channel: {activeSession.channel}</span>}
                       {typeof activeSession?.turn_count === "number" && (
                         <span>{activeSession.turn_count} turns</span>
@@ -481,7 +487,7 @@ function ChatPage() {
                 )}
               </div>
 
-              <div className="flex flex-wrap items-center justify-end gap-2">
+              <div className="flex w-full flex-wrap items-center justify-start gap-2 sm:w-auto sm:justify-end">
                 <div className="hidden items-center gap-3 rounded-2xl border border-border/70 bg-background/70 px-3 py-2 lg:flex">
                   <Label htmlFor="chat-focus-mode" className="gap-1.5 text-[11px] text-muted-foreground">
                     <Focus className="h-3.5 w-3.5" />
@@ -520,12 +526,13 @@ function ChatPage() {
                 {activeSessionId ? (
                   <Button
                     variant="ghost"
-                    size="icon-sm"
+                    size="sm"
                     onClick={() => void refetchTranscript()}
                     aria-label="Refresh transcript"
-                    className={transcriptFetching ? "animate-spin" : undefined}
+                    className="gap-2 rounded-xl"
                   >
-                    <RefreshCw className="h-4 w-4" />
+                    <RefreshCw className={transcriptFetching ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+                    <span className="lg:hidden">Refresh</span>
                   </Button>
                 ) : null}
                 <Button


### PR DESCRIPTION
## Summary
- tighten the mobile chat workflow so active transcripts, session switching, and message sending feel better on phone-width screens
- improve mobile chat composer ergonomics, compact session-queue header behavior, and transcript spacing/readability
- keep the slice UI-only and scoped to the mobile chat flow

## Validation
- `cd ui && npm run build`
- `cd ui && npm run lint`

## Scope
- `ui/src/components/chat/ChatInput.tsx`
- `ui/src/components/chat/ChatSidebar.tsx`
- `ui/src/components/chat/ChatThread.tsx`
- `ui/src/routes/_admin/chat.tsx`
