### PR TITLE
feat(cli): add  surface (#71)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -461,6 +461,8 @@ pub enum ModelsAction {
 pub enum SkillsAction {
     /// List installed skills discovered by the gateway.
     List,
+    /// Re-scan the skills directory and report load/remove counts.
+    Check,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1007,6 +1009,17 @@ mod tests {
             cli.command,
             Command::Skills {
                 action: SkillsAction::List
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_skills_check() {
+        let cli = Cli::try_parse_from(["rune", "skills", "check"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Skills {
+                action: SkillsAction::Check
             }
         ));
     }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -19,7 +19,8 @@ use crate::output::{
     ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
-    SessionTreeNode, SessionTreeResponse, SkillListResponse, SkillSummary, StatusResponse,
+    SessionTreeNode, SessionTreeResponse, SkillCheckResponse, SkillListResponse, SkillSummary,
+    StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -215,6 +216,24 @@ impl GatewayClient {
                 .await
                 .context("invalid JSON from /skills")?;
             Ok(SkillListResponse { skills })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `POST /skills/reload`
+    pub async fn skills_check(&self) -> Result<SkillCheckResponse> {
+        let resp = self
+            .http
+            .post(self.url("/skills/reload"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            resp.json::<SkillCheckResponse>()
+                .await
+                .context("invalid JSON from /skills/reload")
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2794,6 +2813,28 @@ mod tests {
         assert_eq!(resp.skills[1].name, "beta");
         assert!(!resp.skills[1].enabled);
         assert!(resp.skills[1].binary_path.is_none());
+    }
+
+    #[tokio::test]
+    async fn skills_check_parses_reload_summary() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/skills/reload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "discovered": 4,
+                "loaded": 3,
+                "removed": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.skills_check().await.unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.discovered, 4);
+        assert_eq!(resp.loaded, 3);
+        assert_eq!(resp.removed, 1);
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -26,8 +26,7 @@ use cli::{
     AgentsAction, ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell,
     ConfigAction, CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
     MessageTagAction, MessageThreadAction, MessageVoiceAction, ModelsAction, RemindersAction,
-    SessionsAction,
-    SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
+    SessionsAction, SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -969,6 +968,10 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Skills { action } => match action {
             SkillsAction::List => {
                 let result = client.skills_list().await?;
+                println!("{}", render(&result, format));
+            }
+            SkillsAction::Check => {
+                let result = client.skills_check().await?;
                 println!("{}", render(&result, format));
             }
         },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -557,6 +557,29 @@ impl fmt::Display for SkillListResponse {
     }
 }
 
+/// Response for `rune skills check`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillCheckResponse {
+    pub success: bool,
+    pub discovered: usize,
+    pub loaded: usize,
+    pub removed: usize,
+}
+
+impl fmt::Display for SkillCheckResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.success {
+            write!(
+                f,
+                "Skill scan complete — discovered {}, loaded {}, removed {}",
+                self.discovered, self.loaded, self.removed
+            )
+        } else {
+            write!(f, "Skill scan failed.")
+        }
+    }
+}
+
 /// First-class `/status` / `session_status` parity card for an individual session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionStatusCard {
@@ -3158,6 +3181,37 @@ mod tests {
             parsed["skills"][0]["binary_path"],
             "/data/skills/alpha/run.sh"
         );
+    }
+
+    #[test]
+    fn render_skill_check_human() {
+        let response = SkillCheckResponse {
+            success: true,
+            discovered: 3,
+            loaded: 2,
+            removed: 1,
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Skill scan complete"));
+        assert!(out.contains("discovered 3"));
+        assert!(out.contains("loaded 2"));
+        assert!(out.contains("removed 1"));
+    }
+
+    #[test]
+    fn render_skill_check_json() {
+        let response = SkillCheckResponse {
+            success: true,
+            discovered: 3,
+            loaded: 2,
+            removed: 1,
+        };
+        let out = render(&response, OutputFormat::Json);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["success"], true);
+        assert_eq!(parsed["discovered"], 3);
+        assert_eq!(parsed["loaded"], 2);
+        assert_eq!(parsed["removed"], 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add a first-class  CLI surface\n- trigger the gateway's skill directory re-scan via \n- render discovered/loaded/removed counts in both human and JSON output\n\n## What shipped\n-  subcommand under the new  family\n-  hitting \n-  output model with human + JSON rendering\n- parse, client, output, and completion coverage for the new surface\n\n## Validation\n- 
running 358 tests
....................................................................................... 87/358
....................................................................................... 174/358
....................................................................................... 261/358
....................................................................................... 348/358
..........
test result: ok. 358 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.67s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- \n\n## Follow-on\n- \n- skill enable/disable CLI surfaces\n- broader plugins/hooks lifecycle parity under #71