### PR TITLE
feat(config): clarify zero-config env and startup coherence (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -23,7 +23,9 @@ use tokio::signal;
 use tracing::{error, info, warn};
 
 use rune_channels::TelegramAdapter;
-use rune_config::{AppConfig, MemoryLevel, RuntimeMode, StorageBackend};
+use rune_config::{
+    AppConfig, MemoryLevel, ModelBootstrap, PathsProfile, RuntimeMode, StorageBackend,
+};
 use rune_core::ToolCategory;
 use rune_gateway::{Services, init_logging, start};
 use rune_mcp::discovery::McpServerConfig as RuntimeMcpServerConfig;
@@ -63,6 +65,7 @@ use rune_tools::{ToolCall, ToolDefinition, ToolError, ToolExecutor, ToolRegistry
 
 const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
 const OPENAI_BASE_URL_ENV: &str = "OPENAI_BASE_URL";
+const OLLAMA_HOST_ENV: &str = "OLLAMA_HOST";
 const MEMORY_INDEX_POLL_INTERVAL_SECS_ENV: &str = "RUNE_MEMORY_INDEX_POLL_INTERVAL_SECS";
 const DEFAULT_MEMORY_INDEX_POLL_INTERVAL_SECS: u64 = 5;
 
@@ -86,7 +89,7 @@ async fn main() -> Result<()> {
     config.adjust_paths_for_mode(&resolved_mode);
 
     init_logging(&config.logging);
-    emit_startup_banner(&config, config_path);
+    emit_startup_banner(&config, &flags, &resolved_mode);
 
     // Auto-create missing directories in Standalone mode so that `rune` boots
     // without manual `mkdir` (zero-config, issue #61).
@@ -141,13 +144,37 @@ async fn main() -> Result<()> {
 /// small.  We parse the handful of supported flags manually.
 struct StartupFlags {
     config_path: Option<PathBuf>,
+    config_source: ConfigPathSource,
     yolo: bool,
     no_sandbox: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConfigPathSource {
+    Cli,
+    Env,
+    Defaults,
+}
+
+impl ConfigPathSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Env => "env:RUNE_CONFIG",
+            Self::Defaults => "defaults+env",
+        }
+    }
+}
+
+struct DefaultModelSelection {
+    model: String,
+    source: &'static str,
 }
 
 fn parse_startup_flags() -> StartupFlags {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut config_path: Option<PathBuf> = None;
+    let mut config_source = ConfigPathSource::Defaults;
     let mut yolo = false;
     let mut no_sandbox = false;
 
@@ -157,6 +184,7 @@ fn parse_startup_flags() -> StartupFlags {
             "--config" => {
                 if i + 1 < args.len() {
                     config_path = Some(PathBuf::from(&args[i + 1]));
+                    config_source = ConfigPathSource::Cli;
                     i += 2;
                     continue;
                 }
@@ -170,11 +198,15 @@ fn parse_startup_flags() -> StartupFlags {
 
     // Fall back to RUNE_CONFIG env var when --config is not passed.
     if config_path.is_none() {
-        config_path = std::env::var_os("RUNE_CONFIG").map(PathBuf::from);
+        if let Some(path) = std::env::var_os("RUNE_CONFIG").map(PathBuf::from) {
+            config_path = Some(path);
+            config_source = ConfigPathSource::Env;
+        }
     }
 
     StartupFlags {
         config_path,
+        config_source,
         yolo,
         no_sandbox,
     }
@@ -185,7 +217,7 @@ fn display_config_path(path: Option<&Path>) -> String {
         .unwrap_or_else(|| "<defaults+env>".to_string())
 }
 
-fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
+fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: &RuntimeMode) {
     let store_backend = match config.database.backend {
         StorageBackend::Sqlite => "sqlite",
         StorageBackend::Postgres => {
@@ -203,35 +235,108 @@ fn emit_startup_banner(config: &AppConfig, config_path: Option<&Path>) {
             }
         }
     };
+    let config_path = flags.config_path.as_deref();
+    let ollama_host = trimmed_env_var(OLLAMA_HOST_ENV);
+    let state_root = state_root_display(config);
 
     info!(
         version = env!("CARGO_PKG_VERSION"),
         host = %config.gateway.host,
         port = config.gateway.port,
+        config_source = flags.config_source.as_str(),
         config_path = %display_config_path(config_path),
+        requested_mode = config.mode.as_str(),
+        resolved_mode = resolved_mode.as_str(),
+        paths_profile = config.paths.profile().as_str(),
+        state_root = %state_root,
         store_backend,
-        model_backend = if config.models.providers.is_empty() { "auto-detect (probing Ollama…)" } else { "configured" },
+        model_bootstrap = config.models.bootstrap().as_str(),
+        ollama_host = ollama_host.as_deref().unwrap_or("<default>"),
         approval_mode = config.approval.mode.as_str(),
         security_posture = config.security.posture(),
         "starting rune gateway"
     );
 
+    if config.models.bootstrap() == ModelBootstrap::ZeroConfigOllama {
+        if let Some(model) = config.models.default_model.as_deref() {
+            info!(
+                model = model,
+                "models.default_model is set — Rune will prefer it over the Ollama auto-pick if zero-config Ollama is available"
+            );
+        }
+    } else if let Some(ollama_host) = ollama_host {
+        info!(
+            ollama_host = %ollama_host,
+            "OLLAMA_HOST is set but explicit model providers are configured, so zero-config Ollama auto-detect is disabled"
+        );
+    }
+
     // First-use vs. acknowledged bypass warning (issue #64).
     if let Some(posture) = rune_config::BypassPosture::detect(config) {
-        let ack = rune_config::BypassAcknowledgment::from_home()
-            .unwrap_or_else(|| {
-                rune_config::BypassAcknowledgment::new(std::path::Path::new("/tmp/.rune-config"))
-            });
+        let ack = rune_config::BypassAcknowledgment::from_home().unwrap_or_else(|| {
+            rune_config::BypassAcknowledgment::new(std::path::Path::new("/tmp/.rune-config"))
+        });
 
         if ack.is_acknowledged() {
             let reminder = posture.acknowledged_reminder();
-            info!(bypass = reminder, "trusted-environment bypass active (previously acknowledged)");
+            info!(
+                bypass = reminder,
+                "trusted-environment bypass active (previously acknowledged)"
+            );
         } else {
             let warning = posture.first_use_warning();
             eprintln!("{warning}");
             warn!(warning = %warning, "trusted-environment bypass active — NOT YET ACKNOWLEDGED");
         }
     }
+}
+
+fn trimmed_env_var(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn state_root_display(config: &AppConfig) -> String {
+    match config.paths.profile() {
+        PathsProfile::DockerDefault => "/data (+ /config, /secrets)".to_string(),
+        PathsProfile::StandaloneHome | PathsProfile::Custom => config
+            .paths
+            .db_dir
+            .parent()
+            .unwrap_or(Path::new("."))
+            .display()
+            .to_string(),
+    }
+}
+
+fn select_default_model(
+    config: &AppConfig,
+    auto_default_model: Option<String>,
+) -> Option<DefaultModelSelection> {
+    if let Some(model) = config
+        .agents
+        .default_agent()
+        .and_then(|agent| config.agents.effective_model(agent))
+    {
+        return Some(DefaultModelSelection {
+            model: model.to_string(),
+            source: "agent-config",
+        });
+    }
+
+    if let Some(model) = config.models.default_model.as_ref() {
+        return Some(DefaultModelSelection {
+            model: model.clone(),
+            source: "models.default_model",
+        });
+    }
+
+    auto_default_model.map(|model| DefaultModelSelection {
+        model,
+        source: "ollama-auto",
+    })
 }
 
 /// Build all services, returning an optional `EmbeddedPg` handle that
@@ -362,18 +467,15 @@ async fn build_services(
         Arc::new(NoOpCompaction),
     );
 
-    // Resolve default model: agent config → models.default_model → auto-detected Ollama model
-    let default_model = config
-        .agents
-        .default_agent()
-        .and_then(|a| config.agents.effective_model(a))
-        .map(String::from)
-        .or_else(|| config.models.default_model.clone())
-        .or(auto_default_model);
+    let default_model = select_default_model(&config, auto_default_model);
 
-    if let Some(ref model) = default_model {
-        turn_executor = turn_executor.with_default_model(model);
-        info!(model = %model, "default model configured");
+    if let Some(selection) = default_model {
+        turn_executor = turn_executor.with_default_model(&selection.model);
+        info!(
+            model = %selection.model,
+            source = selection.source,
+            "default model configured"
+        );
     }
 
     turn_executor = turn_executor.with_lane_queue(lane_queue.clone());
@@ -2037,27 +2139,34 @@ impl SubagentManager for LiveSubagentManager {
 /// element is `Some` only when Ollama was auto-detected **and** at least one
 /// model is available — callers should use it as a fallback when no explicit
 /// `default_model` is configured.
-async fn build_model_provider(
-    config: &AppConfig,
-) -> (Arc<dyn ModelProvider>, Option<String>) {
+async fn build_model_provider(config: &AppConfig) -> (Arc<dyn ModelProvider>, Option<String>) {
+    let ollama_host = trimmed_env_var(OLLAMA_HOST_ENV);
+
     if !config.models.providers.is_empty() {
-        let provider: Arc<dyn ModelProvider> =
-            match RoutedModelProvider::from_models_config(&config.models) {
-                Ok(provider) => Arc::new(provider),
-                Err(error) => {
-                    warn!(error = %error, "failed to build routed model provider, falling back to echo");
-                    Arc::new(EchoModelProvider)
-                }
-            };
+        let provider: Arc<dyn ModelProvider> = match RoutedModelProvider::from_models_config(
+            &config.models,
+        ) {
+            Ok(provider) => Arc::new(provider),
+            Err(error) => {
+                warn!(error = %error, "failed to build routed model provider, falling back to echo");
+                Arc::new(EchoModelProvider)
+            }
+        };
         return (provider, None);
     }
 
-    // Zero-config Ollama auto-detection (issue #61): honour OLLAMA_HOST
-    // for non-default endpoints, then fall back to localhost:11434.
-    info!("no model providers configured — probing for local Ollama…");
+    let probe_target = ollama_host.as_deref().unwrap_or("http://localhost:11434");
+    info!(
+        probe_target,
+        "no model providers configured — probing zero-config Ollama"
+    );
     match rune_models::OllamaProvider::probe_env().await {
         Some(provider) => {
-            info!(url = %provider.url(), "Ollama detected — using as default provider");
+            info!(
+                ollama_base = %provider.base_url(),
+                url = %provider.url(),
+                "Ollama detected — using as default provider"
+            );
 
             // Auto-select the best pulled model as the default (issue #61).
             let auto_model = provider.pick_default_model().await;
@@ -2077,7 +2186,16 @@ async fn build_model_provider(
             (Arc::new(provider), auto_model)
         }
         None => {
-            info!("no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)");
+            if let Some(ollama_host) = ollama_host {
+                warn!(
+                    ollama_host = %ollama_host,
+                    "OLLAMA_HOST is set but Rune could not reach Ollama there — using echo fallback"
+                );
+            } else {
+                info!(
+                    "no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)"
+                );
+            }
             (Arc::new(EchoModelProvider), None)
         }
     }
@@ -2093,6 +2211,44 @@ mod tests {
     use rune_store::StoreError;
     use rune_store::models::{KeywordSearchRow, VectorSearchRow};
     use rune_tools::memory_index::EmbeddingProvider;
+
+    #[test]
+    fn select_default_model_prefers_agent_over_config_and_auto() {
+        let mut config = AppConfig::default();
+        config.models.default_model = Some("models-default".into());
+        config.agents.list = vec![rune_config::AgentConfig {
+            id: "coder".into(),
+            default: Some(true),
+            model: Some(rune_config::AgentModelSelection::Id("agent-default".into())),
+            workspace: None,
+            system_prompt: None,
+        }];
+
+        let selection =
+            select_default_model(&config, Some("ollama-auto".into())).expect("selection");
+        assert_eq!(selection.model, "agent-default");
+        assert_eq!(selection.source, "agent-config");
+    }
+
+    #[test]
+    fn select_default_model_uses_models_default_before_auto_pick() {
+        let mut config = AppConfig::default();
+        config.models.default_model = Some("models-default".into());
+
+        let selection =
+            select_default_model(&config, Some("ollama-auto".into())).expect("selection");
+        assert_eq!(selection.model, "models-default");
+        assert_eq!(selection.source, "models.default_model");
+    }
+
+    #[test]
+    fn select_default_model_falls_back_to_ollama_auto_pick() {
+        let config = AppConfig::default();
+
+        let selection = select_default_model(&config, Some("llama3.2".into())).expect("selection");
+        assert_eq!(selection.model, "llama3.2");
+        assert_eq!(selection.source, "ollama-auto");
+    }
 
     #[tokio::test]
     async fn build_memory_tool_executor_uses_file_mode_local_scan() {

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -187,18 +187,7 @@ impl AppConfig {
             return; // user overrode, don't touch
         }
         if let Some(home) = home_dir() {
-            let r = home.join(".rune");
-            self.paths = PathsConfig {
-                db_dir: r.join("db"),
-                sessions_dir: r.join("sessions"),
-                memory_dir: r.join("memory"),
-                media_dir: r.join("media"),
-                skills_dir: r.join("skills"),
-                logs_dir: r.join("logs"),
-                backups_dir: r.join("backups"),
-                config_dir: r.join("config"),
-                secrets_dir: r.join("secrets"),
-            };
+            self.paths = standalone_paths_root(&home);
         }
     }
 }
@@ -207,6 +196,21 @@ fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
+}
+
+fn standalone_paths_root(home: &Path) -> PathsConfig {
+    let root = home.join(".rune");
+    PathsConfig {
+        db_dir: root.join("db"),
+        sessions_dir: root.join("sessions"),
+        memory_dir: root.join("memory"),
+        media_dir: root.join("media"),
+        skills_dir: root.join("skills"),
+        logs_dir: root.join("logs"),
+        backups_dir: root.join("backups"),
+        config_dir: root.join("config"),
+        secrets_dir: root.join("secrets"),
+    }
 }
 
 /// Attempt to create and remove a probe file to verify actual writability.
@@ -305,9 +309,12 @@ impl Default for GatewayConfig {
 
 /// Which runtime mode the process is operating in.
 ///
-/// `Auto` (the default) heuristically resolves to `Server` when a database URL
-/// is set, Docker/Kubernetes is detected, or paths begin with `/data`.
-/// Otherwise resolves to `Standalone`.
+/// `Auto` (the default) resolves to `Standalone` for bare-host first use even
+/// when the config is still at Docker-first defaults. The gateway then remaps
+/// those defaults to `~/.rune/*` during startup.
+///
+/// `Auto` resolves to `Server` when a database URL is set, Docker/Kubernetes
+/// is detected, or the operator explicitly points path roots at `/data`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeMode {
@@ -320,6 +327,14 @@ pub enum RuntimeMode {
 impl RuntimeMode {
     /// Resolve `Auto` to a concrete mode based on config and environment signals.
     pub fn resolve(&self, config: &AppConfig) -> RuntimeMode {
+        self.resolve_with_runtime_signals(config, runtime_server_signals_present())
+    }
+
+    fn resolve_with_runtime_signals(
+        &self,
+        config: &AppConfig,
+        runtime_server_signals_present: bool,
+    ) -> RuntimeMode {
         match self {
             RuntimeMode::Standalone => RuntimeMode::Standalone,
             RuntimeMode::Server => RuntimeMode::Server,
@@ -327,12 +342,13 @@ impl RuntimeMode {
                 if config.database.database_url.is_some() {
                     return RuntimeMode::Server;
                 }
-                if config.paths.db_dir.starts_with("/data") {
+                if runtime_server_signals_present {
                     return RuntimeMode::Server;
                 }
-                if std::path::Path::new("/.dockerenv").exists()
-                    || std::env::var("KUBERNETES_SERVICE_HOST").is_ok()
-                {
+                if config.paths == PathsConfig::default() {
+                    return RuntimeMode::Standalone;
+                }
+                if config.paths.db_dir.starts_with("/data") {
                     return RuntimeMode::Server;
                 }
                 RuntimeMode::Standalone
@@ -347,6 +363,10 @@ impl RuntimeMode {
             RuntimeMode::Server => "server",
         }
     }
+}
+
+fn runtime_server_signals_present() -> bool {
+    std::path::Path::new("/.dockerenv").exists() || std::env::var("KUBERNETES_SERVICE_HOST").is_ok()
 }
 
 /// Which storage backend to use.
@@ -465,6 +485,15 @@ pub struct ModelsConfig {
 }
 
 impl ModelsConfig {
+    #[must_use]
+    pub fn bootstrap(&self) -> ModelBootstrap {
+        if self.providers.is_empty() {
+            ModelBootstrap::ZeroConfigOllama
+        } else {
+            ModelBootstrap::ExplicitProviders
+        }
+    }
+
     /// Return every configured model in canonical `provider/model` form.
     #[must_use]
     pub fn inventory(&self) -> Vec<ModelInventoryEntry<'_>> {
@@ -921,6 +950,61 @@ impl Default for PathsConfig {
     }
 }
 
+/// High-level path layout profile surfaced in startup diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PathsProfile {
+    DockerDefault,
+    StandaloneHome,
+    Custom,
+}
+
+impl PathsProfile {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DockerDefault => "docker-default",
+            Self::StandaloneHome => "standalone-home",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+impl PathsConfig {
+    #[must_use]
+    pub fn profile(&self) -> PathsProfile {
+        if *self == PathsConfig::default() {
+            return PathsProfile::DockerDefault;
+        }
+
+        if let Some(home) = home_dir() {
+            if *self == standalone_paths_root(&home) {
+                return PathsProfile::StandaloneHome;
+            }
+        }
+
+        PathsProfile::Custom
+    }
+}
+
+/// How models bootstrap at startup before any request is executed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelBootstrap {
+    ExplicitProviders,
+    ZeroConfigOllama,
+}
+
+impl ModelBootstrap {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExplicitProviders => "explicit-providers",
+            Self::ZeroConfigOllama => "zero-config-ollama",
+        }
+    }
+}
+
 /// Multi-agent configuration.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentsConfig {
@@ -1163,10 +1247,7 @@ impl BypassAcknowledgment {
         }
         std::fs::write(
             &self.sentinel_path,
-            format!(
-                "Bypass risk acknowledged at {:?}\n",
-                SystemTime::now()
-            ),
+            format!("Bypass risk acknowledged at {:?}\n", SystemTime::now()),
         )
     }
 
@@ -1212,18 +1293,24 @@ impl BypassPosture {
     /// Full warning message shown on first use.
     pub fn first_use_warning(self) -> &'static str {
         match self {
-            Self::FullUnrestricted => "\
+            Self::FullUnrestricted => {
+                "\
 WARNING: Rune is starting in unrestricted mode (--yolo + --no-sandbox).
 All tool approvals are auto-bypassed and sandbox boundaries are disabled.
-Only use this in trusted environments (local dev, air-gapped infra).",
-            Self::YoloOnly => "\
+Only use this in trusted environments (local dev, air-gapped infra)."
+            }
+            Self::YoloOnly => {
+                "\
 WARNING: Rune is starting with approval bypass enabled (--yolo).
 All tool calls will be auto-approved without operator confirmation.
-Only use this in trusted environments.",
-            Self::NoSandboxOnly => "\
+Only use this in trusted environments."
+            }
+            Self::NoSandboxOnly => {
+                "\
 WARNING: Rune is starting with sandbox disabled (--no-sandbox).
 Workspace boundary enforcement is off — agents can access the full filesystem.
-Only use this in trusted environments.",
+Only use this in trusted environments."
+            }
         }
     }
 
@@ -2000,6 +2087,27 @@ models = ["gpt-5.4", "gpt-image-1"]
         assert!(config.models.fallbacks.is_empty());
         assert!(config.models.image_fallbacks.is_empty());
         assert!(config.models.auth_orders.is_empty());
+        assert_eq!(config.models.bootstrap(), ModelBootstrap::ZeroConfigOllama);
+    }
+
+    #[test]
+    fn models_bootstrap_detects_explicit_provider_config() {
+        let config = ModelsConfig {
+            providers: vec![ModelProviderConfig {
+                name: "openai".into(),
+                kind: "openai".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("OPENAI_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(config.bootstrap(), ModelBootstrap::ExplicitProviders);
     }
 
     #[test]
@@ -2092,22 +2200,23 @@ models = ["gpt-5.4", "gpt-image-1"]
     fn runtime_mode_auto_resolves_server_with_database_url() {
         let mut config = AppConfig::default();
         config.database.database_url = Some("postgres://localhost/rune".into());
-        // paths are Docker-default (/data), but database_url triggers server first
-        let resolved = config.mode.resolve(&config);
+        let resolved = config.mode.resolve_with_runtime_signals(&config, false);
         assert_eq!(resolved, RuntimeMode::Server);
     }
 
     #[test]
-    fn runtime_mode_auto_resolves_standalone_without_signals() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::remove_var("KUBERNETES_SERVICE_HOST");
-        }
-        let mut config = AppConfig::default();
-        // Override paths to non-Docker to avoid the /data heuristic
-        config.paths.db_dir = PathBuf::from("/tmp/rune-test/db");
-        let resolved = config.mode.resolve(&config);
+    fn runtime_mode_auto_resolves_standalone_for_bare_host_defaults() {
+        let config = AppConfig::default();
+        let resolved = config.mode.resolve_with_runtime_signals(&config, false);
         assert_eq!(resolved, RuntimeMode::Standalone);
+    }
+
+    #[test]
+    fn runtime_mode_auto_resolves_server_for_custom_data_mounts() {
+        let mut config = AppConfig::default();
+        config.paths.db_dir = PathBuf::from("/data/custom/db");
+        let resolved = config.mode.resolve_with_runtime_signals(&config, false);
+        assert_eq!(resolved, RuntimeMode::Server);
     }
 
     #[test]
@@ -2129,6 +2238,22 @@ models = ["gpt-5.4", "gpt-image-1"]
         );
         unsafe {
             // Restore — don't leak into other tests
+            std::env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn paths_profile_detects_standalone_home_layout() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("HOME", "/home/testuser");
+        }
+
+        let mut config = AppConfig::default();
+        config.adjust_paths_for_mode(&RuntimeMode::Standalone);
+        assert_eq!(config.paths.profile(), PathsProfile::StandaloneHome);
+
+        unsafe {
             std::env::remove_var("HOME");
         }
     }
@@ -2241,9 +2366,11 @@ models = ["gpt-5.4", "gpt-image-1"]
         };
 
         // A model that appears only as a fallback (not primary) should not match.
-        assert!(config
-            .fallback_chain_for("anthropic/claude-opus-4-6")
-            .is_none());
+        assert!(
+            config
+                .fallback_chain_for("anthropic/claude-opus-4-6")
+                .is_none()
+        );
     }
 
     #[test]
@@ -2468,16 +2595,28 @@ mode = "auto-exec"
 
     #[test]
     fn security_posture_labels() {
-        let standard = SecurityConfig { sandbox: true, trust_spells: false };
+        let standard = SecurityConfig {
+            sandbox: true,
+            trust_spells: false,
+        };
         assert_eq!(standard.posture(), "standard");
 
-        let trust = SecurityConfig { sandbox: true, trust_spells: true };
+        let trust = SecurityConfig {
+            sandbox: true,
+            trust_spells: true,
+        };
         assert_eq!(trust.posture(), "trust-spells");
 
-        let no_sandbox = SecurityConfig { sandbox: false, trust_spells: false };
+        let no_sandbox = SecurityConfig {
+            sandbox: false,
+            trust_spells: false,
+        };
         assert_eq!(no_sandbox.posture(), "no-sandbox");
 
-        let unrestricted = SecurityConfig { sandbox: false, trust_spells: true };
+        let unrestricted = SecurityConfig {
+            sandbox: false,
+            trust_spells: true,
+        };
         assert_eq!(unrestricted.posture(), "unrestricted");
     }
 
@@ -2619,14 +2758,20 @@ mode = "auto-exec"
     fn bypass_posture_detect_yolo_only() {
         let mut config = AppConfig::default();
         config.approval.mode = ApprovalMode::Yolo;
-        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::YoloOnly));
+        assert_eq!(
+            BypassPosture::detect(&config),
+            Some(BypassPosture::YoloOnly)
+        );
     }
 
     #[test]
     fn bypass_posture_detect_no_sandbox_only() {
         let mut config = AppConfig::default();
         config.security.sandbox = false;
-        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::NoSandboxOnly));
+        assert_eq!(
+            BypassPosture::detect(&config),
+            Some(BypassPosture::NoSandboxOnly)
+        );
     }
 
     #[test]
@@ -2634,7 +2779,10 @@ mode = "auto-exec"
         let mut config = AppConfig::default();
         config.approval.mode = ApprovalMode::Yolo;
         config.security.sandbox = false;
-        assert_eq!(BypassPosture::detect(&config), Some(BypassPosture::FullUnrestricted));
+        assert_eq!(
+            BypassPosture::detect(&config),
+            Some(BypassPosture::FullUnrestricted)
+        );
     }
 
     #[test]

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -733,3 +733,133 @@ The safest container strategy is:
 7. avoid redesigning the runtime around Cosmos DB or Azure SQL unless a specific hosted requirement justifies it
 
 That gives first-class Docker support, Azure compatibility, and the best chance of remaining behaviorally identical to OpenClaw while staying portable.
+
+---
+
+## 13. Zero-config startup coherence (issue #61)
+
+#### 1. Scope
+
+This slice covers only:
+
+- startup config/env precedence
+- local standalone path remapping
+- Docker path preservation
+- zero-config Ollama bootstrap
+- operator-visible startup diagnostics
+
+It does not introduce a setup wizard, new provider abstractions, or multi-provider redesign.
+
+---
+
+#### 2. Startup precedence
+
+Rune resolves startup inputs in this order:
+
+1. `--config <path>`
+2. `RUNE_CONFIG`
+3. built-in defaults plus `RUNE_*` environment overrides
+
+Operator-visible startup logs must show:
+
+- which config source won
+- the resolved config path when one exists
+- the requested runtime mode and the resolved runtime mode
+
+---
+
+#### 3. Local versus Docker path contract
+
+#### 3.1 Bare-host zero-config
+
+When all of these are true:
+
+- `mode = "auto"`
+- no `database.database_url` is configured
+- Docker/Kubernetes runtime signals are absent
+- paths are still at the built-in Docker-first defaults
+
+Rune must resolve startup as standalone local mode and remap paths to:
+
+- `~/.rune/db`
+- `~/.rune/sessions`
+- `~/.rune/memory`
+- `~/.rune/media`
+- `~/.rune/skills`
+- `~/.rune/logs`
+- `~/.rune/backups`
+- `~/.rune/config`
+- `~/.rune/secrets`
+
+This is the zero-config local quick-start contract.
+
+#### 3.2 Docker or server-oriented startup
+
+Rune must preserve the Docker/server layout when either of these is true:
+
+- `database.database_url` is configured
+- Docker/Kubernetes runtime signals are present
+- the operator explicitly points paths at `/data/...`
+
+The canonical server/container paths remain:
+
+- `/data/db`
+- `/data/sessions`
+- `/data/memory`
+- `/data/media`
+- `/data/skills`
+- `/data/logs`
+- `/data/backups`
+- `/config`
+- `/secrets`
+
+Startup logs must show whether the active path profile is:
+
+- `docker-default`
+- `standalone-home`
+- `custom`
+
+---
+
+#### 4. Zero-config Ollama contract
+
+When `models.providers` is empty, Rune uses zero-config model bootstrap:
+
+1. probe `OLLAMA_HOST` when set
+2. otherwise probe `http://localhost:11434`
+3. when Ollama is reachable, use it as the default provider
+4. when pulled models exist, auto-select a default model
+5. when no models are pulled, start without a default model and print actionable guidance
+6. when Ollama is unreachable, fall back to the echo provider
+
+When `models.providers` is non-empty, explicit provider config wins and zero-config Ollama auto-detect is disabled even if `OLLAMA_HOST` is set.
+
+If `models.default_model` is set while Rune is using zero-config Ollama bootstrap, that configured default must win over the Ollama auto-pick.
+
+---
+
+#### 5. Operator-visible startup diagnostics
+
+Startup logging must make these decisions inspectable without reading source code:
+
+- config source: CLI, `RUNE_CONFIG`, or defaults/env
+- requested mode versus resolved mode
+- active path profile and state root
+- storage backend selection
+- model bootstrap mode: explicit providers or zero-config Ollama
+- `OLLAMA_HOST` value when relevant
+- default model source: agent config, `models.default_model`, or Ollama auto-pick
+
+If `OLLAMA_HOST` is set but unreachable, startup must warn explicitly that Rune is falling back instead of silently behaving like localhost probing.
+
+---
+
+#### 9. Failure behavior
+
+#### 9.1 Path validation
+
+Required persistent paths must be checked at startup with a real write probe, not only metadata inspection.
+
+Missing or unwritable parity-critical paths must produce explicit warnings or failures that name the path and reason.
+
+This section is the contract referenced by runtime path validation code.

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -629,3 +629,67 @@ The rewrite cannot honestly be described as functionally identical until every p
 - `known-divergence` with an explicit approved compatibility exception
 
 If evidence is partial, the claim must remain: parity-seeking, not parity-complete.
+
+---
+
+## 16. Zero-config startup coherence (issue #61)
+
+#### 1. Config and environment coherence
+
+#### Contract
+
+Rune startup must behave predictably across file config, environment overrides, and zero-config local defaults.
+
+#### Invariants
+
+- `--config` overrides `RUNE_CONFIG`
+- `RUNE_CONFIG` overrides built-in defaults
+- `RUNE_*` environment variables override file values in the loaded config
+- explicit `models.providers` disables zero-config Ollama auto-detect
+- empty `models.providers` enables zero-config Ollama probing
+- `models.default_model` overrides the Ollama auto-picked model when both are present
+- bare-host `mode = "auto"` with untouched Docker-default paths resolves to standalone local mode
+- Docker/Kubernetes or explicit server signals preserve server-oriented path layout
+
+#### Operator evidence
+
+Startup logs must surface:
+
+- config source
+- requested mode and resolved mode
+- path profile
+- model bootstrap mode
+- `OLLAMA_HOST` relevance
+- default model source
+
+---
+
+#### 2. Zero-config local runtime
+
+#### Contract
+
+A first local boot with no custom config must start in a coherent standalone shape.
+
+#### Required behavior
+
+- default Docker-first paths are remapped to `~/.rune/*` on a bare host
+- required local directories are auto-created for standalone mode
+- path validation remains explicit and operator-visible
+- zero-config Ollama probing uses `OLLAMA_HOST` when provided, otherwise localhost
+
+#### Failure behavior
+
+- unreachable `OLLAMA_HOST` must warn explicitly before fallback
+- reachable Ollama with no pulled models must emit actionable operator guidance
+- missing or unwritable required paths must surface clear path-specific diagnostics
+
+---
+
+#### 3. Non-goals
+
+This slice does not include:
+
+- guided setup flows
+- secret management redesign
+- multi-provider fallback redesign
+- generalized environment-to-provider mapping beyond the current local Ollama path


### PR DESCRIPTION
## Summary
- make zero-config startup decisions more operator-visible across config source, runtime mode, path profile, bootstrap mode, and default-model source
- tighten zero-config local-vs-Docker mode resolution so bare-host first use resolves coherently to standalone while explicit server signals preserve `/data` behavior
- refresh the canonical deployment/parity docs to capture the shipped startup/env contract

## Validation
- `cargo test -p rune-config --offline`
- `cargo test -p rune-gateway-app --offline`

## Scope
- `apps/gateway/src/main.rs`
- `crates/rune-config/src/lib.rs`
- `docs/operator/DEPLOYMENT.md`
- `docs/parity/PARITY-CONTRACTS.md`
