### PR TITLE
feat(cli): add skills enable and disable surfaces (#71)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -463,6 +463,16 @@ pub enum SkillsAction {
     List,
     /// Re-scan the skills directory and report load/remove counts.
     Check,
+    /// Enable a discovered skill in the gateway registry.
+    Enable {
+        /// Skill name.
+        name: String,
+    },
+    /// Disable a discovered skill in the gateway registry.
+    Disable {
+        /// Skill name.
+        name: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1022,6 +1032,28 @@ mod tests {
                 action: SkillsAction::Check
             }
         ));
+    }
+
+    #[test]
+    fn parse_skills_enable_disable() {
+        for (subcommand, matcher) in [("enable", "enable"), ("disable", "disable")] {
+            let cli = Cli::try_parse_from(["rune", "skills", subcommand, "alpha"]).unwrap();
+            match (matcher, cli.command) {
+                (
+                    "enable",
+                    Command::Skills {
+                        action: SkillsAction::Enable { name },
+                    },
+                )
+                | (
+                    "disable",
+                    Command::Skills {
+                        action: SkillsAction::Disable { name },
+                    },
+                ) => assert_eq!(name, "alpha"),
+                other => panic!("unexpected command: {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -239,6 +239,58 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /skills/{name}/enable`
+    pub async fn skills_enable(&self, name: &str) -> Result<ActionResult> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/skills/{name}/enable")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /skills/{name}/enable")?;
+            Ok(ActionResult {
+                success: body["success"].as_bool().unwrap_or(true),
+                message: body["message"]
+                    .as_str()
+                    .unwrap_or("skill enabled")
+                    .to_string(),
+            })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `POST /skills/{name}/disable`
+    pub async fn skills_disable(&self, name: &str) -> Result<ActionResult> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/skills/{name}/disable")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /skills/{name}/disable")?;
+            Ok(ActionResult {
+                success: body["success"].as_bool().unwrap_or(true),
+                message: body["message"]
+                    .as_str()
+                    .unwrap_or("skill disabled")
+                    .to_string(),
+            })
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
     /// `GET /gateway/health`
     pub async fn gateway_health(&self) -> Result<HealthResponse> {
         let resp = self
@@ -2835,6 +2887,42 @@ mod tests {
         assert_eq!(resp.discovered, 4);
         assert_eq!(resp.loaded, 3);
         assert_eq!(resp.removed, 1);
+    }
+
+    #[tokio::test]
+    async fn skills_enable_parses_action_result() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/skills/alpha/enable"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "skill 'alpha' enabled"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.skills_enable("alpha").await.unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message, "skill 'alpha' enabled");
+    }
+
+    #[tokio::test]
+    async fn skills_disable_parses_action_result() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/skills/alpha/disable"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "skill 'alpha' disabled"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.skills_disable("alpha").await.unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.message, "skill 'alpha' disabled");
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -974,6 +974,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.skills_check().await?;
                 println!("{}", render(&result, format));
             }
+            SkillsAction::Enable { name } => {
+                let result = client.skills_enable(&name).await?;
+                println!("{}", render(&result, format));
+            }
+            SkillsAction::Disable { name } => {
+                let result = client.skills_disable(&name).await?;
+                println!("{}", render(&result, format));
+            }
         },
         Command::Completion { action } => match action {
             CompletionAction::Generate { shell } => {


### PR DESCRIPTION
## Summary
- add first-class `rune skills enable` and `rune skills disable` CLI surfaces
- wire the new commands to the existing gateway skill enable/disable endpoints
- add focused parse/client coverage for the new operator-facing skills lifecycle actions

## Validation
- `cargo test -p rune-cli --offline`

## Scope
- `crates/rune-cli/src/cli.rs`
- `crates/rune-cli/src/client.rs`
- `crates/rune-cli/src/lib.rs`
