### PR TITLE
feat(cli): add skills info surface (#71)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -461,6 +461,11 @@ pub enum ModelsAction {
 pub enum SkillsAction {
     /// List installed skills discovered by the gateway.
     List,
+    /// Show details for a single installed skill.
+    Info {
+        /// Skill name.
+        name: String,
+    },
     /// Re-scan the skills directory and report load/remove counts.
     Check,
     /// Enable a discovered skill in the gateway registry.
@@ -1031,6 +1036,17 @@ mod tests {
             Command::Skills {
                 action: SkillsAction::Check
             }
+        ));
+    }
+
+    #[test]
+    fn parse_skills_info() {
+        let cli = Cli::try_parse_from(["rune", "skills", "info", "alpha"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Skills {
+                action: SkillsAction::Info { name }
+            } if name == "alpha"
         ));
     }
 

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use reqwest::Method;
+use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::json;
 use toml_edit::{DocumentMut, Item, Table, Value};
@@ -19,8 +20,8 @@ use crate::output::{
     ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
-    SessionTreeNode, SessionTreeResponse, SkillCheckResponse, SkillListResponse, SkillSummary,
-    StatusResponse,
+    SessionTreeNode, SessionTreeResponse, SkillCheckResponse, SkillInfoResponse,
+    SkillListResponse, SkillSummary, StatusResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -219,6 +220,38 @@ impl GatewayClient {
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
+    }
+
+    /// `GET /skills/{name}` with fallback-to-list if detail is unavailable.
+    pub async fn skills_info(&self, name: &str) -> Result<SkillInfoResponse> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/skills/{name}")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            return resp
+                .json::<SkillInfoResponse>()
+                .await
+                .context("invalid JSON from /skills/{name}");
+        }
+
+        if !matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+
+        let skills = self.skills_list().await?;
+        let skill = skills
+            .skills
+            .into_iter()
+            .find(|skill| skill.name == name)
+            .ok_or_else(|| anyhow::anyhow!("skill not found: {name}"))?;
+        Ok(SkillInfoResponse { skill })
     }
 
     /// `POST /skills/reload`
@@ -2887,6 +2920,65 @@ mod tests {
         assert_eq!(resp.discovered, 4);
         assert_eq!(resp.loaded, 3);
         assert_eq!(resp.removed, 1);
+    }
+
+    #[tokio::test]
+    async fn skills_info_falls_back_to_list_when_detail_route_is_absent() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/skills/alpha"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "name": "alpha",
+                    "description": "First skill",
+                    "enabled": true,
+                    "source_dir": "/data/skills/alpha",
+                    "binary_path": "/data/skills/alpha/run.sh"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.skills_info("alpha").await.unwrap();
+        assert_eq!(resp.skill.name, "alpha");
+        assert!(resp.skill.enabled);
+        assert_eq!(
+            resp.skill.binary_path.as_deref(),
+            Some("/data/skills/alpha/run.sh")
+        );
+    }
+
+    #[tokio::test]
+    async fn skills_info_errors_when_skill_is_missing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/skills/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "name": "alpha",
+                    "description": "First skill",
+                    "enabled": true,
+                    "source_dir": "/data/skills/alpha",
+                    "binary_path": "/data/skills/alpha/run.sh"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let err = client.skills_info("missing").await.unwrap_err();
+        assert!(err.to_string().contains("skill not found: missing"));
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -970,6 +970,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.skills_list().await?;
                 println!("{}", render(&result, format));
             }
+            SkillsAction::Info { name } => {
+                let result = client.skills_info(&name).await?;
+                println!("{}", render(&result, format));
+            }
             SkillsAction::Check => {
                 let result = client.skills_check().await?;
                 println!("{}", render(&result, format));

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -557,6 +557,27 @@ impl fmt::Display for SkillListResponse {
     }
 }
 
+/// Response for `rune skills info`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillInfoResponse {
+    #[serde(flatten)]
+    pub skill: SkillSummary,
+}
+
+impl fmt::Display for SkillInfoResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Skill: {}", self.skill.name)?;
+        writeln!(f, "  Enabled: {}", self.skill.enabled)?;
+        writeln!(f, "  Description: {}", self.skill.description)?;
+        writeln!(f, "  Source: {}", self.skill.source_dir)?;
+        write!(
+            f,
+            "  Binary: {}",
+            self.skill.binary_path.as_deref().unwrap_or("-")
+        )
+    }
+}
+
 /// Response for `rune skills check`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillCheckResponse {
@@ -3181,6 +3202,44 @@ mod tests {
             parsed["skills"][0]["binary_path"],
             "/data/skills/alpha/run.sh"
         );
+    }
+
+    #[test]
+    fn render_skill_info_human() {
+        let response = SkillInfoResponse {
+            skill: SkillSummary {
+                name: "alpha".into(),
+                description: "First skill".into(),
+                enabled: true,
+                source_dir: "/data/skills/alpha".into(),
+                binary_path: Some("/data/skills/alpha/run.sh".into()),
+            },
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Skill: alpha"));
+        assert!(out.contains("Enabled: true"));
+        assert!(out.contains("Description: First skill"));
+        assert!(out.contains("Source: /data/skills/alpha"));
+        assert!(out.contains("Binary: /data/skills/alpha/run.sh"));
+    }
+
+    #[test]
+    fn render_skill_info_json() {
+        let response = SkillInfoResponse {
+            skill: SkillSummary {
+                name: "alpha".into(),
+                description: "First skill".into(),
+                enabled: true,
+                source_dir: "/data/skills/alpha".into(),
+                binary_path: Some("/data/skills/alpha/run.sh".into()),
+            },
+        };
+        let out = render(&response, OutputFormat::Json);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["name"], "alpha");
+        assert_eq!(parsed["enabled"], true);
+        assert_eq!(parsed["source_dir"], "/data/skills/alpha");
+        assert_eq!(parsed["binary_path"], "/data/skills/alpha/run.sh");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class `rune skills info <name>`
- fetch detailed skill metadata from the gateway with a list-based fallback when a dedicated detail route is absent
- add focused parse/client/output coverage for the new skill detail surface

## Validation
- `cargo test -p rune-cli --offline parse_skills_info`
- `cargo test -p rune-cli --offline skills_info`

## Scope
- `crates/rune-cli/src/cli.rs`
- `crates/rune-cli/src/client.rs`
- `crates/rune-cli/src/lib.rs`
- `crates/rune-cli/src/output.rs`
