### PR TITLE
feat(cli): add  surface (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -702,14 +702,23 @@ pub enum MessageAction {
         #[arg(long)]
         session: Option<String>,
     },
-    /// Pin or unpin a message in a channel.
+    /// Pin a message in a channel.
     Pin {
-        /// ID of the message to pin or unpin.
+        /// ID of the message to pin.
         #[arg(long)]
         message_id: String,
-        /// Unpin the message instead of pinning it.
+        /// Channel adapter the message belongs to.
         #[arg(long)]
-        unpin: bool,
+        channel: Option<String>,
+        /// Session ID the message belongs to.
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Unpin a message in a channel.
+    Unpin {
+        /// ID of the message to unpin.
+        #[arg(long)]
+        message_id: String,
         /// Channel adapter the message belongs to.
         #[arg(long)]
         channel: Option<String>,
@@ -2927,13 +2936,11 @@ mod tests {
                 action:
                     MessageAction::Pin {
                         message_id,
-                        unpin,
                         channel,
                         session,
                     },
             } => {
                 assert_eq!(message_id, "msg-50");
-                assert!(!unpin);
                 assert_eq!(channel.as_deref(), Some("telegram"));
                 assert_eq!(session.as_deref(), Some("sess-3"));
             }
@@ -2946,24 +2953,21 @@ mod tests {
         let cli = Cli::try_parse_from([
             "rune",
             "message",
-            "pin",
+            "unpin",
             "--message-id",
             "msg-77",
-            "--unpin",
         ])
         .unwrap();
         match cli.command {
             Command::Message {
                 action:
-                    MessageAction::Pin {
+                    MessageAction::Unpin {
                         message_id,
-                        unpin,
                         channel,
                         session,
                     },
             } => {
                 assert_eq!(message_id, "msg-77");
-                assert!(unpin);
                 assert!(channel.is_none());
                 assert!(session.is_none());
             }
@@ -2974,7 +2978,19 @@ mod tests {
     #[test]
     fn message_pin_requires_message_id() {
         assert!(Cli::try_parse_from(["rune", "message", "pin"]).is_err());
-        assert!(Cli::try_parse_from(["rune", "message", "pin", "--unpin"]).is_err());
+    }
+
+    #[test]
+    fn message_unpin_requires_message_id() {
+        assert!(Cli::try_parse_from(["rune", "message", "unpin"]).is_err());
+    }
+
+    #[test]
+    fn message_pin_rejects_unpin_flag() {
+        assert!(
+            Cli::try_parse_from(["rune", "message", "pin", "--message-id", "msg-77", "--unpin"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -1204,7 +1204,6 @@ impl GatewayClient {
         }
     }
 
-    /// `POST /messages/pin`
     /// `PATCH /messages/{id}` — edit the text content of an existing message.
     pub async fn message_edit(
         &self,
@@ -1258,6 +1257,7 @@ impl GatewayClient {
         }
     }
 
+    /// `POST /messages/pin`
     pub async fn message_pin(
         &self,
         message_id: &str,

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1563,14 +1563,28 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
             MessageAction::Pin {
                 message_id,
-                unpin,
                 channel,
                 session,
             } => {
                 let result = client
                     .message_pin(
                         &message_id,
-                        unpin,
+                        false,
+                        channel.as_deref(),
+                        session.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
+            MessageAction::Unpin {
+                message_id,
+                channel,
+                session,
+            } => {
+                let result = client
+                    .message_pin(
+                        &message_id,
+                        true,
                         channel.as_deref(),
                         session.as_deref(),
                     )


### PR DESCRIPTION
## Summary\n- add a first-class  CLI surface\n- split the former overloaded  path into explicit  and  verbs\n- keep the patch narrow and operator-facing for issue #74 parity work\n\n## What changed\n-  CLI subcommand\n- explicit CLI execution path for unpin via existing message pin client method with \n- parse coverage for  and rejection coverage for \n\n## Validation\n- 
running 366 tests
....................................................................................... 87/366
....................................................................................... 174/366
....................................................................................... 261/366
....................................................................................... 348/366
..................
test result: ok. 366 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- \n\n## Why this slice\nOpenClaw parity inventory calls out  as its own operator-facing verb. This patch makes Rune match that surface explicitly instead of burying it behind a flag on .