### PR TITLE
feat(gateway): add skill detail route (#71)

### DIFF
--- a/crates/rune-gateway/src/error.rs
+++ b/crates/rune-gateway/src/error.rs
@@ -23,6 +23,10 @@ pub enum GatewayError {
     #[error("session not found: {0}")]
     SessionNotFound(String),
 
+    /// Skill not found.
+    #[error("skill not found: {0}")]
+    SkillNotFound(String),
+
     /// Job not found.
     #[error("job not found: {0}")]
     JobNotFound(String),
@@ -54,6 +58,13 @@ impl IntoResponse for GatewayError {
             Self::SessionNotFound(_) => (
                 StatusCode::NOT_FOUND,
                 "session_not_found",
+                false,
+                false,
+                self.to_string(),
+            ),
+            Self::SkillNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                "skill_not_found",
                 false,
                 false,
                 self.to_string(),

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2191,6 +2191,19 @@ pub async fn list_skills(
     Ok(Json(skills.into_iter().map(skill_to_response).collect()))
 }
 
+pub async fn get_skill(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<SkillResponse>, GatewayError> {
+    let skill = state
+        .skill_registry
+        .get(&name)
+        .await
+        .ok_or_else(|| GatewayError::SkillNotFound(name.clone()))?;
+
+    Ok(Json(skill_to_response(skill)))
+}
+
 pub async fn reload_skills(
     State(state): State<AppState>,
 ) -> Result<Json<SkillReloadResponse>, GatewayError> {
@@ -2208,7 +2221,7 @@ pub async fn enable_skill(
             message: format!("skill '{name}' enabled"),
         }))
     } else {
-        Err(GatewayError::BadRequest(format!("unknown skill: {name}")))
+        Err(GatewayError::SkillNotFound(name))
     }
 }
 
@@ -2222,7 +2235,7 @@ pub async fn disable_skill(
             message: format!("skill '{name}' disabled"),
         }))
     } else {
-        Err(GatewayError::BadRequest(format!("unknown skill: {name}")))
+        Err(GatewayError::SkillNotFound(name))
     }
 }
 

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -291,6 +291,7 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/models/scan", post(routes::scan_models))
         // Skill routes
         .route("/skills", get(routes::list_skills))
+        .route("/skills/{name}", get(routes::get_skill))
         .route("/skills/reload", post(routes::reload_skills))
         .route("/skills/{name}/enable", post(routes::enable_skill))
         .route("/skills/{name}/disable", post(routes::disable_skill))

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4558,7 +4558,10 @@ enabled: false
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "skill_not_found");
+    assert_eq!(json["message"], "skill not found: missing");
 
     let response = app
         .oneshot(
@@ -4568,7 +4571,71 @@ enabled: false
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "skill_not_found");
+    assert_eq!(json["message"], "skill not found: missing");
+}
+
+#[tokio::test]
+async fn skills_detail_route_returns_skill_and_missing_error() {
+    let mut config = AppConfig::default();
+    let skills_dir =
+        std::env::temp_dir().join(format!("rune-gw-skill-detail-{}", Uuid::now_v7()));
+    std::fs::create_dir_all(skills_dir.join("alpha")).unwrap();
+    std::fs::write(
+        skills_dir.join("alpha/SKILL.md"),
+        r#"---
+name: alpha
+description: Alpha skill
+binary: ./run-alpha.sh
+enabled: true
+---
+
+# Alpha
+"#,
+    )
+    .unwrap();
+    config.paths.skills_dir = skills_dir.clone();
+
+    let app = build_test_app_with_config(config, None);
+
+    let response = app
+        .clone()
+        .oneshot(Request::post("/skills/reload").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(Request::get("/skills/alpha").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["name"], "alpha");
+    assert_eq!(json["description"], "Alpha skill");
+    assert_eq!(json["enabled"], true);
+    assert_eq!(json["source_dir"], skills_dir.join("alpha").display().to_string());
+    assert!(
+        json["binary_path"]
+            .as_str()
+            .unwrap()
+            .contains("run-alpha.sh")
+    );
+
+    let response = app
+        .oneshot(Request::get("/skills/missing").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "skill_not_found");
+    assert_eq!(json["message"], "skill not found: missing");
+    assert_eq!(json["retriable"], false);
+    assert_eq!(json["approval_required"], false);
+    assert!(json["request_id"].as_str().is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a dedicated `GET /skills/{name}` gateway route for detailed skill metadata
- return a not-found error shape for missing skill lookups
- add focused route coverage for skill detail fetches and missing-skill responses

## Validation
- `cargo test --offline -p rune-gateway list_skills -- --nocapture`
- `cargo test --offline -p rune-gateway get_skill -- --nocapture`

## Scope
- `crates/rune-gateway/src/error.rs`
- `crates/rune-gateway/src/routes.rs`
- `crates/rune-gateway/src/server.rs`
- `crates/rune-gateway/tests/route_tests.rs`
