### PR TITLE
feat(cli): add gateway logs query surface (#40)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -81,6 +81,21 @@ pub enum Command {
     Doctor,
     /// Show a compact operator dashboard summary.
     Dashboard,
+    /// Query structured gateway logs.
+    Logs {
+        /// Filter by log level.
+        #[arg(long)]
+        level: Option<String>,
+        /// Filter by source/component name.
+        #[arg(long)]
+        source: Option<String>,
+        /// Maximum number of entries to return.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Lower-bound timestamp or relative cursor understood by the gateway.
+        #[arg(long)]
+        since: Option<String>,
+    },
     /// Manage cron jobs.
     Cron {
         #[command(subcommand)]
@@ -1024,6 +1039,37 @@ mod tests {
     fn parse_dashboard() {
         let cli = Cli::try_parse_from(["rune", "dashboard"]).unwrap();
         assert!(matches!(cli.command, Command::Dashboard));
+    }
+
+    #[test]
+    fn parse_logs() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "logs",
+            "--level",
+            "warn",
+            "--source",
+            "gateway",
+            "--limit",
+            "25",
+            "--since",
+            "2026-03-20T09:00:00Z",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Logs {
+                level,
+                source,
+                limit,
+                since,
+            } => {
+                assert_eq!(level.as_deref(), Some("warn"));
+                assert_eq!(source.as_deref(), Some("gateway"));
+                assert_eq!(limit, Some(25));
+                assert_eq!(since.as_deref(), Some("2026-03-20T09:00:00Z"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 
     #[test]
@@ -2950,14 +2996,8 @@ mod tests {
 
     #[test]
     fn parse_message_unpin() {
-        let cli = Cli::try_parse_from([
-            "rune",
-            "message",
-            "unpin",
-            "--message-id",
-            "msg-77",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "message", "unpin", "--message-id", "msg-77"]).unwrap();
         match cli.command {
             Command::Message {
                 action:
@@ -2987,10 +3027,15 @@ mod tests {
 
     #[test]
     fn message_pin_rejects_unpin_flag() {
-        assert!(
-            Cli::try_parse_from(["rune", "message", "pin", "--message-id", "msg-77", "--unpin"])
-                .is_err()
-        );
+        assert!(Cli::try_parse_from([
+            "rune",
+            "message",
+            "pin",
+            "--message-id",
+            "msg-77",
+            "--unpin"
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -15,8 +15,8 @@ use crate::output::{
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
-    SystemEventListResponse, GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse,
-    GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
+    GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
+    HealthResponse, HeartbeatStatusResponse, LogsQueryResponse, SystemEventListResponse,
     ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
@@ -85,6 +85,47 @@ impl GatewayClient {
             })
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /api/logs`
+    pub async fn logs_query(
+        &self,
+        level: Option<&str>,
+        source: Option<&str>,
+        limit: Option<usize>,
+        since: Option<&str>,
+    ) -> Result<LogsQueryResponse> {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(level) = level {
+            query.push(("level", level.to_string()));
+        }
+        if let Some(source) = source {
+            query.push(("source", source.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(since) = since {
+            query.push(("since", since.to_string()));
+        }
+
+        let resp = self
+            .http
+            .get(self.url("/api/logs"))
+            .query(&query)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            resp.json::<LogsQueryResponse>()
+                .await
+                .context("invalid JSON from /api/logs")
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
         }
     }
 
@@ -2688,6 +2729,43 @@ mod tests {
         let client = GatewayClient::new(&server.uri());
         let resp = client.cron_status().await.unwrap();
         assert_eq!(resp.total_jobs, 1);
+    }
+
+    #[tokio::test]
+    async fn logs_query_passes_filters_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/logs"))
+            .and(query_param("level", "warn"))
+            .and(query_param("source", "gateway"))
+            .and(query_param("limit", "25"))
+            .and(query_param("since", "2026-03-20T09:00:00Z"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "entries": [
+                    {
+                        "timestamp": "2026-03-20T09:30:00Z",
+                        "level": "warn",
+                        "message": "gateway restart pending"
+                    }
+                ],
+                "message": "1 log entry returned"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .logs_query(
+                Some("warn"),
+                Some("gateway"),
+                Some(25),
+                Some("2026-03-20T09:00:00Z"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.entries.len(), 1);
+        assert_eq!(resp.entries[0]["level"], "warn");
+        assert_eq!(resp.message, "1 log entry returned");
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -906,6 +906,22 @@ pub async fn run(cli: Cli) -> Result<()> {
             let result = client.health().await?;
             println!("{}", render(&result, format));
         }
+        Command::Logs {
+            level,
+            source,
+            limit,
+            since,
+        } => {
+            let result = client
+                .logs_query(
+                    level.as_deref(),
+                    source.as_deref(),
+                    limit,
+                    since.as_deref(),
+                )
+                .await?;
+            println!("{}", render(&result, format));
+        }
         Command::Doctor => {
             let ws_root = dirs::home_dir()
                 .map(|h| h.join(".rune/workspace"))

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -499,7 +499,11 @@ impl fmt::Display for TemplateStartResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Session started from template.")?;
         writeln!(f, "  Session:  {}", self.session_id)?;
-        writeln!(f, "  Template: {} ({})", self.template_name, self.template_slug)?;
+        writeln!(
+            f,
+            "  Template: {} ({})",
+            self.template_name, self.template_slug
+        )?;
         writeln!(f, "  Mode:     {}", self.mode)?;
         write!(f, "  Status:   {}", self.status)
     }
@@ -1007,6 +1011,31 @@ impl fmt::Display for ChannelLogsResponse {
         }
         if let Some(note) = &self.note {
             write!(f, "  Note:     {note}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response for `logs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogsQueryResponse {
+    pub entries: Vec<serde_json::Value>,
+    pub message: String,
+}
+
+impl fmt::Display for LogsQueryResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Logs")?;
+        writeln!(f, "  Entries: {}", self.entries.len())?;
+        write!(f, "  Message: {}", self.message)?;
+        if !self.entries.is_empty() {
+            for entry in &self.entries {
+                write!(
+                    f,
+                    "\n  - {}",
+                    serde_json::to_string(entry).unwrap_or_else(|_| entry.to_string())
+                )?;
+            }
         }
         Ok(())
     }
@@ -3535,6 +3564,34 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Channel logs"));
         assert!(out.contains("No matching log files found."));
+    }
+
+    #[test]
+    fn render_logs_query_human() {
+        let response = LogsQueryResponse {
+            entries: vec![serde_json::json!({
+                "timestamp": "2026-03-20T09:00:00Z",
+                "level": "warn",
+                "message": "gateway restart pending"
+            })],
+            message: "1 log entry returned".into(),
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Logs"));
+        assert!(out.contains("Entries: 1"));
+        assert!(out.contains("gateway restart pending"));
+    }
+
+    #[test]
+    fn render_logs_query_json() {
+        let response = LogsQueryResponse {
+            entries: vec![],
+            message: "structured log query not yet aggregated".into(),
+        };
+        let out = render(&response, OutputFormat::Json);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["entries"], serde_json::json!([]));
+        assert_eq!(value["message"], "structured log query not yet aggregated");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class `rune logs` command for querying structured gateway logs
- wire the CLI to the existing `/api/logs` HTTP surface with level/source/limit/since filters
- add focused parse/client/output coverage for the new logs query surface

## Validation
- `cargo test -p rune-cli --offline parse_logs`
- `cargo test -p rune-cli --offline logs_query`

## Scope
- `crates/rune-cli/src/cli.rs`
- `crates/rune-cli/src/client.rs`
- `crates/rune-cli/src/lib.rs`
- `crates/rune-cli/src/output.rs`
