### PR TITLE
feat(cli): add gateway doctor/log surfaces (#40)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -1,6 +1,6 @@
 //! Clap-based CLI definition with all subcommands.
 
-use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 
 /// Rune — the operator CLI for managing the Rune AI runtime.
 #[derive(Debug, Parser)]
@@ -77,25 +77,15 @@ pub enum Command {
     Status,
     /// Run a health check against the gateway.
     Health,
-    /// Run diagnostic checks (config, connectivity, etc.).
-    Doctor,
+    /// Run gateway-backed diagnostic checks and inspect recent results.
+    Doctor {
+        #[command(subcommand)]
+        action: Option<DoctorAction>,
+    },
     /// Show a compact operator dashboard summary.
     Dashboard,
     /// Query structured gateway logs.
-    Logs {
-        /// Filter by log level.
-        #[arg(long)]
-        level: Option<String>,
-        /// Filter by source/component name.
-        #[arg(long)]
-        source: Option<String>,
-        /// Maximum number of entries to return.
-        #[arg(long)]
-        limit: Option<usize>,
-        /// Lower-bound timestamp or relative cursor understood by the gateway.
-        #[arg(long)]
-        since: Option<String>,
-    },
+    Logs(LogsArgs),
     /// Manage cron jobs.
     Cron {
         #[command(subcommand)]
@@ -169,6 +159,22 @@ pub enum Command {
     },
 }
 
+#[derive(Debug, Clone, Args)]
+pub struct LogsArgs {
+    /// Filter by log level.
+    #[arg(long)]
+    pub level: Option<String>,
+    /// Filter by source/component name.
+    #[arg(long)]
+    pub source: Option<String>,
+    /// Maximum number of entries to return.
+    #[arg(long)]
+    pub limit: Option<usize>,
+    /// Lower-bound timestamp or relative cursor understood by the gateway.
+    #[arg(long)]
+    pub since: Option<String>,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum GatewayAction {
     /// Query gateway status.
@@ -179,6 +185,13 @@ pub enum GatewayAction {
     Probe,
     /// Discover operator-facing runtime URLs and config binding details.
     Discover,
+    /// Query structured gateway logs.
+    Logs(LogsArgs),
+    /// Run gateway-backed diagnostic checks and inspect recent results.
+    Doctor {
+        #[command(subcommand)]
+        action: Option<DoctorAction>,
+    },
     /// Perform a raw gateway HTTP call.
     Call {
         /// HTTP method to use.
@@ -203,6 +216,14 @@ pub enum GatewayAction {
     Restart,
     /// Run the gateway in the foreground using the local rune-gateway binary.
     Run,
+}
+
+#[derive(Debug, Clone, Copy, Subcommand)]
+pub enum DoctorAction {
+    /// Execute a fresh doctor run via the gateway.
+    Run,
+    /// Fetch the most recent doctor report from the gateway.
+    Results,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1032,7 +1053,29 @@ mod tests {
     #[test]
     fn parse_doctor() {
         let cli = Cli::try_parse_from(["rune", "doctor"]).unwrap();
-        assert!(matches!(cli.command, Command::Doctor));
+        assert!(matches!(cli.command, Command::Doctor { action: None }));
+    }
+
+    #[test]
+    fn parse_doctor_run() {
+        let cli = Cli::try_parse_from(["rune", "doctor", "run"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Doctor {
+                action: Some(DoctorAction::Run)
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_doctor_results() {
+        let cli = Cli::try_parse_from(["rune", "doctor", "results"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Doctor {
+                action: Some(DoctorAction::Results)
+            }
+        ));
     }
 
     #[test]
@@ -1057,12 +1100,12 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Command::Logs {
+            Command::Logs(LogsArgs {
                 level,
                 source,
                 limit,
                 since,
-            } => {
+            }) => {
                 assert_eq!(level.as_deref(), Some("warn"));
                 assert_eq!(source.as_deref(), Some("gateway"));
                 assert_eq!(limit, Some(25));
@@ -1070,6 +1113,41 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_gateway_logs() {
+        let cli = Cli::try_parse_from(["rune", "gateway", "logs", "--limit", "50"]).unwrap();
+        match cli.command {
+            Command::Gateway {
+                action:
+                    GatewayAction::Logs(LogsArgs {
+                        level,
+                        source,
+                        limit,
+                        since,
+                    }),
+            } => {
+                assert_eq!(level, None);
+                assert_eq!(source, None);
+                assert_eq!(limit, Some(50));
+                assert_eq!(since, None);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_gateway_doctor_results() {
+        let cli = Cli::try_parse_from(["rune", "gateway", "doctor", "results"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Gateway {
+                action: GatewayAction::Doctor {
+                    action: Some(DoctorAction::Results)
+                }
+            }
+        ));
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -14,9 +14,9 @@ use crate::output::{
     ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
-    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorCheck, DoctorReport,
-    GatewayCallResponse, GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse,
-    HealthResponse, HeartbeatStatusResponse, LogsQueryResponse, SystemEventListResponse,
+    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorReport, GatewayCallResponse,
+    GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse,
+    HeartbeatStatusResponse, LogsQueryResponse, SystemEventListResponse,
     ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
@@ -122,6 +122,46 @@ impl GatewayClient {
             resp.json::<LogsQueryResponse>()
                 .await
                 .context("invalid JSON from /api/logs")
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
+        }
+    }
+
+    /// `POST /api/doctor/run`
+    pub async fn doctor_run(&self) -> Result<DoctorReport> {
+        let resp = self
+            .http
+            .post(self.url("/api/doctor/run"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            resp.json::<DoctorReport>()
+                .await
+                .context("invalid JSON from /api/doctor/run")
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
+        }
+    }
+
+    /// `GET /api/doctor/results`
+    pub async fn doctor_results(&self) -> Result<DoctorReport> {
+        let resp = self
+            .http
+            .get(self.url("/api/doctor/results"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            resp.json::<DoctorReport>()
+                .await
+                .context("invalid JSON from /api/doctor/results")
         } else {
             let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
@@ -2235,44 +2275,9 @@ impl GatewayClient {
         }
     }
 
-    /// Run doctor checks: config validation + gateway connectivity + model provider reachability.
+    /// Execute a fresh doctor run via the gateway.
     pub async fn doctor(&self) -> Result<DoctorReport> {
-        let mut checks = Vec::new();
-
-        let config_check = match rune_config::AppConfig::load(None::<&str>) {
-            Ok(_) => DoctorCheck {
-                name: "config".into(),
-                passed: true,
-                detail: "Configuration loaded successfully.".into(),
-            },
-            Err(e) => DoctorCheck {
-                name: "config".into(),
-                passed: false,
-                detail: format!("Failed to load config: {e}"),
-            },
-        };
-        checks.push(config_check);
-
-        let gw_check = match self.health().await {
-            Ok(h) if h.healthy => DoctorCheck {
-                name: "gateway".into(),
-                passed: true,
-                detail: "Gateway is reachable and healthy.".into(),
-            },
-            Ok(h) => DoctorCheck {
-                name: "gateway".into(),
-                passed: false,
-                detail: h.message,
-            },
-            Err(e) => DoctorCheck {
-                name: "gateway".into(),
-                passed: false,
-                detail: format!("Cannot reach gateway: {e}"),
-            },
-        };
-        checks.push(gw_check);
-
-        Ok(DoctorReport { checks })
+        self.doctor_run().await
     }
 
     // ── Approvals ─────────────────────────────────────────────────────
@@ -2766,6 +2771,60 @@ mod tests {
         assert_eq!(resp.entries.len(), 1);
         assert_eq!(resp.entries[0]["level"], "warn");
         assert_eq!(resp.message, "1 log entry returned");
+    }
+
+    #[tokio::test]
+    async fn doctor_run_posts_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/doctor/run"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "overall": "degraded",
+                "checks": [
+                    {
+                        "name": "auth",
+                        "status": "warn",
+                        "message": "no auth token configured"
+                    }
+                ],
+                "run_at": "2026-03-20T09:35:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.doctor_run().await.unwrap();
+        assert_eq!(resp.overall, "degraded");
+        assert_eq!(resp.checks.len(), 1);
+        assert_eq!(resp.checks[0].status, "warn");
+        assert_eq!(resp.run_at, "2026-03-20T09:35:00Z");
+    }
+
+    #[tokio::test]
+    async fn doctor_results_gets_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/doctor/results"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "overall": "healthy",
+                "checks": [
+                    {
+                        "name": "session_store",
+                        "status": "pass",
+                        "message": "session store reachable"
+                    }
+                ],
+                "run_at": "2026-03-20T09:36:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.doctor_results().await.unwrap();
+        assert_eq!(resp.overall, "healthy");
+        assert_eq!(resp.checks[0].name, "session_store");
+        assert_eq!(resp.checks[0].status, "pass");
+        assert_eq!(resp.run_at, "2026-03-20T09:36:00Z");
     }
 
     #[tokio::test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -24,9 +24,10 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 pub use cli::Cli;
 use cli::{
     AgentsAction, ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell,
-    ConfigAction, CronAction, CronDeliveryMode, GatewayAction, MemoryAction, MessageAction,
-    MessageTagAction, MessageThreadAction, MessageVoiceAction, ModelsAction, RemindersAction,
-    SessionsAction, SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
+    ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction, LogsArgs,
+    MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
+    ModelsAction, RemindersAction, SessionsAction, SkillsAction, SystemAction,
+    SystemEventAction, SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -867,6 +868,29 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.gateway_discover().await?;
                 println!("{}", render(&result, format));
             }
+            GatewayAction::Logs(LogsArgs {
+                level,
+                source,
+                limit,
+                since,
+            }) => {
+                let result = client
+                    .logs_query(
+                        level.as_deref(),
+                        source.as_deref(),
+                        limit,
+                        since.as_deref(),
+                    )
+                    .await?;
+                println!("{}", render(&result, format));
+            }
+            GatewayAction::Doctor { action } => {
+                let result = match action.unwrap_or(DoctorAction::Run) {
+                    DoctorAction::Run => client.doctor_run().await?,
+                    DoctorAction::Results => client.doctor_results().await?,
+                };
+                println!("{}", render(&result, format));
+            }
             GatewayAction::Call {
                 method,
                 path,
@@ -906,12 +930,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             let result = client.health().await?;
             println!("{}", render(&result, format));
         }
-        Command::Logs {
+        Command::Logs(LogsArgs {
             level,
             source,
             limit,
             since,
-        } => {
+        }) => {
             let result = client
                 .logs_query(
                     level.as_deref(),
@@ -922,21 +946,12 @@ pub async fn run(cli: Cli) -> Result<()> {
                 .await?;
             println!("{}", render(&result, format));
         }
-        Command::Doctor => {
-            let ws_root = dirs::home_dir()
-                .map(|h| h.join(".rune/workspace"))
-                .unwrap_or_else(|| std::path::PathBuf::from("."));
-            let results =
-                doctor::run_all_checks(None, Some(&cli.gateway_url), Some(&ws_root)).await;
-            let output = doctor::format_results(&results);
-            if matches!(format, OutputFormat::Json) {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&results).unwrap_or_default()
-                );
-            } else {
-                print!("{output}");
-            }
+        Command::Doctor { action } => {
+            let result = match action.unwrap_or(DoctorAction::Run) {
+                DoctorAction::Run => client.doctor_run().await?,
+                DoctorAction::Results => client.doctor_results().await?,
+            };
+            println!("{}", render(&result, format));
         }
         Command::Dashboard => {
             let gateway = client.status().await?;

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -73,33 +73,46 @@ impl fmt::Display for HealthResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DoctorCheck {
     pub name: String,
-    pub passed: bool,
-    pub detail: String,
+    pub status: String,
+    pub message: String,
 }
 
 impl fmt::Display for DoctorCheck {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let icon = if self.passed { "✓" } else { "✗" };
-        write!(f, "  {icon} {}: {}", self.name, self.detail)
+        let icon = match self.status.as_str() {
+            "pass" => "✓",
+            "warn" => "!",
+            "fail" => "✗",
+            _ => "•",
+        };
+        write!(f, "  {icon} {} [{}]: {}", self.name, self.status, self.message)
     }
 }
 
 /// Full doctor report.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DoctorReport {
+    pub overall: String,
     pub checks: Vec<DoctorCheck>,
+    pub run_at: String,
 }
 
 impl fmt::Display for DoctorReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Doctor Report")?;
         writeln!(f, "─────────────")?;
+        writeln!(f, "Overall: {}", self.overall)?;
+        writeln!(f, "Run at:   {}", self.run_at)?;
         for check in &self.checks {
             writeln!(f, "{check}")?;
         }
-        let passed = self.checks.iter().filter(|c| c.passed).count();
+        let passed = self
+            .checks
+            .iter()
+            .filter(|check| check.status == "pass")
+            .count();
         let total = self.checks.len();
-        write!(f, "\n{passed}/{total} checks passed")
+        write!(f, "\nChecks: {passed}/{total} passing")
     }
 }
 
@@ -1028,17 +1041,38 @@ impl fmt::Display for LogsQueryResponse {
         writeln!(f, "Logs")?;
         writeln!(f, "  Entries: {}", self.entries.len())?;
         write!(f, "  Message: {}", self.message)?;
-        if !self.entries.is_empty() {
-            for entry in &self.entries {
-                write!(
-                    f,
-                    "\n  - {}",
-                    serde_json::to_string(entry).unwrap_or_else(|_| entry.to_string())
-                )?;
-            }
+        for entry in &self.entries {
+            let rendered = format_log_entry(entry);
+            write!(f, "\n  - {rendered}")?;
         }
         Ok(())
     }
+}
+
+fn format_log_entry(entry: &serde_json::Value) -> String {
+    let timestamp = entry.get("timestamp").and_then(serde_json::Value::as_str);
+    let level = entry.get("level").and_then(serde_json::Value::as_str);
+    let source = entry.get("source").and_then(serde_json::Value::as_str);
+    let message = entry.get("message").and_then(serde_json::Value::as_str);
+
+    if timestamp.is_some() || level.is_some() || source.is_some() || message.is_some() {
+        let mut parts = Vec::new();
+        if let Some(timestamp) = timestamp {
+            parts.push(timestamp.to_string());
+        }
+        if let Some(level) = level {
+            parts.push(level.to_uppercase());
+        }
+        if let Some(source) = source {
+            parts.push(format!("source={source}"));
+        }
+        if let Some(message) = message {
+            parts.push(message.to_string());
+        }
+        return parts.join(" | ");
+    }
+
+    serde_json::to_string(entry).unwrap_or_else(|_| entry.to_string())
 }
 
 /// Per-provider model configuration detail.
@@ -2936,21 +2970,25 @@ mod tests {
     #[test]
     fn render_doctor_report() {
         let r = DoctorReport {
+            overall: "degraded".into(),
             checks: vec![
                 DoctorCheck {
                     name: "config".into(),
-                    passed: true,
-                    detail: "valid".into(),
+                    status: "pass".into(),
+                    message: "valid".into(),
                 },
                 DoctorCheck {
                     name: "db".into(),
-                    passed: false,
-                    detail: "unreachable".into(),
+                    status: "fail".into(),
+                    message: "unreachable".into(),
                 },
             ],
+            run_at: "2026-03-20T09:30:00Z".into(),
         };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("1/2 checks passed"));
+        assert!(out.contains("Overall: degraded"));
+        assert!(out.contains("Checks: 1/2 passing"));
+        assert!(out.contains("db [fail]: unreachable"));
     }
 
     #[test]
@@ -3572,6 +3610,7 @@ mod tests {
             entries: vec![serde_json::json!({
                 "timestamp": "2026-03-20T09:00:00Z",
                 "level": "warn",
+                "source": "gateway",
                 "message": "gateway restart pending"
             })],
             message: "1 log entry returned".into(),
@@ -3579,7 +3618,7 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Logs"));
         assert!(out.contains("Entries: 1"));
-        assert!(out.contains("gateway restart pending"));
+        assert!(out.contains("2026-03-20T09:00:00Z | WARN | source=gateway | gateway restart pending"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class gateway-backed `rune doctor` run/results surfaces
- add `rune logs` plus `rune gateway logs` aliases over the existing `/api/logs` endpoint
- align doctor/log rendering with the gateway response shape and add focused CLI/client/output coverage

## Validation
- `cargo test -p rune-cli --offline parse_doctor`
- `cargo test -p rune-cli --offline parse_logs`
- `cargo test -p rune-cli --offline parse_gateway_logs`
- `cargo test -p rune-cli --offline parse_gateway_doctor_results`
- `cargo test -p rune-cli --offline render_doctor_report`
- `cargo test -p rune-cli --offline render_logs_query_human`
- `cargo test -p rune-cli --offline render_logs_query_json`
- `cargo test -p rune-cli --offline logs_query_passes_filters_and_parses_response`
- `cargo test -p rune-cli --offline doctor_run_posts_and_parses_response`
- `cargo test -p rune-cli --offline doctor_results_gets_and_parses_response`

## Scope
- `crates/rune-cli/src/cli.rs`
- `crates/rune-cli/src/client.rs`
- `crates/rune-cli/src/lib.rs`
- `crates/rune-cli/src/output.rs`
