### PR TITLE
feat(cli): add gateway config/runtime admin surfaces (#40)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -181,6 +181,16 @@ pub enum GatewayAction {
     Status,
     /// Run a health check against the gateway.
     Health,
+    /// Inspect and mutate the live gateway config surface.
+    Config {
+        #[command(subcommand)]
+        action: GatewayConfigAction,
+    },
+    /// Inspect runtime control-plane status surfaced by the gateway.
+    Runtime {
+        #[command(subcommand)]
+        action: GatewayRuntimeAction,
+    },
     /// Probe RPC/API reachability and auth separately from process status.
     Probe,
     /// Discover operator-facing runtime URLs and config binding details.
@@ -216,6 +226,36 @@ pub enum GatewayAction {
     Restart,
     /// Run the gateway in the foreground using the local rune-gateway binary.
     Run,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GatewayConfigAction {
+    /// Fetch the live gateway config with secrets redacted.
+    Show,
+    /// Replace the live gateway config from a JSON file or stdin (`-`).
+    Apply {
+        /// JSON file path, or `-` to read from stdin.
+        input: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GatewayRuntimeAction {
+    /// Inspect and control the heartbeat runner.
+    Heartbeat {
+        #[command(subcommand)]
+        action: GatewayRuntimeHeartbeatAction,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Subcommand)]
+pub enum GatewayRuntimeHeartbeatAction {
+    /// Enable the heartbeat runner.
+    Enable,
+    /// Disable the heartbeat runner.
+    Disable,
+    /// Show heartbeat runner status (enabled, interval, counters).
+    Status,
 }
 
 #[derive(Debug, Clone, Copy, Subcommand)]
@@ -1249,6 +1289,49 @@ mod tests {
             cli.command,
             Command::Gateway {
                 action: GatewayAction::Health
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_gateway_config_show() {
+        let cli = Cli::try_parse_from(["rune", "gateway", "config", "show"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Gateway {
+                action: GatewayAction::Config {
+                    action: GatewayConfigAction::Show
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_gateway_config_apply() {
+        let cli = Cli::try_parse_from(["rune", "gateway", "config", "apply", "live.json"]).unwrap();
+        match cli.command {
+            Command::Gateway {
+                action:
+                    GatewayAction::Config {
+                        action: GatewayConfigAction::Apply { input },
+                    },
+            } => assert_eq!(input, "live.json"),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_gateway_runtime_heartbeat_status() {
+        let cli =
+            Cli::try_parse_from(["rune", "gateway", "runtime", "heartbeat", "status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Gateway {
+                action: GatewayAction::Runtime {
+                    action: GatewayRuntimeAction::Heartbeat {
+                        action: GatewayRuntimeHeartbeatAction::Status
+                    }
+                }
             }
         ));
     }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -15,8 +15,9 @@ use crate::output::{
     ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
     ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
     CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorReport, GatewayCallResponse,
-    GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse,
-    HeartbeatStatusResponse, LogsQueryResponse, SystemEventListResponse,
+    GatewayConfigResponse, GatewayDiscoverResponse, GatewayProbeResponse,
+    GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse, LogsQueryResponse,
+    SystemEventListResponse,
     ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
@@ -85,6 +86,64 @@ impl GatewayClient {
             })
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
+        }
+    }
+
+    /// `GET /config`
+    pub async fn gateway_config(&self) -> Result<GatewayConfigResponse> {
+        let resp = self
+            .http
+            .get(self.url("/config"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let config = resp
+                .json::<serde_json::Value>()
+                .await
+                .context("invalid JSON from /config")?;
+            Ok(GatewayConfigResponse {
+                action: "current".to_string(),
+                config,
+                note: Some("Returned from the live gateway; secrets are redacted.".to_string()),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
+        }
+    }
+
+    /// `PUT /config`
+    pub async fn gateway_config_apply(
+        &self,
+        config: serde_json::Value,
+    ) -> Result<GatewayConfigResponse> {
+        let resp = self
+            .http
+            .put(self.url("/config"))
+            .json(&config)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if resp.status().is_success() {
+            let config = resp
+                .json::<serde_json::Value>()
+                .await
+                .context("invalid JSON from PUT /config")?;
+            Ok(GatewayConfigResponse {
+                action: "applied".to_string(),
+                config,
+                note: Some(
+                    "Live gateway config replaced; returned config view is redacted.".to_string(),
+                ),
+            })
+        } else {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned HTTP {status}: {body_text}");
         }
     }
 
@@ -2664,6 +2723,63 @@ mod tests {
         assert_eq!(resp.status, "running");
         assert_eq!(resp.version.as_deref(), Some("0.1.0"));
         assert_eq!(resp.uptime_seconds, Some(300));
+    }
+
+    #[tokio::test]
+    async fn gateway_config_gets_redacted_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/config"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "gateway": {
+                    "host": "127.0.0.1",
+                    "auth_token": "***redacted***"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.gateway_config().await.unwrap();
+        assert_eq!(resp.action, "current");
+        assert_eq!(resp.config["gateway"]["host"], "127.0.0.1");
+        assert_eq!(resp.config["gateway"]["auth_token"], "***redacted***");
+    }
+
+    #[tokio::test]
+    async fn gateway_config_apply_puts_json_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/config"))
+            .and(body_json(serde_json::json!({
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 8787
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 8787,
+                    "auth_token": "***redacted***"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .gateway_config_apply(serde_json::json!({
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 8787
+                }
+            }))
+            .await
+            .unwrap();
+        assert_eq!(resp.action, "applied");
+        assert_eq!(resp.config["gateway"]["port"], 8787);
+        assert_eq!(resp.config["gateway"]["auth_token"], "***redacted***");
     }
 
     #[test]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -24,10 +24,11 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 pub use cli::Cli;
 use cli::{
     AgentsAction, ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell,
-    ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction, LogsArgs,
+    ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
+    GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, RemindersAction, SessionsAction, SkillsAction, SystemAction,
-    SystemEventAction, SystemHeartbeatAction,
+    ModelsAction, RemindersAction, SessionsAction, SkillsAction, SystemAction, SystemEventAction,
+    SystemHeartbeatAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -154,6 +155,29 @@ fn print_completion(shell: CompletionShell) -> Result<()> {
         &mut std::io::stdout(),
     );
     Ok(())
+}
+
+fn read_gateway_config_input(input: &str) -> Result<serde_json::Value> {
+    let raw = if input == "-" {
+        use std::io::Read as _;
+
+        let mut stdin = String::new();
+        std::io::stdin()
+            .read_to_string(&mut stdin)
+            .context("failed to read gateway config JSON from stdin")?;
+        stdin
+    } else {
+        std::fs::read_to_string(input)
+            .with_context(|| format!("failed to read gateway config JSON from {input}"))?
+    };
+
+    serde_json::from_str(&raw).with_context(|| {
+        if input == "-" {
+            "failed to parse gateway config JSON from stdin".to_string()
+        } else {
+            format!("failed to parse gateway config JSON from {input}")
+        }
+    })
 }
 
 fn parse_reminder_duration(input: &str) -> Result<DateTime<Utc>> {
@@ -860,6 +884,33 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.gateway_health().await?;
                 println!("{}", render(&result, format));
             }
+            GatewayAction::Config { action } => match action {
+                GatewayConfigAction::Show => {
+                    let result = client.gateway_config().await?;
+                    println!("{}", render(&result, format));
+                }
+                GatewayConfigAction::Apply { input } => {
+                    let config = read_gateway_config_input(&input)?;
+                    let result = client.gateway_config_apply(config).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            GatewayAction::Runtime { action } => match action {
+                GatewayRuntimeAction::Heartbeat { action } => match action {
+                    GatewayRuntimeHeartbeatAction::Enable => {
+                        let result = client.heartbeat_enable().await?;
+                        println!("{}", render(&result, format));
+                    }
+                    GatewayRuntimeHeartbeatAction::Disable => {
+                        let result = client.heartbeat_disable().await?;
+                        println!("{}", render(&result, format));
+                    }
+                    GatewayRuntimeHeartbeatAction::Status => {
+                        let result = client.heartbeat_status().await?;
+                        println!("{}", render(&result, format));
+                    }
+                },
+            },
             GatewayAction::Probe => {
                 let result = client.gateway_probe().await?;
                 println!("{}", render(&result, format));
@@ -2095,6 +2146,21 @@ models = ["dall-e-3"]
     fn parse_reminder_duration_rejects_bad_unit() {
         let err = parse_reminder_duration("5w").unwrap_err();
         assert!(err.to_string().contains("invalid reminder duration unit"));
+    }
+
+    #[test]
+    fn read_gateway_config_input_reads_json_file() {
+        let tmp = TempDir::new().unwrap();
+        let input_path = tmp.path().join("gateway-config.json");
+        std::fs::write(
+            &input_path,
+            r#"{"gateway":{"host":"127.0.0.1","port":8787}}"#,
+        )
+        .unwrap();
+
+        let config = read_gateway_config_input(input_path.to_str().unwrap()).unwrap();
+        assert_eq!(config["gateway"]["host"], "127.0.0.1");
+        assert_eq!(config["gateway"]["port"], 8787);
     }
 
     #[test]

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -1747,6 +1747,33 @@ impl fmt::Display for ConfigMutationResponse {
     }
 }
 
+/// Live config snapshot returned by the gateway `/config` surface.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayConfigResponse {
+    pub action: String,
+    pub config: serde_json::Value,
+    pub note: Option<String>,
+}
+
+impl fmt::Display for GatewayConfigResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let heading = if self.action == "applied" {
+            "Gateway config applied"
+        } else {
+            "Gateway config"
+        };
+        writeln!(f, "{heading}")?;
+        if let Some(note) = &self.note {
+            writeln!(f, "  Note: {note}")?;
+        }
+        write!(
+            f,
+            "{}",
+            serde_json::to_string_pretty(&self.config).unwrap_or_else(|_| "{}".to_string())
+        )
+    }
+}
+
 /// Simple action acknowledgment (gateway start/stop).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionResult {
@@ -3547,6 +3574,24 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Gateway discovery"));
         assert!(out.contains("WebSocket URL: ws://127.0.0.1:8787/ws"));
+    }
+
+    #[test]
+    fn render_gateway_config() {
+        let response = GatewayConfigResponse {
+            action: "current".into(),
+            config: serde_json::json!({
+                "gateway": {
+                    "host": "127.0.0.1",
+                    "auth_token": "***redacted***"
+                }
+            }),
+            note: Some("Returned from the live gateway; secrets are redacted.".into()),
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Gateway config"));
+        assert!(out.contains("Returned from the live gateway; secrets are redacted."));
+        assert!(out.contains("\"auth_token\": \"***redacted***\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class gateway config show/apply CLI surfaces
- add gateway runtime heartbeat inspection/control CLI surfaces
- add focused parse/client/output coverage for the new config/runtime admin commands

## Validation
- `cargo test -p rune-cli --offline parse_gateway_config_show`
- `cargo test -p rune-cli --offline parse_gateway_config_apply`
- `cargo test -p rune-cli --offline parse_gateway_runtime_heartbeat_status`
- `cargo test -p rune-cli --offline render_gateway_config`
- `cargo test -p rune-cli --offline gateway_config_gets_redacted_json`
- `cargo test -p rune-cli --offline gateway_config_apply_puts_json_and_parses_response`

## Scope
- `crates/rune-cli/src/cli.rs`
- `crates/rune-cli/src/client.rs`
- `crates/rune-cli/src/lib.rs`
- `crates/rune-cli/src/output.rs`
