### PR TITLE
feat(config): clarify provider detection and default-provider selection (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -171,6 +171,11 @@ struct DefaultModelSelection {
     source: &'static str,
 }
 
+struct DefaultProviderSelection {
+    provider: String,
+    source: &'static str,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum StartupProviderResolution {
     ExplicitProviders,
@@ -354,24 +359,37 @@ fn configured_provider_summary(config: &AppConfig) -> String {
     }
 }
 
+fn configured_default_provider(config: &AppConfig) -> DefaultProviderSelection {
+    match config.configured_default_provider() {
+        Ok(Some(selection)) => DefaultProviderSelection {
+            provider: selection.provider.name.clone(),
+            source: selection.source.as_str(),
+        },
+        Ok(None) => DefaultProviderSelection {
+            provider: "<none>".to_string(),
+            source: "none",
+        },
+        Err(error) => DefaultProviderSelection {
+            provider: format!("<unresolved:{error}>"),
+            source: "unresolved-configured-default",
+        },
+    }
+}
+
 fn resolved_default_provider(
     config: &AppConfig,
     provider_resolution: StartupProviderResolution,
-    default_model: Option<&DefaultModelSelection>,
-) -> String {
-    let Some(selection) = default_model else {
-        return "<none>".to_string();
-    };
-
-    if provider_resolution == StartupProviderResolution::ZeroConfigOllama
-        || selection.source == "ollama-auto"
-    {
-        return "ollama".to_string();
-    }
-
-    match config.models.resolve_model(&selection.model) {
-        Ok(resolved) => resolved.provider.name.clone(),
-        Err(error) => format!("<unresolved:{error}>"),
+) -> DefaultProviderSelection {
+    match provider_resolution {
+        StartupProviderResolution::ZeroConfigOllama => DefaultProviderSelection {
+            provider: "ollama".to_string(),
+            source: "zero-config-ollama",
+        },
+        StartupProviderResolution::EchoFallback => DefaultProviderSelection {
+            provider: "echo".to_string(),
+            source: "echo-fallback",
+        },
+        StartupProviderResolution::ExplicitProviders => configured_default_provider(config),
     }
 }
 
@@ -381,13 +399,15 @@ fn emit_startup_model_resolution(
     default_model: Option<&DefaultModelSelection>,
 ) {
     let configured_default_model = config.configured_default_model();
+    let configured_default_provider = configured_default_provider(config);
     let provider_detail = match provider_resolution {
         StartupProviderResolution::ExplicitProviders => configured_provider_summary(config),
-        StartupProviderResolution::ZeroConfigOllama => trimmed_env_var(OLLAMA_HOST_ENV)
-            .unwrap_or_else(|| "http://localhost:11434".to_string()),
+        StartupProviderResolution::ZeroConfigOllama => {
+            trimmed_env_var(OLLAMA_HOST_ENV).unwrap_or_else(|| "http://localhost:11434".to_string())
+        }
         StartupProviderResolution::EchoFallback => "echo".to_string(),
     };
-    let default_provider = resolved_default_provider(config, provider_resolution, default_model);
+    let default_provider = resolved_default_provider(config, provider_resolution);
 
     info!(
         configured_providers = %configured_provider_summary(config),
@@ -397,9 +417,12 @@ fn emit_startup_model_resolution(
         configured_default_model_source = configured_default_model
             .map(|selection| selection.source.as_str())
             .unwrap_or("none"),
+        configured_default_provider = %configured_default_provider.provider,
+        configured_default_provider_source = configured_default_provider.source,
         provider_resolution = provider_resolution.as_str(),
         provider_detail = %provider_detail,
-        default_provider = %default_provider,
+        default_provider = %default_provider.provider,
+        default_provider_source = default_provider.source,
         default_model = default_model
             .map(|selection| selection.model.as_str())
             .unwrap_or("<none>"),
@@ -437,7 +460,8 @@ async fn build_services(
         SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
     );
 
-    let (model_provider, auto_default_model, provider_resolution) = build_model_provider(&config).await;
+    let (model_provider, auto_default_model, provider_resolution) =
+        build_model_provider(&config).await;
     let model_provider: Arc<dyn ModelProvider> = model_provider;
     let scheduler = Arc::new(Scheduler::new_with_repos(
         job_repo.clone(),
@@ -2213,7 +2237,11 @@ impl SubagentManager for LiveSubagentManager {
 /// `default_model` is configured.
 async fn build_model_provider(
     config: &AppConfig,
-) -> (Arc<dyn ModelProvider>, Option<String>, StartupProviderResolution) {
+) -> (
+    Arc<dyn ModelProvider>,
+    Option<String>,
+    StartupProviderResolution,
+) {
     let ollama_host = trimmed_env_var(OLLAMA_HOST_ENV);
 
     if !config.models.providers.is_empty() {
@@ -2223,7 +2251,11 @@ async fn build_model_provider(
             Ok(provider) => Arc::new(provider),
             Err(error) => {
                 warn!(error = %error, "failed to build routed model provider, falling back to echo");
-                Arc::new(EchoModelProvider)
+                return (
+                    Arc::new(EchoModelProvider),
+                    None,
+                    StartupProviderResolution::EchoFallback,
+                );
             }
         };
         return (provider, None, StartupProviderResolution::ExplicitProviders);
@@ -2274,7 +2306,11 @@ async fn build_model_provider(
                     "no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)"
                 );
             }
-            (Arc::new(EchoModelProvider), None, StartupProviderResolution::EchoFallback)
+            (
+                Arc::new(EchoModelProvider),
+                None,
+                StartupProviderResolution::EchoFallback,
+            )
         }
     }
 }
@@ -2329,7 +2365,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_default_provider_uses_explicit_provider_inventory() {
+    fn configured_default_provider_uses_explicit_provider_inventory() {
         let config = AppConfig {
             models: rune_config::ModelsConfig {
                 default_model: Some("gpt-5.4".into()),
@@ -2348,38 +2384,56 @@ mod tests {
             },
             ..AppConfig::default()
         };
-        let selection =
-            select_default_model(&config, None).expect("configured explicit default model");
+        let selection = configured_default_provider(&config);
 
-        assert_eq!(
-            resolved_default_provider(
-                &config,
-                StartupProviderResolution::ExplicitProviders,
-                Some(&selection),
-            ),
-            "openai"
-        );
+        assert_eq!(selection.provider, "openai");
+        assert_eq!(selection.source, "models.default_model");
     }
 
     #[test]
-    fn resolved_default_provider_is_ollama_for_zero_config_defaults() {
+    fn resolved_default_provider_is_ollama_even_without_default_model() {
+        let config = AppConfig::default();
+
+        let selection =
+            resolved_default_provider(&config, StartupProviderResolution::ZeroConfigOllama);
+
+        assert_eq!(selection.provider, "ollama");
+        assert_eq!(selection.source, "zero-config-ollama");
+    }
+
+    #[test]
+    fn configured_default_provider_uses_single_provider_without_default_model() {
         let mut config = AppConfig::default();
-        config.models.default_model = Some("llama3.2".into());
-        let selection =
-            select_default_model(&config, Some("llama3.2".into())).expect("configured default");
+        config.models.providers = vec![rune_config::ModelProviderConfig {
+            name: "openai".into(),
+            kind: "openai".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: None,
+            deployment_name: None,
+            api_version: None,
+            api_key_env: Some("OPENAI_API_KEY".into()),
+            model_alias: None,
+            models: vec![],
+        }];
 
-        assert_eq!(
-            resolved_default_provider(
-                &config,
-                StartupProviderResolution::ZeroConfigOllama,
-                Some(&selection),
-            ),
-            "ollama"
-        );
+        let selection = configured_default_provider(&config);
+
+        assert_eq!(selection.provider, "openai");
+        assert_eq!(selection.source, "single-provider");
     }
 
     #[test]
-    fn resolved_default_provider_reports_unresolved_explicit_models() {
+    fn resolved_default_provider_is_echo_for_fallback() {
+        let config = AppConfig::default();
+
+        let selection = resolved_default_provider(&config, StartupProviderResolution::EchoFallback);
+
+        assert_eq!(selection.provider, "echo");
+        assert_eq!(selection.source, "echo-fallback");
+    }
+
+    #[test]
+    fn configured_default_provider_reports_unresolved_explicit_models() {
         let mut config = AppConfig::default();
         config.models.default_model = Some("missing-model".into());
         config.models.providers = vec![
@@ -2406,15 +2460,36 @@ mod tests {
                 models: vec![rune_config::ConfiguredModel::Id("claude-sonnet-4-5".into())],
             },
         ];
-        let selection =
-            select_default_model(&config, None).expect("configured explicit default model");
-        let provider = resolved_default_provider(
-            &config,
-            StartupProviderResolution::ExplicitProviders,
-            Some(&selection),
-        );
+        let provider = configured_default_provider(&config);
 
-        assert!(provider.starts_with("<unresolved:"));
+        assert!(provider.provider.starts_with("<unresolved:"));
+        assert_eq!(provider.source, "unresolved-configured-default");
+    }
+
+    #[tokio::test]
+    async fn build_model_provider_reports_echo_fallback_for_invalid_explicit_provider_config() {
+        let config = AppConfig {
+            models: rune_config::ModelsConfig {
+                providers: vec![rune_config::ModelProviderConfig {
+                    name: "openai".into(),
+                    kind: "openai".into(),
+                    base_url: "https://api.openai.com/v1".into(),
+                    api_key: None,
+                    deployment_name: None,
+                    api_version: None,
+                    api_key_env: Some("MISSING_OPENAI_API_KEY".into()),
+                    model_alias: None,
+                    models: vec![rune_config::ConfiguredModel::Id("gpt-5.4".into())],
+                }],
+                ..Default::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let (_, auto_default_model, resolution) = build_model_provider(&config).await;
+
+        assert_eq!(auto_default_model, None);
+        assert_eq!(resolution, StartupProviderResolution::EchoFallback);
     }
 
     #[tokio::test]

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -213,6 +213,43 @@ impl AppConfig {
                 source: ConfiguredDefaultModelSource::ModelsDefault,
             })
     }
+
+    /// Return the configured default provider before runtime auto-detection.
+    ///
+    /// This is detectable when:
+    /// - a configured default model resolves to an explicit provider, or
+    /// - exactly one explicit provider is configured
+    pub fn configured_default_provider(
+        &self,
+    ) -> Result<Option<ConfiguredDefaultProvider<'_>>, ModelResolutionError> {
+        if self.models.providers.is_empty() {
+            return Ok(None);
+        }
+
+        if let Some(selection) = self.configured_default_model() {
+            let resolved = self.models.resolve_model(selection.model)?;
+            return Ok(Some(ConfiguredDefaultProvider {
+                provider: resolved.provider,
+                source: match selection.source {
+                    ConfiguredDefaultModelSource::AgentConfig => {
+                        ConfiguredDefaultProviderSource::AgentConfig
+                    }
+                    ConfiguredDefaultModelSource::ModelsDefault => {
+                        ConfiguredDefaultProviderSource::ModelsDefault
+                    }
+                },
+            }));
+        }
+
+        if self.models.providers.len() == 1 {
+            return Ok(Some(ConfiguredDefaultProvider {
+                provider: &self.models.providers[0],
+                source: ConfiguredDefaultProviderSource::SingleProvider,
+            }));
+        }
+
+        Ok(None)
+    }
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -1060,6 +1097,33 @@ impl ConfiguredDefaultModelSource {
 pub struct ConfiguredDefaultModel<'a> {
     pub model: &'a str,
     pub source: ConfiguredDefaultModelSource,
+}
+
+/// Source of the configured default provider before runtime auto-detection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConfiguredDefaultProviderSource {
+    AgentConfig,
+    ModelsDefault,
+    SingleProvider,
+}
+
+impl ConfiguredDefaultProviderSource {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentConfig => "agent-config",
+            Self::ModelsDefault => "models.default_model",
+            Self::SingleProvider => "single-provider",
+        }
+    }
+}
+
+/// Configured default provider selection before runtime auto-detection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConfiguredDefaultProvider<'a> {
+    pub provider: &'a ModelProviderConfig,
+    pub source: ConfiguredDefaultProviderSource,
 }
 
 /// Multi-agent configuration.
@@ -2228,7 +2292,186 @@ models = ["gpt-5.4", "gpt-image-1"]
             .configured_default_model()
             .expect("configured default model");
         assert_eq!(selection.model, "models-default");
-        assert_eq!(selection.source, ConfiguredDefaultModelSource::ModelsDefault);
+        assert_eq!(
+            selection.source,
+            ConfiguredDefaultModelSource::ModelsDefault
+        );
+    }
+
+    #[test]
+    fn configured_default_provider_prefers_agent_model_provider() {
+        let mut config = AppConfig::default();
+        config.models.default_model = Some("openai/gpt-5.4".into());
+        config.models.providers = vec![
+            ModelProviderConfig {
+                name: "openai".into(),
+                kind: "openai".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("OPENAI_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "anthropic".into(),
+                kind: "anthropic".into(),
+                base_url: "https://api.anthropic.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("ANTHROPIC_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-sonnet-4-5".into())],
+            },
+        ];
+        config.agents.list = vec![AgentConfig {
+            id: "coder".into(),
+            default: Some(true),
+            model: Some(AgentModelSelection::Id(
+                "anthropic/claude-sonnet-4-5".into(),
+            )),
+            workspace: None,
+            system_prompt: None,
+        }];
+
+        let selection = config
+            .configured_default_provider()
+            .expect("provider detection should succeed")
+            .expect("configured default provider");
+        assert_eq!(selection.provider.name, "anthropic");
+        assert_eq!(
+            selection.source,
+            ConfiguredDefaultProviderSource::AgentConfig
+        );
+    }
+
+    #[test]
+    fn configured_default_provider_uses_models_default_provider() {
+        let mut config = AppConfig::default();
+        config.models.default_model = Some("openai/gpt-5.4".into());
+        config.models.providers = vec![ModelProviderConfig {
+            name: "openai".into(),
+            kind: "openai".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: None,
+            deployment_name: None,
+            api_version: None,
+            api_key_env: Some("OPENAI_API_KEY".into()),
+            model_alias: None,
+            models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+        }];
+
+        let selection = config
+            .configured_default_provider()
+            .expect("provider detection should succeed")
+            .expect("configured default provider");
+        assert_eq!(selection.provider.name, "openai");
+        assert_eq!(
+            selection.source,
+            ConfiguredDefaultProviderSource::ModelsDefault
+        );
+    }
+
+    #[test]
+    fn configured_default_provider_uses_single_provider_without_default_model() {
+        let mut config = AppConfig::default();
+        config.models.providers = vec![ModelProviderConfig {
+            name: "openai".into(),
+            kind: "openai".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: None,
+            deployment_name: None,
+            api_version: None,
+            api_key_env: Some("OPENAI_API_KEY".into()),
+            model_alias: None,
+            models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+        }];
+
+        let selection = config
+            .configured_default_provider()
+            .expect("provider detection should succeed")
+            .expect("configured default provider");
+        assert_eq!(selection.provider.name, "openai");
+        assert_eq!(
+            selection.source,
+            ConfiguredDefaultProviderSource::SingleProvider
+        );
+    }
+
+    #[test]
+    fn configured_default_provider_returns_none_for_multi_provider_without_default_model() {
+        let mut config = AppConfig::default();
+        config.models.providers = vec![
+            ModelProviderConfig {
+                name: "openai".into(),
+                kind: "openai".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("OPENAI_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "anthropic".into(),
+                kind: "anthropic".into(),
+                base_url: "https://api.anthropic.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("ANTHROPIC_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-sonnet-4-5".into())],
+            },
+        ];
+
+        assert_eq!(
+            config
+                .configured_default_provider()
+                .expect("provider detection should succeed"),
+            None
+        );
+    }
+
+    #[test]
+    fn configured_default_provider_reports_unresolved_default_model() {
+        let mut config = AppConfig::default();
+        config.models.default_model = Some("missing-model".into());
+        config.models.providers = vec![
+            ModelProviderConfig {
+                name: "openai".into(),
+                kind: "openai".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("OPENAI_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            },
+            ModelProviderConfig {
+                name: "anthropic".into(),
+                kind: "anthropic".into(),
+                base_url: "https://api.anthropic.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("ANTHROPIC_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("claude-sonnet-4-5".into())],
+            },
+        ];
+
+        let err = config
+            .configured_default_provider()
+            .expect_err("missing explicit default should be unresolved");
+        assert!(matches!(
+            err,
+            ModelResolutionError::UnknownModel { model } if model == "missing-model"
+        ));
     }
 
     #[test]

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -836,6 +836,15 @@ When `models.providers` is non-empty, explicit provider config wins and zero-con
 
 If `models.default_model` is set while Rune is using zero-config Ollama bootstrap, that configured default must win over the Ollama auto-pick.
 
+When explicit providers are configured, Rune should detect a configured default provider in this order:
+
+1. resolve the default agent model when one exists
+2. otherwise resolve `models.default_model` when it exists
+3. otherwise, when exactly one provider is configured, treat that provider as the configured default provider even before a default model is chosen
+4. otherwise leave the configured default provider unset
+
+If an explicit default model cannot be resolved against the configured provider inventory, startup diagnostics must surface that as unresolved instead of silently inventing a provider.
+
 ---
 
 #### 5. Operator-visible startup diagnostics
@@ -850,12 +859,15 @@ Startup logging must make these decisions inspectable without reading source cod
 - `OLLAMA_HOST` value when relevant
 - configured providers summary
 - configured default model and its source before runtime probing
+- configured default provider and its source before runtime probing when detectable
 - resolved provider mode: explicit providers, zero-config Ollama, or echo fallback
 - resolved provider detail: configured provider names, Ollama probe target, or echo
-- resolved default provider for the chosen default model when one exists
+- resolved default provider and its source after runtime provider selection
 - default model source: agent config, `models.default_model`, or Ollama auto-pick
 
 If `OLLAMA_HOST` is set but unreachable, startup must warn explicitly that Rune is falling back instead of silently behaving like localhost probing.
+
+If explicit provider construction fails at startup, Rune must report `echo-fallback` as the resolved provider mode rather than logging the configured provider inventory as if it were active.
 
 ---
 

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -648,8 +648,10 @@ Rune startup must behave predictably across file config, environment overrides, 
 - explicit `models.providers` disables zero-config Ollama auto-detect
 - empty `models.providers` enables zero-config Ollama probing
 - `models.default_model` overrides the Ollama auto-picked model when both are present
+- explicit default-provider detection follows: default agent model, then `models.default_model`, then single explicit provider when only one exists
 - bare-host `mode = "auto"` with untouched Docker-default paths resolves to standalone local mode
 - Docker/Kubernetes or explicit server signals preserve server-oriented path layout
+- unresolved explicit default-model references stay unresolved in diagnostics; Rune does not guess a provider
 
 #### Operator evidence
 
@@ -662,8 +664,9 @@ Startup logs must surface:
 - `OLLAMA_HOST` relevance
 - configured providers summary
 - configured default model and source
+- configured default provider and source when detectable
 - resolved provider mode and detail
-- resolved default provider when a default model is selected
+- resolved default provider and source after runtime provider selection
 - default model source
 
 ---
@@ -685,6 +688,7 @@ A first local boot with no custom config must start in a coherent standalone sha
 
 - unreachable `OLLAMA_HOST` must warn explicitly before fallback
 - reachable Ollama with no pulled models must emit actionable operator guidance
+- explicit provider build failure must surface as `echo-fallback` in runtime provider resolution
 - missing or unwritable required paths must surface clear path-specific diagnostics
 
 ---


### PR DESCRIPTION
## Summary
- surface configured default-provider detection before runtime probing
- surface resolved default-provider source after startup provider selection, including explicit-provider build failure fallback
- document the explicit-provider/default-provider detection contract in canonical operator/parity docs

## Validation
- `cargo test --offline -p rune-config configured_default_provider`
- `cargo test --offline -p rune-gateway-app default_provider`

## Scope
- `apps/gateway/src/main.rs`
- `crates/rune-config/src/lib.rs`
- `docs/operator/DEPLOYMENT.md`
- `docs/parity/PARITY-CONTRACTS.md`
