### PR TITLE
feat(config): tighten zero-config Ollama env mapping (#61)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -259,6 +259,7 @@ fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: 
     };
     let config_path = flags.config_path.as_deref();
     let ollama_host = trimmed_env_var(OLLAMA_HOST_ENV);
+    let ollama_probe_target = zero_config_ollama_probe_target(config);
     let state_root = state_root_display(config);
 
     info!(
@@ -273,7 +274,8 @@ fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: 
         state_root = %state_root,
         store_backend,
         model_bootstrap = config.models.bootstrap().as_str(),
-        ollama_host = ollama_host.as_deref().unwrap_or("<default>"),
+        ollama_host = ollama_host.as_deref().unwrap_or("<unset>"),
+        ollama_probe_target = ollama_probe_target.as_deref().unwrap_or("<disabled>"),
         approval_mode = config.approval.mode.as_str(),
         security_posture = config.security.posture(),
         "starting rune gateway"
@@ -331,6 +333,13 @@ fn state_root_display(config: &AppConfig) -> String {
             .display()
             .to_string(),
     }
+}
+
+fn zero_config_ollama_probe_target(config: &AppConfig) -> Option<String> {
+    let ollama_host = trimmed_env_var(OLLAMA_HOST_ENV);
+    config
+        .models
+        .zero_config_ollama_base_url(ollama_host.as_deref())
 }
 
 fn select_default_model(
@@ -402,9 +411,8 @@ fn emit_startup_model_resolution(
     let configured_default_provider = configured_default_provider(config);
     let provider_detail = match provider_resolution {
         StartupProviderResolution::ExplicitProviders => configured_provider_summary(config),
-        StartupProviderResolution::ZeroConfigOllama => {
-            trimmed_env_var(OLLAMA_HOST_ENV).unwrap_or_else(|| "http://localhost:11434".to_string())
-        }
+        StartupProviderResolution::ZeroConfigOllama => zero_config_ollama_probe_target(config)
+            .unwrap_or_else(|| "http://localhost:11434".to_string()),
         StartupProviderResolution::EchoFallback => "echo".to_string(),
     };
     let default_provider = resolved_default_provider(config, provider_resolution);
@@ -2261,14 +2269,23 @@ async fn build_model_provider(
         return (provider, None, StartupProviderResolution::ExplicitProviders);
     }
 
-    let probe_target = ollama_host.as_deref().unwrap_or("http://localhost:11434");
+    let probe_target = config
+        .models
+        .zero_config_ollama_base_url(ollama_host.as_deref())
+        .unwrap_or_else(|| "http://localhost:11434".to_string());
     info!(
-        probe_target,
+        probe_target = %probe_target,
         "no model providers configured — probing zero-config Ollama"
     );
-    match rune_models::OllamaProvider::probe_env().await {
+    let detected = if ollama_host.is_some() {
+        rune_models::OllamaProvider::probe_url(&probe_target).await
+    } else {
+        rune_models::OllamaProvider::probe_local().await
+    };
+    match detected {
         Some(provider) => {
             info!(
+                probe_target = %probe_target,
                 ollama_base = %provider.base_url(),
                 url = %provider.url(),
                 "Ollama detected — using as default provider"
@@ -2299,10 +2316,12 @@ async fn build_model_provider(
             if let Some(ollama_host) = ollama_host {
                 warn!(
                     ollama_host = %ollama_host,
+                    probe_target = %probe_target,
                     "OLLAMA_HOST is set but Rune could not reach Ollama there — using echo fallback"
                 );
             } else {
                 info!(
+                    probe_target = %probe_target,
                     "no Ollama found — using echo fallback (configure a provider in config.toml or set OLLAMA_HOST)"
                 );
             }
@@ -2325,6 +2344,11 @@ mod tests {
     use rune_store::StoreError;
     use rune_store::models::{KeywordSearchRow, VectorSearchRow};
     use rune_tools::memory_index::EmbeddingProvider;
+
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        ENV_LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
 
     #[test]
     fn select_default_model_prefers_agent_over_config_and_auto() {
@@ -2430,6 +2454,52 @@ mod tests {
 
         assert_eq!(selection.provider, "echo");
         assert_eq!(selection.source, "echo-fallback");
+    }
+
+    #[test]
+    fn zero_config_ollama_probe_target_reads_and_normalizes_env() {
+        let _guard = env_lock().lock().expect("env lock");
+        unsafe {
+            std::env::set_var(OLLAMA_HOST_ENV, "  ollama-box/  ");
+        }
+
+        let probe_target = zero_config_ollama_probe_target(&AppConfig::default());
+
+        assert_eq!(probe_target.as_deref(), Some("http://ollama-box:11434"));
+        unsafe {
+            std::env::remove_var(OLLAMA_HOST_ENV);
+        }
+    }
+
+    #[test]
+    fn zero_config_ollama_probe_target_is_disabled_by_explicit_providers() {
+        let _guard = env_lock().lock().expect("env lock");
+        unsafe {
+            std::env::set_var(OLLAMA_HOST_ENV, "ollama-box");
+        }
+
+        let config = AppConfig {
+            models: rune_config::ModelsConfig {
+                providers: vec![rune_config::ModelProviderConfig {
+                    name: "openai".into(),
+                    kind: "openai".into(),
+                    base_url: "https://api.openai.com/v1".into(),
+                    api_key: None,
+                    deployment_name: None,
+                    api_version: None,
+                    api_key_env: Some("OPENAI_API_KEY".into()),
+                    model_alias: None,
+                    models: vec![rune_config::ConfiguredModel::Id("gpt-5.4".into())],
+                }],
+                ..Default::default()
+            },
+            ..AppConfig::default()
+        };
+
+        assert_eq!(zero_config_ollama_probe_target(&config), None);
+        unsafe {
+            std::env::remove_var(OLLAMA_HOST_ENV);
+        }
     }
 
     #[test]

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -563,6 +563,19 @@ impl ModelsConfig {
             .collect()
     }
 
+    /// Return the effective Ollama base URL for zero-config startup probing.
+    ///
+    /// When explicit providers are configured, zero-config Ollama probing is
+    /// disabled and this returns `None`.
+    #[must_use]
+    pub fn zero_config_ollama_base_url(&self, ollama_host: Option<&str>) -> Option<String> {
+        if self.bootstrap() != ModelBootstrap::ZeroConfigOllama {
+            return None;
+        }
+
+        Some(normalize_zero_config_ollama_host(ollama_host))
+    }
+
     /// Return every configured model in canonical `provider/model` form.
     #[must_use]
     pub fn inventory(&self) -> Vec<ModelInventoryEntry<'_>> {
@@ -675,6 +688,26 @@ impl ModelsConfig {
             model: model_ref.to_string(),
         })
     }
+}
+
+fn normalize_zero_config_ollama_host(ollama_host: Option<&str>) -> String {
+    let Some(value) = ollama_host
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.trim_end_matches('/'))
+    else {
+        return "http://localhost:11434".to_string();
+    };
+
+    if value.starts_with("http://") || value.starts_with("https://") {
+        return value.to_string();
+    }
+
+    if value.contains(':') {
+        return format!("http://{value}");
+    }
+
+    format!("http://{value}:11434")
 }
 
 /// Named ordered fallback chain metadata.
@@ -2229,6 +2262,56 @@ models = ["gpt-5.4", "gpt-image-1"]
         };
 
         assert_eq!(config.bootstrap(), ModelBootstrap::ExplicitProviders);
+    }
+
+    #[test]
+    fn zero_config_ollama_base_url_defaults_to_localhost() {
+        let config = ModelsConfig::default();
+
+        assert_eq!(
+            config.zero_config_ollama_base_url(None),
+            Some("http://localhost:11434".into())
+        );
+    }
+
+    #[test]
+    fn zero_config_ollama_base_url_normalizes_bare_env_host() {
+        let config = ModelsConfig::default();
+
+        assert_eq!(
+            config.zero_config_ollama_base_url(Some("  ollama-box/  ")),
+            Some("http://ollama-box:11434".into())
+        );
+    }
+
+    #[test]
+    fn zero_config_ollama_base_url_strips_trailing_slash_from_full_url() {
+        let config = ModelsConfig::default();
+
+        assert_eq!(
+            config.zero_config_ollama_base_url(Some("https://ollama.example.com:443/")),
+            Some("https://ollama.example.com:443".into())
+        );
+    }
+
+    #[test]
+    fn zero_config_ollama_base_url_is_disabled_when_explicit_providers_exist() {
+        let config = ModelsConfig {
+            providers: vec![ModelProviderConfig {
+                name: "openai".into(),
+                kind: "openai".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                api_key: None,
+                deployment_name: None,
+                api_version: None,
+                api_key_env: Some("OPENAI_API_KEY".into()),
+                model_alias: None,
+                models: vec![ConfiguredModel::Id("gpt-5.4".into())],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(config.zero_config_ollama_base_url(Some("ollama-box")), None);
     }
 
     #[test]

--- a/crates/rune-models/src/provider/ollama.rs
+++ b/crates/rune-models/src/provider/ollama.rs
@@ -237,7 +237,9 @@ impl OllamaProvider {
     /// `OLLAMA_HOST` follows Ollama's own convention — it may be a bare
     /// `host:port`, a full `http://host:port` URL, or just a host name.
     /// A scheme is prepended when missing and the default port is appended
-    /// when absent.
+    /// when absent. This normalization matches Rune's zero-config startup
+    /// diagnostics so the reported probe target and the actual probe stay in
+    /// sync.
     pub async fn probe_env() -> Option<Self> {
         match std::env::var("OLLAMA_HOST") {
             Ok(val) if !val.trim().is_empty() => {
@@ -377,7 +379,10 @@ mod tests {
     async fn probe_unreachable_returns_none() {
         // Port 19999 should not have an Ollama instance.
         let result = OllamaProvider::probe_url("http://127.0.0.1:19999").await;
-        assert!(result.is_none(), "probe of unreachable host should return None");
+        assert!(
+            result.is_none(),
+            "probe of unreachable host should return None"
+        );
     }
 
     // --- normalize_ollama_host tests ---
@@ -423,6 +428,14 @@ mod tests {
     }
 
     #[test]
+    fn normalize_bare_hostname_with_trailing_slash_appends_default_port() {
+        assert_eq!(
+            normalize_ollama_host("ollama-server/"),
+            "http://ollama-server:11434"
+        );
+    }
+
+    #[test]
     fn normalize_bare_ip_appends_default_port() {
         assert_eq!(
             normalize_ollama_host("192.168.1.100"),
@@ -442,7 +455,9 @@ mod tests {
     async fn probe_env_falls_back_to_local_when_unset() {
         // Ensure OLLAMA_HOST is not set, then probe_env should behave like
         // probe_local (i.e. return None on CI where nothing listens on 11434).
-        unsafe { std::env::remove_var("OLLAMA_HOST"); }
+        unsafe {
+            std::env::remove_var("OLLAMA_HOST");
+        }
         let result = OllamaProvider::probe_env().await;
         // We can't assert Some because Ollama may not be running, but the
         // code path should not panic.
@@ -453,10 +468,17 @@ mod tests {
     async fn probe_env_uses_ollama_host_when_set() {
         // Point OLLAMA_HOST at an unreachable address — should return None
         // without panicking, proving the env var was read.
-        unsafe { std::env::set_var("OLLAMA_HOST", "http://127.0.0.1:19999"); }
+        unsafe {
+            std::env::set_var("OLLAMA_HOST", "http://127.0.0.1:19999");
+        }
         let result = OllamaProvider::probe_env().await;
-        assert!(result.is_none(), "unreachable OLLAMA_HOST should return None");
-        unsafe { std::env::remove_var("OLLAMA_HOST"); }
+        assert!(
+            result.is_none(),
+            "unreachable OLLAMA_HOST should return None"
+        );
+        unsafe {
+            std::env::remove_var("OLLAMA_HOST");
+        }
     }
 
     // --- rank_preferred_model tests ---
@@ -536,16 +558,28 @@ mod tests {
     fn guidance_contains_pull_commands() {
         let provider = OllamaProvider::new();
         let guidance = provider.empty_model_guidance();
-        assert!(guidance.contains("ollama pull llama3.2"), "should suggest llama3.2");
-        assert!(guidance.contains("ollama pull llama3.1:8b"), "should suggest llama3.1:8b");
-        assert!(guidance.contains("ollama pull qwen2.5:7b"), "should suggest qwen2.5:7b");
+        assert!(
+            guidance.contains("ollama pull llama3.2"),
+            "should suggest llama3.2"
+        );
+        assert!(
+            guidance.contains("ollama pull llama3.1:8b"),
+            "should suggest llama3.1:8b"
+        );
+        assert!(
+            guidance.contains("ollama pull qwen2.5:7b"),
+            "should suggest qwen2.5:7b"
+        );
     }
 
     #[test]
     fn guidance_mentions_restart() {
         let provider = OllamaProvider::new();
         let guidance = provider.empty_model_guidance();
-        assert!(guidance.contains("restart Rune"), "should mention restarting Rune");
+        assert!(
+            guidance.contains("restart Rune"),
+            "should mention restarting Rune"
+        );
     }
 
     #[test]

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -825,14 +825,20 @@ Startup logs must show whether the active path profile is:
 
 When `models.providers` is empty, Rune uses zero-config model bootstrap:
 
-1. probe `OLLAMA_HOST` when set
+1. normalize `OLLAMA_HOST` into an effective Ollama base URL when set
 2. otherwise probe `http://localhost:11434`
 3. when Ollama is reachable, use it as the default provider
 4. when pulled models exist, auto-select a default model
 5. when no models are pulled, start without a default model and print actionable guidance
 6. when Ollama is unreachable, fall back to the echo provider
 
-When `models.providers` is non-empty, explicit provider config wins and zero-config Ollama auto-detect is disabled even if `OLLAMA_HOST` is set.
+Accepted `OLLAMA_HOST` forms mirror Ollama itself:
+
+- `http://host:port` or `https://host:port`
+- `host:port` which maps to `http://host:port`
+- `host` which maps to `http://host:11434`
+
+When `models.providers` is non-empty, explicit provider config wins and zero-config Ollama auto-detect is disabled even if `OLLAMA_HOST` is set. Startup diagnostics should reflect that the env var is ignored rather than treating it as an active probe target.
 
 If `models.default_model` is set while Rune is using zero-config Ollama bootstrap, that configured default must win over the Ollama auto-pick.
 
@@ -856,7 +862,8 @@ Startup logging must make these decisions inspectable without reading source cod
 - active path profile and state root
 - storage backend selection
 - model bootstrap mode: explicit providers or zero-config Ollama
-- `OLLAMA_HOST` value when relevant
+- raw `OLLAMA_HOST` value when present
+- effective zero-config Ollama probe target when relevant
 - configured providers summary
 - configured default model and its source before runtime probing
 - configured default provider and its source before runtime probing when detectable
@@ -865,7 +872,7 @@ Startup logging must make these decisions inspectable without reading source cod
 - resolved default provider and its source after runtime provider selection
 - default model source: agent config, `models.default_model`, or Ollama auto-pick
 
-If `OLLAMA_HOST` is set but unreachable, startup must warn explicitly that Rune is falling back instead of silently behaving like localhost probing.
+If `OLLAMA_HOST` is set but unreachable, startup must warn explicitly that Rune is falling back, and must name the normalized probe target instead of silently behaving like localhost probing.
 
 If explicit provider construction fails at startup, Rune must report `echo-fallback` as the resolved provider mode rather than logging the configured provider inventory as if it were active.
 

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -661,7 +661,8 @@ Startup logs must surface:
 - requested mode and resolved mode
 - path profile
 - model bootstrap mode
-- `OLLAMA_HOST` relevance
+- raw `OLLAMA_HOST` when present plus whether it is relevant
+- effective zero-config Ollama probe target when relevant
 - configured providers summary
 - configured default model and source
 - configured default provider and source when detectable
@@ -682,11 +683,11 @@ A first local boot with no custom config must start in a coherent standalone sha
 - default Docker-first paths are remapped to `~/.rune/*` on a bare host
 - required local directories are auto-created for standalone mode
 - path validation remains explicit and operator-visible
-- zero-config Ollama probing uses `OLLAMA_HOST` when provided, otherwise localhost
+- zero-config Ollama probing uses the normalized `OLLAMA_HOST` target when provided, otherwise localhost
 
 #### Failure behavior
 
-- unreachable `OLLAMA_HOST` must warn explicitly before fallback
+- unreachable `OLLAMA_HOST` must warn explicitly before fallback and include the normalized probe target
 - reachable Ollama with no pulled models must emit actionable operator guidance
 - explicit provider build failure must surface as `echo-fallback` in runtime provider resolution
 - missing or unwritable required paths must surface clear path-specific diagnostics


### PR DESCRIPTION
## Summary
- normalize `OLLAMA_HOST` into an explicit zero-config probe target and surface it in startup diagnostics
- ensure zero-config Ollama probing uses the normalized target while explicit providers disable the probe target entirely
- document the normalized probe-target contract in canonical operator/parity docs and cover it with focused config/gateway/model tests

## Validation
- `cargo test --offline -p rune-config zero_config_ollama_base_url`
- `cargo test --offline -p rune-gateway-app zero_config_ollama_probe_target`
- `cargo test --offline -p rune-gateway-app default_provider`
- `cargo test --offline -p rune-models normalize_bare_hostname_with_trailing_slash_appends_default_port -- --nocapture`

## Scope
- `apps/gateway/src/main.rs`
- `crates/rune-config/src/lib.rs`
- `crates/rune-models/src/provider/ollama.rs`
- `docs/operator/DEPLOYMENT.md`
- `docs/parity/PARITY-CONTRACTS.md`
