### PR TITLE
docs(parity): record subagent control transport gap (#73)

### DIFF
--- a/docs/parity/CLI-MATRIX.md
+++ b/docs/parity/CLI-MATRIX.md
@@ -60,7 +60,7 @@
 |-----------------|----------------|--------|---------------------|----------|
 | `message` | `rune message` | **Partial** | `send`, `read`, `edit`, `delete`, `react`, `pin`, `search`, `broadcast`, `thread list/reply`, `voice send/status`, `tag`, `ack`, `list-reactions` shipped | #74 |
 | `agent` | — | **Not started** | Direct agent-turn invocation | #70 |
-| `agents` | `rune agents` | **Partial** | `list`, `show`, `status`, `tree`, `templates`, `start --template` shipped. Missing broader orchestration/admin parity. | #63/#70 |
+| `agents` | `rune agents` | **Partial** | `list`, `show`, `status`, `tree`, `templates`, `start --template` shipped. `steer`/`kill` remain blocked because no client-facing transport surface exists yet to send those control actions, even though internal lifecycle/session logic already exists. | #63/#70 |
 | `acp` | — | **Not started** | ACP bridge/client | #70 |
 | `devices` | — | **Not started** | `list`, `remove`, `clear`, `approve`, `reject`, `rotate`, `revoke` | — |
 | `pairing` | — | **Not started** | `list`, `approve` | — |
@@ -79,7 +79,7 @@
 ### Tier 1 summary
 
 - **Shipped:** 0
-- **Partial:** 3 (`message` — breadth verbs remain; `agents` — broader orchestration/admin parity remains; `skills` — plugins/hooks lifecycle still missing)
+- **Partial:** 3 (`message` — breadth verbs remain; `agents` — inspect/start flows ship but `steer`/`kill` are still blocked on missing client-facing transport; `skills` — plugins/hooks lifecycle still missing)
 - **Not started:** 14
 
 ---
@@ -172,7 +172,7 @@ The `message` family is the most actively developed #74 artifact. Current verb c
 7. `config` — bridge from shipped local/gateway config surfaces to true interactive configure parity (#40/#61)
 
 ### Medium-term (Tier 1, highest value)
-8. `agent` / `acp` — agent orchestration CLI breadth beyond current `agents` surfaces (#70)
+8. `agent` / `acp` — agent orchestration CLI breadth beyond current `agents` inspect/start surfaces, including the missing client-facing transport needed for `steer` / `kill` parity (#70)
 9. `skills` / `plugins` / `hooks` — complete extension lifecycle beyond the shipped `skills` family core (#71/#68)
 10. `backup` — backup/restore workflow (#67)
 11. `devices` / `pairing` / `node` / `nodes` — multi-node surface (no issue yet)
@@ -185,6 +185,6 @@ The `message` family is the most actively developed #74 artifact. Current verb c
 |-----------|--------|
 | Every OpenClaw CLI family has a Rune decision | **Done** — this matrix |
 | Shell completion generation for bash, zsh, fish | **Shipped** — PR #143 |
-| Operator workflow families have working equivalents | **Partial** — `sessions`, `approvals`, `system`, substantial `message` / `agents` surfaces, plus first gateway-backed `logs`/`doctor` admin surfaces shipped; `secrets` still not started |
+| Operator workflow families have working equivalents | **Partial** — `sessions`, `approvals`, `system`, substantial `message` surfaces, and `agents` inspect/start flows shipped, plus first gateway-backed `logs`/`doctor` admin surfaces; subagent `steer` / `kill` still lack a client-facing transport and `secrets` is still not started |
 | Lifecycle families have working equivalents | **Not started** — `setup`, `update`, `uninstall`, `reset` all missing |
 | Audit matrix produced | **Done** — this document |

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -604,6 +604,21 @@ None — built-in templates are compiled into the binary. Session state is persi
 
 `implemented` — template listing and `start --template` launch path wired end-to-end.
 
+### Current parity boundary
+
+The currently shipped `rune agents` operator surface is:
+
+- `list`
+- `show`
+- `status`
+- `tree`
+- `templates`
+- `start --template`
+
+That surface is intentionally narrower than full subagent-control parity.
+Internal lifecycle/session logic for descendant agents exists, but Rune does not yet expose a client-facing transport contract for subagent `steer` or `kill` actions.
+Until that transport surface exists on the public CLI/API/event path, `steer` and `kill` remain blocked and must not be described as shipped parity.
+
 ---
 
 ## 14. Evidence checklist template

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -1361,3 +1361,30 @@ This document does not require:
 - in-process plugin loading in phase 1
 
 What it does require is preservation of the behavioral contract seen by operators, channels, tools, and tests.
+
+---
+
+## Issue #73 subagent control transport gap
+
+The current client-visible `rune agents` surface supports:
+
+- `list`
+- `show`
+- `status`
+- `tree`
+- `templates`
+- `start --template`
+
+`steer` and `kill` are not parity-shipped yet.
+
+The blocker is not absence of all internal lifecycle logic. Rune already has internal subagent lifecycle/session transitions, but it does **not** yet expose a supported client-facing transport contract for interactive subagent control. Until that transport exists, parity status should be treated as:
+
+- inspectable: yes
+- startable: yes
+- steerable through a supported public transport: no
+- kill/cancel through a supported public transport: no
+
+Any future parity claim for `steer` or `kill` must include both:
+
+1. a callable client-facing transport surface, and
+2. operator-visible success/failure semantics for those actions.


### PR DESCRIPTION
## Summary
- refresh the parity docs so issue #73 reflects the current truthful state of the `rune agents` family
- document that list/show/status/tree/templates/start are shipped while steer/kill remain blocked on a missing client-facing transport surface
- update the CLI matrix and protocol contract so operator-facing parity claims stay honest

## Scope
- `docs/parity/CLI-MATRIX.md`
- `docs/parity/PARITY-CONTRACTS.md`
- `docs/parity/PROTOCOLS.md`
