### PR TITLE
docs(ops): clarify backup and restore operator workflow (#70)

### DIFF
--- a/docs/FUNCTIONALITY-CHECKLIST.md
+++ b/docs/FUNCTIONALITY-CHECKLIST.md
@@ -128,6 +128,7 @@ Implementation note (2026-03-19): the operator CLI now exposes the `models` comm
 - [ ] `hooks` command family
 - [ ] `webhooks` helpers
 - [ ] `backup` command family
+  - 2026-03-20 docs alignment: operator-facing backup/restore workflow is documented in `docs/operator/DEPLOYMENT.md` and `docs/parity/PROTOCOLS.md`, but the dedicated `rune backup create|restore|list` CLI remains intentionally unchecked until it ships.
 - [ ] `update` command family
 - [ ] `setup` / `onboard` / `uninstall`
 
@@ -367,8 +368,11 @@ Implementation note (2026-03-13): `completion generate <shell>` now emits real s
 - [ ] structured logs
 - [ ] metrics/tracing
 - [x] backup/export
+  - 2026-03-20 docs slice: the shipped operator workflow now explicitly defines quiesce/capture steps, durable-state domains, exclusions, and mode-aware use of filesystem/database-native tooling. This is documentation parity for backup/export, not a claim that the dedicated `backup` CLI family is shipped.
 - [x] restore/migration workflow
+  - 2026-03-20 docs slice: restore guidance now explicitly requires same-layout recovery, provider-native restore steps for managed services, post-restore verification (`rune doctor`, health/status, scheduler/transcript/approval sanity), and declared degraded-recovery limits.
 - [x] restart preservation workflow
+  - 2026-03-20 docs slice: operator docs now make restart/restore expectations explicit for sessions, memory, scheduler state, approvals/audit trails, and other durable state while calling out that live PTY/process attachment and in-flight work are not promised to resume in place.
 - [ ] update path
 - [ ] doctor/diagnostics
 - [ ] doctor interactive repair flow

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -542,13 +542,17 @@ Not recommended as default deployment targets for the parity-first container arc
 
 ## 12. Backup and restore expectations
 
-Container deployment must make backup/restore straightforward. See [PROTOCOLS.md §15.4](../parity/PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full behavioral contract and CLI workflow spec.
+Container deployment must make backup/restore straightforward.
+The shipped operator-facing slice today is the documented workflow below plus filesystem- and database-native tooling.
+The dedicated `rune backup` command family remains a parity target rather than a shipped requirement; see [PROTOCOLS.md §15.4](../parity/PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full workflow and target CLI contract.
 
 ## 12.1 What must be backup-friendly
 
 - database files or managed DB dumps
 - memory documents
 - session/transcript artifacts
+- scheduler/reminder state and related run history
+- approval state and operator audit records
 - skills/plugins bundles
 - configuration overlays
 - secrets references/config, excluding secret values where policy requires external secret storage
@@ -558,12 +562,14 @@ Container deployment must make backup/restore straightforward. See [PROTOCOLS.md
 
 ### Local-first Docker
 
+- stop or quiesce the runtime before capture when consistency requires it
 - filesystem snapshot of mounted paths
 - PostgreSQL-consistent backup/export for `/data/db` when running embedded PostgreSQL
 - optional archive bundles into `/data/backups`
 
 ### Hosted Azure with mounted filesystem
 
+- stop or quiesce the runtime before capture when consistency requires it
 - volume/share snapshot where available
 - PostgreSQL backups if managed DB is used
 - Blob Storage replication for backup archives
@@ -572,17 +578,63 @@ Container deployment must make backup/restore straightforward. See [PROTOCOLS.md
 
 A restore should reconstruct the runtime without needing image-layer recovery or undocumented hidden paths.
 
-## 12.4 Minimum workflow contract
+## 12.4 Operator backup workflow
 
-Any documented Rune backup/restore workflow should make these steps explicit:
+Operators should follow one explicit workflow regardless of whether the capture mechanism is a filesystem snapshot, database dump, or future `rune backup` archive:
 
-1. **Quiesce or coordinate writes** where required (for example, ensure embedded PostgreSQL export/snapshot consistency and avoid mid-write filesystem capture).
-2. **Capture all required durable domains**: DB state, sessions, memory, media when retained, skills, logs/exports as policy requires, config overlays, and backup staging outputs.
-3. **Exclude secret values from backup metadata** while preserving secret references/config needed to reconnect the runtime after restore.
-4. **Restore into the same logical path layout** (`~/.rune/*` locally or `/data/*`, `/config`, `/secrets` in Docker).
-5. **Run post-restore verification**: `rune doctor`, health/status checks, scheduler/job sanity, and session/transcript inspectability checks.
+1. **Identify the deployment mode and data owners** before capture.
+   - Decide whether `/data/db` is authoritative or whether PostgreSQL/object storage are managed externally.
+2. **Quiesce or coordinate writes** before capture.
+   - For embedded PostgreSQL or filesystem snapshots, stop the runtime or otherwise guarantee a consistent checkpoint/snapshot boundary.
+3. **Capture every required durable domain**.
+   - Include DB state, sessions, memory, media when retained, skills, logs/exports as policy requires, config overlays, and `/data/backups` when prior archives are part of the recovery posture.
+   - Preserve secret references/config needed to reconnect after restore, but never secret values.
+4. **Record what the artifact contains and excludes**.
+   - Operators need a manifest or equivalent notes naming capture time, Rune version, included domains, and excluded domains with reason.
+
+## 12.5 Operator restore workflow
+
+1. **Restore into the same logical layout the runtime expects**.
+   - Use `~/.rune/*` locally or `/data/*`, `/config`, and `/secrets` in Docker. Do not restore state into image-layer-only paths.
+2. **Restore provider-managed and filesystem-managed domains through their native mechanisms**.
+   - Managed PostgreSQL, Blob Storage, or other provider-owned data must be restored from provider-native snapshots/replication rather than guessed from local filesystem artifacts.
+3. **Recreate secret material separately when secrets are externally managed**.
+   - Backups preserve secret references/config, not secret values.
+4. **Bring the runtime back only after durable state is in place**.
+   - Restore must not overwrite a live instance silently or race with active writers.
 
 If a deployment mode uses managed PostgreSQL or external object storage, the operator docs must state which parts are restored from provider-native snapshots versus local filesystem artifacts.
+
+## 12.6 Post-restore verification
+
+Run these checks after every restore:
+
+1. `rune doctor`
+2. health/status checks to confirm the runtime is alive, reachable, and pointed at the expected mounts/services
+3. scheduler/reminder inspection to confirm jobs, run history, and next-run derivation look sane
+4. session/transcript inspection to confirm recent history is readable
+5. approval/audit inspection to confirm pending approvals and durable audit trails remain visible
+6. memory/skills/media spot checks for the deployment-specific domains that were restored
+
+## 12.7 Recovery expectations and limits
+
+Backup/restore is expected to recover operator-visible durable state:
+
+- sessions and transcripts
+- memory and curated workspace state
+- scheduler/reminder definitions, run history, and next-run derivation
+- pending approvals and related auditability
+- config overlays and path layout assumptions
+- logs/exports when the operator included them in the capture set
+
+Backup/restore is **not** required to resurrect purely live runtime state:
+
+- attached PTY sessions or live child-process handles
+- in-flight turn execution in the middle of a request
+- transient caches or temporary scratch files
+- provider-managed data that was not included in a provider-native snapshot/export
+
+When a subsystem cannot be fully recreated, the limitation must be stated explicitly in the runbook and verified during post-restore checks.
 
 ---
 

--- a/docs/parity/PARITY-CONTRACTS.md
+++ b/docs/parity/PARITY-CONTRACTS.md
@@ -450,6 +450,7 @@ Do not mark a subsystem parity-complete without black-box evidence.
 - same logical paths exist across host and container modes
 - local-first mode remains reference behavior
 - Azure support is real but optional, not architecture-capturing
+- recovery expectations are explicit: restore recovers durable operator-visible state, not hidden image-layer state or undocumented live runtime handles
 
 ### Required persisted state domains
 
@@ -471,12 +472,15 @@ See [DEPLOYMENT.md §5.1](../operator/DEPLOYMENT.md#51-local--docker-path-equiva
 - deployment docs and config model
 - health/readiness endpoints
 - backup/restore workflows
+- operator runbook for backup, restore, and post-restore verification
 
 ### Failure behavior expectations
 
 - missing mounts/config fail fast and clearly
 - read-only or degraded storage modes surface explicit errors
-- backup/restore workflows are documented and testable (see [PROTOCOLS.md §15.4](PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full contract and CLI workflow spec)
+- backup/restore workflows are documented and testable (see [PROTOCOLS.md §15.4](PROTOCOLS.md#154-backup-and-restore-workflow-contract) for the full contract and target CLI workflow spec)
+- the current shipped recovery interface is explicit even before the dedicated `rune backup` CLI lands
+- degraded-recovery cases are declared explicitly instead of being discovered during an incident
 
 #### Read-only filesystem detection
 
@@ -505,9 +509,10 @@ See [PROTOCOLS.md §3.7](PROTOCOLS.md#secrets-never-logged-invariant) for the fu
 ### Minimum parity evidence
 
 - local Docker deployment with mounted state
-- backup workflow documentation naming included durable-state domains and exclusions (see [PROTOCOLS.md §15.4.5](PROTOCOLS.md#1545-cli-workflow-contract))
-- restore workflow documentation naming prerequisites and post-restore verification checks (see [PROTOCOLS.md §15.4.5](PROTOCOLS.md#1545-cli-workflow-contract))
+- backup workflow documentation naming included durable-state domains, exclusions, and whether the shipped path is runbook/native tooling or a dedicated CLI (see [PROTOCOLS.md §15.4](PROTOCOLS.md#154-backup-and-restore-workflow-contract))
+- restore workflow documentation naming prerequisites, same-layout restore rules, and post-restore verification checks (see [PROTOCOLS.md §15.4](PROTOCOLS.md#154-backup-and-restore-workflow-contract))
 - restart-preservation documentation naming which state must survive container restart and which post-restart checks operators should run
+- degraded-recovery documentation naming what is not expected to survive restore in place (for example, live PTY/process attachment or unmanaged provider-side state)
 - restart durability tests
 - PostgreSQL-backed Azure-hosted mode tests
 - Azure Files/Blob mapping validation for intended domains

--- a/docs/parity/PROTOCOLS.md
+++ b/docs/parity/PROTOCOLS.md
@@ -1237,11 +1237,11 @@ A compliant backup workflow must preserve or explicitly account for:
 
 Backup workflows must be:
 
-- **documented**  operator can tell what is included and what is intentionally excluded
-- **restorable**  output is suitable for reconstructing runtime state
-- **image-independent**  no reliance on hidden image-layer state or container archaeology
-- **mode-aware**  local embedded-PostgreSQL, mounted Docker, and managed-PostgreSQL deployments can differ in mechanism but not in operator clarity
-- **secret-safe**  secret values never appear in archive manifests, logs, doctor output, or status surfaces
+- **documented** - operator can tell what is included and what is intentionally excluded
+- **restorable** - output is suitable for reconstructing runtime state
+- **image-independent** - no reliance on hidden image-layer state or container archaeology
+- **mode-aware** - local embedded-PostgreSQL, mounted Docker, and managed-PostgreSQL deployments can differ in mechanism but not in operator clarity
+- **secret-safe** - secret values never appear in archive manifests, logs, doctor output, or status surfaces
 
 ### 15.4.3 Restore behavior expectations
 
@@ -1252,24 +1252,32 @@ A restore workflow must, at minimum, be able to reconstruct enough durable state
 - scheduler/job state and next-run derivation
 - pending approvals and related operator auditability
 - config overlays and path layout expectations
+- logs/exports when the operator explicitly treated them as part of the retained recovery set
 
-Where a restore cannot fully recreate a subsystem (for example, external provider-managed data), the limitation must be stated explicitly in operator docs.
+Restore is a durable-state recovery contract, not a promise to resurrect every live runtime handle in place.
+Live child-process attachment, PTY continuity, or in-flight turn continuation may be lost across restore unless explicitly implemented and documented.
+
+Where a restore cannot fully recreate a subsystem (for example, external provider-managed data), the limitation must be stated explicitly in operator docs together with the required provider-native recovery step.
 
 ### 15.4.4 Minimum operator evidence
 
 The project should provide enough operator-facing documentation and/or commands that a reviewer can verify:
 
+- which operator workflow is shipped today (documented runbook/native tooling versus dedicated CLI)
 - what to snapshot or export before upgrade
 - where backup artifacts live (`/data/backups` or equivalent)
 - how local paths map to Docker-mounted paths
 - what preconditions are required for a clean restore
 - what post-restore checks to run (`doctor`, health/status, scheduler state sanity)
+- which degraded-recovery cases are expected (for example, provider-managed state, live process handles, or in-flight work)
 
-### 15.4.5 CLI workflow contract
+### 15.4.5 Target CLI workflow contract (`rune backup`, not yet shipped)
 
-The `rune backup` command family is the primary operator interface for snapshot and recovery workflows. These commands must implement the behavioral expectations defined in §15.4.1–§15.4.4.
+The currently shipped operator-facing interface is the documented workflow in deployment/operator docs plus filesystem- and database-native tooling.
+The `rune backup` command family remains the intended future primary interface for snapshot and recovery workflows.
+When it ships, these commands must implement the behavioral expectations defined in §15.4.1–§15.4.4.
 
-#### Expected subcommands
+#### Planned subcommands
 
 | Subcommand | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary
- tighten the operator-facing backup and restore workflow docs around the currently shipped behavior
- align parity and protocol docs so recovery expectations are explicit and consistent
- refresh the checklist language so operators can verify backup/restore readiness without guessing

## Scope
- `docs/FUNCTIONALITY-CHECKLIST.md`
- `docs/operator/DEPLOYMENT.md`
- `docs/parity/PARITY-CONTRACTS.md`
- `docs/parity/PROTOCOLS.md`
