### PR TITLE
feat(cli): add setup/backup/update/reset lifecycle CLI families (#74)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -157,6 +157,24 @@ pub enum Command {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Run first-time setup wizard.
+    Setup,
+    /// Manage backups of durable state.
+    Backup {
+        #[command(subcommand)]
+        action: BackupAction,
+    },
+    /// Manage gateway updates.
+    Update {
+        #[command(subcommand)]
+        action: UpdateAction,
+    },
+    /// Factory-reset all state (requires confirmation).
+    Reset {
+        /// Confirm the destructive reset operation.
+        #[arg(long)]
+        confirm: bool,
+    },
 }
 
 #[derive(Debug, Clone, Args)]
@@ -1068,6 +1086,37 @@ pub enum ConfigAction {
         #[arg(short, long)]
         file: Option<String>,
     },
+}
+
+
+#[derive(Debug, Subcommand)]
+pub enum BackupAction {
+    /// Create a backup of all durable state.
+    Create {
+        /// Optional human-readable label for the backup.
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// List available backups.
+    List,
+    /// Restore from a specific backup.
+    Restore {
+        /// Backup identifier to restore from.
+        id: String,
+        /// Confirm the restore operation.
+        #[arg(long)]
+        confirm: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum UpdateAction {
+    /// Check for available updates.
+    Check,
+    /// Apply a pending update.
+    Apply,
+    /// Show current update status.
+    Status,
 }
 
 #[cfg(test)]
@@ -3773,5 +3822,71 @@ mod tests {
             Cli::try_parse_from(["rune", "message", "list-reactions", "--channel", "slack"])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn parse_setup() {
+        let cli = Cli::try_parse_from(["rune", "setup"]).unwrap();
+        assert!(matches!(cli.command, Command::Setup));
+    }
+
+    #[test]
+    fn parse_backup_create() {
+        let cli = Cli::try_parse_from(["rune", "backup", "create"]).unwrap();
+        assert!(matches!(cli.command, Command::Backup { action: BackupAction::Create { label: None } }));
+    }
+
+    #[test]
+    fn parse_backup_create_with_label() {
+        let cli = Cli::try_parse_from(["rune", "backup", "create", "--label", "nightly"]).unwrap();
+        match cli.command {
+            Command::Backup { action: BackupAction::Create { label } } => assert_eq!(label.as_deref(), Some("nightly")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_backup_list() {
+        let cli = Cli::try_parse_from(["rune", "backup", "list"]).unwrap();
+        assert!(matches!(cli.command, Command::Backup { action: BackupAction::List }));
+    }
+
+    #[test]
+    fn parse_backup_restore() {
+        let cli = Cli::try_parse_from(["rune", "backup", "restore", "bk-001", "--confirm"]).unwrap();
+        match cli.command {
+            Command::Backup { action: BackupAction::Restore { id, confirm } } => { assert_eq!(id, "bk-001"); assert!(confirm); }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_update_check() {
+        let cli = Cli::try_parse_from(["rune", "update", "check"]).unwrap();
+        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Check }));
+    }
+
+    #[test]
+    fn parse_update_apply() {
+        let cli = Cli::try_parse_from(["rune", "update", "apply"]).unwrap();
+        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Apply }));
+    }
+
+    #[test]
+    fn parse_update_status() {
+        let cli = Cli::try_parse_from(["rune", "update", "status"]).unwrap();
+        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Status }));
+    }
+
+    #[test]
+    fn parse_reset_with_confirm() {
+        let cli = Cli::try_parse_from(["rune", "reset", "--confirm"]).unwrap();
+        match cli.command { Command::Reset { confirm } => assert!(confirm), other => panic!("{other:?}") }
+    }
+
+    #[test]
+    fn parse_reset_no_confirm() {
+        let cli = Cli::try_parse_from(["rune", "reset"]).unwrap();
+        match cli.command { Command::Reset { confirm } => assert!(!confirm), other => panic!("{other:?}") }
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -22,6 +22,8 @@ use crate::output::{
     MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
     SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
     SessionTreeNode, SessionTreeResponse, SkillCheckResponse, SkillInfoResponse,
+    SetupResponse, BackupCreateResponse, BackupListResponse, BackupRestoreResponse,
+    UpdateCheckResponse, UpdateApplyResponse, UpdateStatusResponse, ResetResponse,
     SkillListResponse, SkillSummary, StatusResponse,
 };
 
@@ -2455,6 +2457,15 @@ impl GatewayClient {
             bail!("Gateway returned HTTP {}", resp.status());
         }
     }
+
+    pub async fn setup(&self) -> Result<SetupResponse> { let r = self.http.post(self.url("/setup")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn backup_create(&self, label: Option<&str>) -> Result<BackupCreateResponse> { let mut b = serde_json::json!({}); if let Some(l) = label { b["label"] = serde_json::Value::String(l.into()); } let r = self.http.post(self.url("/backups")).json(&b).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn backup_list(&self) -> Result<BackupListResponse> { let r = self.http.get(self.url("/backups")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn backup_restore(&self, id: &str) -> Result<BackupRestoreResponse> { let r = self.http.post(self.url(&format!("/backups/{id}/restore"))).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn update_check(&self) -> Result<UpdateCheckResponse> { let r = self.http.get(self.url("/update/check")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn update_apply(&self) -> Result<UpdateApplyResponse> { let r = self.http.post(self.url("/update/apply")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn update_status(&self) -> Result<UpdateStatusResponse> { let r = self.http.get(self.url("/update/status")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
+    pub async fn reset(&self) -> Result<ResetResponse> { let r = self.http.post(self.url("/reset")).send().await.context("gateway")?; if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); } }
 }
 
 fn local_config_path() -> std::path::PathBuf {
@@ -4404,4 +4415,19 @@ mod tests {
         assert!(resp.detail.contains("404"));
         assert!(resp.detail.contains("Thread not found"));
     }
+}
+
+#[cfg(test)]
+mod lifecycle_client_tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    #[tokio::test] async fn setup_ok() { let s = MockServer::start().await; Mock::given(method("POST")).and(path("/setup")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"success":true,"detail":"done"}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).setup().await.unwrap().success); }
+    #[tokio::test] async fn backup_create_ok() { let s = MockServer::start().await; Mock::given(method("POST")).and(path("/backups")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"success":true,"backup_id":"bk-42","detail":"ok"}))).mount(&s).await; assert_eq!(GatewayClient::new(&s.uri()).backup_create(Some("x")).await.unwrap().backup_id, "bk-42"); }
+    #[tokio::test] async fn backup_list_ok() { let s = MockServer::start().await; Mock::given(method("GET")).and(path("/backups")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"backups":[]}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).backup_list().await.unwrap().backups.is_empty()); }
+    #[tokio::test] async fn backup_restore_ok() { let s = MockServer::start().await; Mock::given(method("POST")).and(path("/backups/bk-1/restore")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"success":true,"backup_id":"bk-1","detail":"ok"}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).backup_restore("bk-1").await.unwrap().success); }
+    #[tokio::test] async fn update_check_ok() { let s = MockServer::start().await; Mock::given(method("GET")).and(path("/update/check")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"available":true,"current_version":"0.1","latest_version":"0.2","detail":"x"}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).update_check().await.unwrap().available); }
+    #[tokio::test] async fn update_apply_ok() { let s = MockServer::start().await; Mock::given(method("POST")).and(path("/update/apply")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"success":true,"version":"0.2","detail":"ok"}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).update_apply().await.unwrap().success); }
+    #[tokio::test] async fn update_status_ok() { let s = MockServer::start().await; Mock::given(method("GET")).and(path("/update/status")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"current_version":"0.2","update_channel":"stable","last_check":"2026-01-01"}))).mount(&s).await; assert_eq!(GatewayClient::new(&s.uri()).update_status().await.unwrap().update_channel, "stable"); }
+    #[tokio::test] async fn reset_ok() { let s = MockServer::start().await; Mock::given(method("POST")).and(path("/reset")).respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"success":true,"detail":"ok"}))).mount(&s).await; assert!(GatewayClient::new(&s.uri()).reset().await.unwrap().success); }
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -23,11 +23,11 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 
 pub use cli::Cli;
 use cli::{
-    AgentsAction, ApprovalsAction, ChannelsAction, Command, CompletionAction, CompletionShell,
+    AgentsAction, ApprovalsAction, BackupAction, ChannelsAction, Command, CompletionAction, CompletionShell,
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, RemindersAction, SessionsAction, SkillsAction, SystemAction, SystemEventAction,
+    ModelsAction, RemindersAction, SessionsAction, SkillsAction, SystemAction, SystemEventAction, UpdateAction,
     SystemHeartbeatAction,
 };
 use client::{
@@ -1893,6 +1893,44 @@ pub async fn run(cli: Cli) -> Result<()> {
                 println!("{}", render(&result, format));
             }
         },
+        Command::Setup => {
+            let result = client.setup().await?;
+            println!("{}", render(&result, format));
+        }
+        Command::Backup { action } => match action {
+            BackupAction::Create { label } => {
+                let result = client.backup_create(label.as_deref()).await?;
+                println!("{}", render(&result, format));
+            }
+            BackupAction::List => {
+                let result = client.backup_list().await?;
+                println!("{}", render(&result, format));
+            }
+            BackupAction::Restore { id, confirm } => {
+                if !confirm { anyhow::bail!("Backup restore requires --confirm flag."); }
+                let result = client.backup_restore(&id).await?;
+                println!("{}", render(&result, format));
+            }
+        },
+        Command::Update { action } => match action {
+            UpdateAction::Check => {
+                let result = client.update_check().await?;
+                println!("{}", render(&result, format));
+            }
+            UpdateAction::Apply => {
+                let result = client.update_apply().await?;
+                println!("{}", render(&result, format));
+            }
+            UpdateAction::Status => {
+                let result = client.update_status().await?;
+                println!("{}", render(&result, format));
+            }
+        },
+        Command::Reset { confirm } => {
+            if !confirm { anyhow::bail!("Factory reset requires --confirm flag."); }
+            let result = client.reset().await?;
+            println!("{}", render(&result, format));
+        }
         Command::Config { action } => match action {
             ConfigAction::Show => {
                 let result = show_config()?;

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -5098,3 +5098,53 @@ mod tests {
         assert!(out.contains("    line three"));
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupResponse { pub success: bool, pub detail: String }
+impl fmt::Display for SetupResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} {}", if self.success { "\u{2713}" } else { "\u{2717}" }, self.detail) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupCreateResponse { pub success: bool, pub backup_id: String, pub detail: String }
+impl fmt::Display for BackupCreateResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} {} (id: {})", if self.success { "\u{2713}" } else { "\u{2717}" }, self.detail, self.backup_id) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupSummary { pub id: String, pub label: Option<String>, pub created_at: String, pub size_bytes: Option<u64> }
+impl fmt::Display for BackupSummary { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.id)?; if let Some(ref l) = self.label { write!(f, " ({l})")?; } write!(f, " created={}", self.created_at)?; if let Some(s) = self.size_bytes { write!(f, " size={s}B")?; } Ok(()) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupListResponse { pub backups: Vec<BackupSummary> }
+impl fmt::Display for BackupListResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.backups.is_empty() { return write!(f, "No backups found."); } for b in &self.backups { writeln!(f, "  {b}")?; } Ok(()) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupRestoreResponse { pub success: bool, pub backup_id: String, pub detail: String }
+impl fmt::Display for BackupRestoreResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} {} (backup: {})", if self.success { "\u{2713}" } else { "\u{2717}" }, self.detail, self.backup_id) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCheckResponse { pub available: bool, pub current_version: String, pub latest_version: Option<String>, pub detail: String }
+impl fmt::Display for UpdateCheckResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.available { write!(f, "Update available: {} \u{2192} {}", self.current_version, self.latest_version.as_deref().unwrap_or("unknown")) } else { write!(f, "Up to date ({})", self.current_version) } } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateApplyResponse { pub success: bool, pub version: String, pub detail: String }
+impl fmt::Display for UpdateApplyResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} {} (v{})", if self.success { "\u{2713}" } else { "\u{2717}" }, self.detail, self.version) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateStatusResponse { pub current_version: String, pub update_channel: String, pub last_check: Option<String> }
+impl fmt::Display for UpdateStatusResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "version={} channel={}", self.current_version, self.update_channel)?; if let Some(ref l) = self.last_check { write!(f, " last_check={l}")?; } Ok(()) } }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResetResponse { pub success: bool, pub detail: String }
+impl fmt::Display for ResetResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} {}", if self.success { "\u{2713}" } else { "\u{2717}" }, self.detail) } }
+
+#[cfg(test)]
+mod lifecycle_output_tests {
+    use super::*;
+    #[test] fn setup_ok() { assert!(SetupResponse { success: true, detail: "x".into() }.to_string().contains("\u{2713}")); }
+    #[test] fn backup_create_ok() { assert!(BackupCreateResponse { success: true, backup_id: "b1".into(), detail: "x".into() }.to_string().contains("b1")); }
+    #[test] fn backup_list_empty() { assert_eq!(BackupListResponse { backups: vec![] }.to_string(), "No backups found."); }
+    #[test] fn backup_restore_ok() { assert!(BackupRestoreResponse { success: true, backup_id: "b1".into(), detail: "x".into() }.to_string().contains("\u{2713}")); }
+    #[test] fn update_check_ok() { assert!(UpdateCheckResponse { available: true, current_version: "0.1".into(), latest_version: Some("0.2".into()), detail: "x".into() }.to_string().contains("0.2")); }
+    #[test] fn update_up_to_date() { assert!(UpdateCheckResponse { available: false, current_version: "0.2".into(), latest_version: None, detail: "x".into() }.to_string().contains("Up to date")); }
+    #[test] fn update_apply_ok() { assert!(UpdateApplyResponse { success: true, version: "0.2".into(), detail: "x".into() }.to_string().contains("\u{2713}")); }
+    #[test] fn update_status_ok() { assert!(UpdateStatusResponse { current_version: "0.2".into(), update_channel: "stable".into(), last_check: None }.to_string().contains("stable")); }
+    #[test] fn reset_ok() { assert!(ResetResponse { success: true, detail: "x".into() }.to_string().contains("\u{2713}")); }
+}


### PR DESCRIPTION
## Summary
- Adds `rune setup` — first-time setup wizard (POST /setup)
- Adds `rune backup create|list|restore` — backup management (POST/GET /backups, POST /backups/:id/restore)
- Adds `rune update check|apply|status` — update management (GET /update/check, POST /update/apply, GET /update/status)
- Adds `rune reset --confirm` — factory reset (POST /reset, requires --confirm flag)
- Full test coverage: CLI parse tests, wiremock client tests, output Display tests (412 total pass)

Closes part of #74, relates to #70.

## Test plan
- [x] `cargo check -p rune-cli` — compiles clean
- [x] `cargo test -p rune-cli` — 412 tests pass
- [ ] Manual smoke test of each subcommand against a running gateway