### PR TITLE
feat(tools): add web_fetch and git tools

### DIFF
--- a/crates/rune-tools/src/git_tool.rs
+++ b/crates/rune-tools/src/git_tool.rs
@@ -1,0 +1,346 @@
+//! Git tool for agents to perform version control operations via subprocess.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use tracing::instrument;
+
+use crate::definition::{ToolCall, ToolDefinition, ToolResult};
+use crate::error::ToolError;
+use crate::executor::ToolExecutor;
+
+/// Allowed git subcommands. Anything outside this list is rejected.
+const ALLOWED_OPERATIONS: &[&str] = &[
+    "status", "diff", "add", "commit", "push", "pull", "log", "branch", "checkout", "merge",
+];
+
+/// Maximum output bytes returned from a git command (50 KB).
+const MAX_OUTPUT_BYTES: usize = 50 * 1024;
+
+/// Default timeout for git operations (60 seconds).
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+/// Executor for the `git` tool.
+///
+/// Wraps the git CLI, running subcommands as child processes within a
+/// workspace boundary. Only an allow-listed set of operations are permitted.
+pub struct GitToolExecutor {
+    workspace_root: PathBuf,
+}
+
+impl GitToolExecutor {
+    /// Create a new git tool executor rooted at the given workspace directory.
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+        }
+    }
+
+    #[instrument(skip(self, call), fields(tool = "git"))]
+    async fn handle(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let operation = call
+            .arguments
+            .get("operation")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidArguments {
+                tool: "git".into(),
+                reason: "missing required field: operation".into(),
+            })?;
+
+        // Validate against allow-list
+        if !ALLOWED_OPERATIONS.contains(&operation) {
+            return Ok(ToolResult {
+                tool_call_id: call.tool_call_id,
+                output: format!(
+                    "Unsupported git operation: {operation}. Allowed: {}",
+                    ALLOWED_OPERATIONS.join(", ")
+                ),
+                is_error: true,
+                tool_execution_id: None,
+            });
+        }
+
+        // Collect additional arguments
+        let args: Vec<String> = call
+            .arguments
+            .get("args")
+            .and_then(|v| {
+                // Accept either a JSON array of strings or a single string
+                if let Some(arr) = v.as_array() {
+                    Some(
+                        arr.iter()
+                            .filter_map(|item| item.as_str().map(String::from))
+                            .collect(),
+                    )
+                } else if let Some(s) = v.as_str() {
+                    // Split a single string on whitespace for convenience
+                    Some(s.split_whitespace().map(String::from).collect())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+
+        // Validate workspace root exists
+        let workspace_root = self
+            .workspace_root
+            .canonicalize()
+            .map_err(|e| ToolError::ExecutionFailed(format!("workspace root invalid: {e}")))?;
+
+        // Build the command: git <operation> [args...]
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.arg(operation);
+        cmd.args(&args);
+        cmd.current_dir(&workspace_root);
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        // Spawn and wait with timeout
+        let child = cmd
+            .spawn()
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to spawn git: {e}")))?;
+
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| {
+            ToolError::ExecutionFailed(format!(
+                "git {operation} timed out after {DEFAULT_TIMEOUT_SECS}s"
+            ))
+        })?
+        .map_err(|e| ToolError::ExecutionFailed(format!("git process error: {e}")))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        // Format output
+        let mut result_text = String::new();
+
+        if !stdout.is_empty() {
+            result_text.push_str(&stdout);
+        }
+
+        if !stderr.is_empty() {
+            if !result_text.is_empty() {
+                result_text.push('\n');
+            }
+            result_text.push_str(&stderr);
+        }
+
+        if result_text.is_empty() {
+            result_text = format!("git {operation} completed (exit code {exit_code})");
+        }
+
+        // Truncate if too large
+        if result_text.len() > MAX_OUTPUT_BYTES {
+            let truncated = truncate_utf8(&result_text, MAX_OUTPUT_BYTES);
+            result_text = format!(
+                "{truncated}\n\n[truncated: showing {MAX_OUTPUT_BYTES} of {} bytes]",
+                result_text.len()
+            );
+        }
+
+        let is_error = !output.status.success();
+        if is_error {
+            result_text = format!("git {operation} failed (exit code {exit_code}):\n{result_text}");
+        }
+
+        Ok(ToolResult {
+            tool_call_id: call.tool_call_id,
+            output: result_text,
+            is_error,
+            tool_execution_id: None,
+        })
+    }
+}
+
+/// Truncate a string to at most `max_bytes` without splitting a UTF-8 codepoint.
+fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[async_trait]
+impl ToolExecutor for GitToolExecutor {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
+        match call.tool_name.as_str() {
+            "git" => self.handle(&call).await,
+            other => Err(ToolError::NotFound(other.into())),
+        }
+    }
+}
+
+/// Return the `ToolDefinition` for registration in the tool registry.
+pub fn git_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "git".into(),
+        description: "Execute git operations in the workspace. Supports: status, diff, add, commit, push, pull, log, branch, checkout, merge.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "description": "Git subcommand to execute",
+                    "enum": ["status", "diff", "add", "commit", "push", "pull", "log", "branch", "checkout", "merge"]
+                },
+                "args": {
+                    "description": "Additional arguments for the git command. Can be a JSON array of strings or a single string (split on whitespace).",
+                    "oneOf": [
+                        { "type": "array", "items": { "type": "string" } },
+                        { "type": "string" }
+                    ]
+                }
+            },
+            "required": ["operation"]
+        }),
+        category: rune_core::ToolCategory::ProcessExec,
+        requires_approval: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rune_core::ToolCallId;
+
+    fn make_call(args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            tool_call_id: ToolCallId::new(),
+            tool_name: "git".into(),
+            arguments: args,
+        }
+    }
+
+    #[test]
+    fn definition_schema_has_required_operation() {
+        let def = git_tool_definition();
+        assert_eq!(def.name, "git");
+        let required = def.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("operation")));
+    }
+
+    #[tokio::test]
+    async fn missing_operation_returns_error() {
+        let exec = GitToolExecutor::new("/tmp");
+        let call = make_call(serde_json::json!({}));
+        let err = exec.execute(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidArguments { .. }));
+    }
+
+    #[tokio::test]
+    async fn unsupported_operation_returns_error_result() {
+        let exec = GitToolExecutor::new("/tmp");
+        let call = make_call(serde_json::json!({"operation": "rebase"}));
+        let result = exec.execute(call).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output.contains("Unsupported git operation"));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_name_rejected() {
+        let exec = GitToolExecutor::new("/tmp");
+        let call = ToolCall {
+            tool_call_id: ToolCallId::new(),
+            tool_name: "not_git".into(),
+            arguments: serde_json::json!({}),
+        };
+        let err = exec.execute(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn git_status_in_temp_dir() {
+        // Create a temp directory with a git repo
+        let dir = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output();
+
+        // Skip test if git is not available
+        let Ok(init_output) = status else { return };
+        if !init_output.status.success() {
+            return;
+        }
+
+        let exec = GitToolExecutor::new(dir.path());
+        let call = make_call(serde_json::json!({"operation": "status"}));
+        let result = exec.execute(call).await.unwrap();
+        assert!(!result.is_error, "git status should succeed: {}", result.output);
+    }
+
+    #[tokio::test]
+    async fn git_log_in_temp_dir() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Init repo + create initial commit
+        let init = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output();
+        let Ok(init_out) = init else { return };
+        if !init_out.status.success() {
+            return;
+        }
+
+        // Configure git user for the test repo
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output();
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output();
+
+        // Create a file and commit
+        std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
+        let _ = std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output();
+        let _ = std::process::Command::new("git")
+            .args(["commit", "-m", "initial commit"])
+            .current_dir(dir.path())
+            .output();
+
+        let exec = GitToolExecutor::new(dir.path());
+
+        // Test log with args as array
+        let call = make_call(serde_json::json!({"operation": "log", "args": ["--oneline", "-1"]}));
+        let result = exec.execute(call).await.unwrap();
+        assert!(!result.is_error, "git log should succeed: {}", result.output);
+        assert!(result.output.contains("initial commit"));
+    }
+
+    #[tokio::test]
+    async fn args_as_string_splits_on_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let init = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output();
+        let Ok(init_out) = init else { return };
+        if !init_out.status.success() {
+            return;
+        }
+
+        let exec = GitToolExecutor::new(dir.path());
+        let call = make_call(serde_json::json!({"operation": "branch", "args": "-a"}));
+        let result = exec.execute(call).await.unwrap();
+        // In a fresh repo with no commits, branch -a may return empty or error
+        // We just check it doesn't fail with our own error
+        assert!(!result.output.contains("Unsupported git operation"));
+    }
+}

--- a/crates/rune-tools/src/lib.rs
+++ b/crates/rune-tools/src/lib.rs
@@ -8,6 +8,7 @@ pub mod exec_tool;
 mod executor;
 pub mod file_tools;
 pub mod gateway_tool;
+pub mod git_tool;
 pub mod memory_index;
 pub mod memory_tool;
 pub mod message_tool;
@@ -18,6 +19,7 @@ pub mod session_tool;
 pub mod spawn_tool;
 mod stubs;
 pub mod subagent_tool;
+pub mod web_fetch_tool;
 
 pub use definition::{ToolCall, ToolDefinition, ToolResult};
 pub use error::ToolError;

--- a/crates/rune-tools/src/stubs.rs
+++ b/crates/rune-tools/src/stubs.rs
@@ -146,6 +146,10 @@ pub fn register_builtin_stubs(registry: &mut ToolRegistry) {
     for tool in builtins {
         registry.register(tool);
     }
+
+    // Register real tool definitions (executors are wired separately)
+    registry.register(crate::web_fetch_tool::web_fetch_tool_definition());
+    registry.register(crate::git_tool::git_tool_definition());
 }
 
 /// Validate that a tool call's arguments satisfy the `required` fields in the tool schema.

--- a/crates/rune-tools/src/tests.rs
+++ b/crates/rune-tools/src/tests.rs
@@ -94,7 +94,7 @@ fn register_builtin_stubs_populates_expected_tools() {
     let mut reg = ToolRegistry::new();
     register_builtin_stubs(&mut reg);
 
-    assert_eq!(reg.len(), 8);
+    assert_eq!(reg.len(), 10);
 
     let expected = [
         "read_file",
@@ -105,6 +105,8 @@ fn register_builtin_stubs_populates_expected_tools() {
         "execute_command",
         "list_sessions",
         "get_session_status",
+        "web_fetch",
+        "git",
     ];
     for name in expected {
         assert!(reg.lookup(name).is_ok(), "missing builtin: {name}");

--- a/crates/rune-tools/src/web_fetch_tool.rs
+++ b/crates/rune-tools/src/web_fetch_tool.rs
@@ -1,0 +1,313 @@
+//! HTTP fetch tool for agents to retrieve web content, APIs, and issue trackers.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tracing::instrument;
+
+use crate::definition::{ToolCall, ToolDefinition, ToolResult};
+use crate::error::ToolError;
+use crate::executor::ToolExecutor;
+
+/// Maximum response body size returned to the LLM context (50 KB).
+const MAX_BODY_BYTES: usize = 50 * 1024;
+
+/// Default request timeout.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Executor for the `web_fetch` tool.
+///
+/// Makes HTTP GET/POST requests and returns the response body, truncated
+/// to fit within LLM context limits.
+pub struct WebFetchToolExecutor {
+    client: reqwest::Client,
+}
+
+impl WebFetchToolExecutor {
+    /// Create a new web-fetch executor with default settings.
+    pub fn new() -> Result<Self, ToolError> {
+        let client = reqwest::Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .user_agent("rune-agent/0.1")
+            .build()
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to build HTTP client: {e}")))?;
+        Ok(Self { client })
+    }
+
+    /// Create from an existing reqwest client (useful for testing).
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+
+    #[instrument(skip(self, call), fields(tool = "web_fetch"))]
+    async fn handle(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let url = call
+            .arguments
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidArguments {
+                tool: "web_fetch".into(),
+                reason: "missing required field: url".into(),
+            })?;
+
+        let method = call
+            .arguments
+            .get("method")
+            .and_then(|v| v.as_str())
+            .unwrap_or("GET")
+            .to_uppercase();
+
+        // Parse optional headers
+        let headers: HashMap<String, String> = call
+            .arguments
+            .get("headers")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        let body = call
+            .arguments
+            .get("body")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Build the request
+        let mut request = match method.as_str() {
+            "GET" => self.client.get(url),
+            "POST" => self.client.post(url),
+            other => {
+                return Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output: format!("Unsupported HTTP method: {other}. Use GET or POST."),
+                    is_error: true,
+                    tool_execution_id: None,
+                });
+            }
+        };
+
+        // Apply headers
+        for (key, value) in &headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+
+        // Apply body (POST)
+        if let Some(body_content) = body {
+            request = request.body(body_content);
+        }
+
+        // Execute the request
+        let response = match request.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                let msg = if e.is_timeout() {
+                    format!("Request timed out after {}s", DEFAULT_TIMEOUT.as_secs())
+                } else if e.is_connect() {
+                    format!("Connection failed: {e}")
+                } else {
+                    format!("HTTP request failed: {e}")
+                };
+                return Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output: msg,
+                    is_error: true,
+                    tool_execution_id: None,
+                });
+            }
+        };
+
+        let status = response.status();
+        let status_code = status.as_u16();
+
+        // Collect selected response headers
+        let response_headers: Vec<String> = response
+            .headers()
+            .iter()
+            .filter(|(name, _)| {
+                let n = name.as_str();
+                matches!(
+                    n,
+                    "content-type"
+                        | "content-length"
+                        | "location"
+                        | "x-ratelimit-remaining"
+                        | "retry-after"
+                )
+            })
+            .map(|(name, value)| {
+                format!("{}: {}", name, value.to_str().unwrap_or("<binary>"))
+            })
+            .collect();
+
+        // Read body text
+        let full_body = match response.text().await {
+            Ok(text) => text,
+            Err(e) => {
+                return Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output: format!("HTTP {status_code} — failed to read response body: {e}"),
+                    is_error: true,
+                    tool_execution_id: None,
+                });
+            }
+        };
+
+        // Truncate for LLM context
+        let (body_text, truncated) = if full_body.len() > MAX_BODY_BYTES {
+            let truncated_body = truncate_utf8(&full_body, MAX_BODY_BYTES);
+            (truncated_body.to_string(), true)
+        } else {
+            (full_body.clone(), false)
+        };
+
+        // Format output
+        let mut output = format!("HTTP {status_code} {}\n", status.canonical_reason().unwrap_or(""));
+        if !response_headers.is_empty() {
+            for h in &response_headers {
+                output.push_str(h);
+                output.push('\n');
+            }
+        }
+        output.push('\n');
+        output.push_str(&body_text);
+        if truncated {
+            output.push_str(&format!(
+                "\n\n[truncated: showing {MAX_BODY_BYTES} of {} bytes]",
+                full_body.len()
+            ));
+        }
+
+        Ok(ToolResult {
+            tool_call_id: call.tool_call_id,
+            output,
+            is_error: false,
+            tool_execution_id: None,
+        })
+    }
+}
+
+/// Truncate a string to at most `max_bytes` without splitting a UTF-8 codepoint.
+fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[async_trait]
+impl ToolExecutor for WebFetchToolExecutor {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
+        match call.tool_name.as_str() {
+            "web_fetch" => self.handle(&call).await,
+            other => Err(ToolError::NotFound(other.into())),
+        }
+    }
+}
+
+/// Return the `ToolDefinition` for registration in the tool registry.
+pub fn web_fetch_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "web_fetch".into(),
+        description: "Fetch content from a URL via HTTP GET or POST. Returns status code, selected headers, and response body (truncated to 50KB for LLM context).".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to fetch"
+                },
+                "method": {
+                    "type": "string",
+                    "description": "HTTP method: GET or POST (default: GET)",
+                    "enum": ["GET", "POST"]
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Optional HTTP headers as key-value pairs",
+                    "additionalProperties": { "type": "string" }
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Optional request body (for POST requests)"
+                }
+            },
+            "required": ["url"]
+        }),
+        category: rune_core::ToolCategory::External,
+        requires_approval: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rune_core::ToolCallId;
+
+    fn make_call(args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            tool_call_id: ToolCallId::new(),
+            tool_name: "web_fetch".into(),
+            arguments: args,
+        }
+    }
+
+    #[test]
+    fn truncate_utf8_ascii() {
+        assert_eq!(truncate_utf8("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_utf8_multibyte() {
+        // '€' is 3 bytes (E2 82 AC)
+        let s = "a€b";
+        // at max_bytes=2, we can't fit '€' so we get just "a"
+        assert_eq!(truncate_utf8(s, 2), "a");
+        // at max_bytes=4, we get "a€"
+        assert_eq!(truncate_utf8(s, 4), "a€");
+    }
+
+    #[test]
+    fn truncate_utf8_no_truncation() {
+        assert_eq!(truncate_utf8("short", 100), "short");
+    }
+
+    #[test]
+    fn definition_schema_has_required_url() {
+        let def = web_fetch_tool_definition();
+        assert_eq!(def.name, "web_fetch");
+        let required = def.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("url")));
+    }
+
+    #[tokio::test]
+    async fn missing_url_returns_error() {
+        let exec = WebFetchToolExecutor::new().unwrap();
+        let call = make_call(serde_json::json!({}));
+        let err = exec.execute(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidArguments { .. }));
+    }
+
+    #[tokio::test]
+    async fn unsupported_method_returns_error_result() {
+        let exec = WebFetchToolExecutor::new().unwrap();
+        let call = make_call(serde_json::json!({"url": "http://example.com", "method": "DELETE"}));
+        let result = exec.execute(call).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output.contains("Unsupported HTTP method"));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_name_rejected() {
+        let exec = WebFetchToolExecutor::new().unwrap();
+        let call = ToolCall {
+            tool_call_id: ToolCallId::new(),
+            tool_name: "not_web_fetch".into(),
+            arguments: serde_json::json!({}),
+        };
+        let err = exec.execute(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::NotFound(_)));
+    }
+}


### PR DESCRIPTION
## Summary
- **web_fetch tool**: HTTP GET/POST with custom headers, body support, 30s timeout, 50KB response truncation for LLM context limits. Uses reqwest. Registered as `External` category with approval required.
- **git tool**: Subprocess wrapper for git CLI with allow-listed operations (status, diff, add, commit, push, pull, log, branch, checkout, merge). Workspace boundary enforcement, 60s timeout. Registered as `ProcessExec` with approval required.
- Both tools follow existing `ToolExecutor` trait pattern and are registered in the builtin tool registry.

## Test plan
- [x] All 133 existing + new tests pass (`cargo test -p rune-tools`)
- [x] `cargo check -p rune-tools` compiles clean
- [x] web_fetch: unit tests for missing URL, unsupported method, UTF-8 truncation, schema validation
- [x] git: unit tests for missing operation, unsupported operation, git status/log in temp repos, string arg splitting