### PR TITLE
feat(ui): add service-worker offline shell for PWA support

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -1,0 +1,96 @@
+/// <reference lib="webworker" />
+
+const CACHE_NAME = "rune-shell-v1";
+
+/**
+ * Static shell assets cached on install for offline loading.
+ * The root document and key static assets are precached;
+ * additional build-hashed assets are cached on first fetch.
+ */
+const PRECACHE_URLS = [
+  "/",
+  "/manifest.json",
+  "/favicon.svg",
+  "/icons.svg",
+  "/pwa-icon-192.png",
+];
+
+/* ---------- install: precache shell assets ---------- */
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+/* ---------- activate: purge old caches ---------- */
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+/* ---------- fetch: cache-first for shell, network-first for API ---------- */
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests
+  if (request.method !== "GET") return;
+
+  // Skip API/WebSocket routes — always go to network
+  if (
+    url.pathname.startsWith("/api") ||
+    url.pathname.startsWith("/ws") ||
+    url.pathname.startsWith("/health") ||
+    url.pathname.startsWith("/status")
+  ) {
+    return;
+  }
+
+  // For navigation requests (HTML pages), try network first, fall back to
+  // cached shell so the SPA can boot offline.
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match("/") || caches.match(request)),
+    );
+    return;
+  }
+
+  // Static assets (JS/CSS/images): cache-first, falling back to network.
+  // Vite-hashed assets are immutable so cache-first is safe.
+  event.respondWith(
+    caches.match(request).then(
+      (cached) =>
+        cached ||
+        fetch(request).then((response) => {
+          // Only cache successful same-origin responses
+          if (response.ok && url.origin === self.location.origin) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        }),
+    ),
+  );
+});

--- a/ui/src/lib/register-sw.ts
+++ b/ui/src/lib/register-sw.ts
@@ -1,0 +1,13 @@
+/**
+ * Register the service worker for offline PWA shell support.
+ * Called once at app boot from main.tsx.
+ */
+export function registerServiceWorker(): void {
+  if (!("serviceWorker" in navigator)) return;
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.warn("[rune] service-worker registration failed:", err);
+    });
+  });
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from "react-dom/client";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { QueryProvider, queryClient } from "@/integrations/tanstack-query/root-provider";
 import { routeTree } from "./routeTree.gen";
+import { registerServiceWorker } from "@/lib/register-sw";
 import "./styles.css";
+
+registerServiceWorker();
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
## Summary
- Adds a vanilla service worker (`ui/public/sw.js`) that precaches the static shell (index, manifest, icons) on install
- Navigation requests use network-first with cache fallback so the SPA boots offline; Vite-hashed assets use cache-first
- API/WebSocket routes are excluded from SW caching
- Service worker registration wired via `ui/src/lib/register-sw.ts`, called from `main.tsx`

Builds on the PWA metadata shipped in PR #207.

## Test plan
- [x] `tsc -b` passes (no type errors)
- [x] `vite build` succeeds, `sw.js` present in `dist/`
- [ ] Manual: load operator UI, confirm SW registers in DevTools > Application
- [ ] Manual: go offline in DevTools, reload — shell loads from cache

Closes #60