### PR TITLE
feat(cli): MS365 mail/calendar read-detail surface (issue #206)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -263,6 +263,12 @@ pub enum Ms365MailAction {
         #[arg(long, default_value = "Inbox")]
         folder: String,
     },
+    /// Read a single mail message by ID.
+    Read {
+        /// Message ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
 }
 
 /// Calendar subcommands.
@@ -276,6 +282,12 @@ pub enum Ms365CalendarAction {
         /// Look-ahead window in hours.
         #[arg(long, default_value_t = 24)]
         hours: u32,
+    },
+    /// Read a single calendar event by ID.
+    Read {
+        /// Event ID to retrieve.
+        #[arg(long)]
+        id: String,
     },
 }
 
@@ -4650,6 +4662,28 @@ mod subagent_cli_tests {
         let cli = Cli::try_parse_from(["rune", "reset"]).unwrap();
         match cli.command {
             Command::Reset { confirm } => assert!(!confirm),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_mail_read() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "mail", "read", "--id", "abc123"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Mail { action: Ms365MailAction::Read { id } } } => {
+                assert_eq!(id, "abc123");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_calendar_read() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "calendar", "read", "--id", "evt456"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Calendar { action: Ms365CalendarAction::Read { id } } } => {
+                assert_eq!(id, "evt456");
+            }
             other => panic!("unexpected: {other:?}"),
         }
     }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2940,6 +2940,16 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_mail_read(&self, id: &str) -> Result<crate::output::Ms365MailReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_calendar_read(&self, id: &str) -> Result<crate::output::Ms365CalendarReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/calendar/events/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1173,10 +1173,18 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_mail_unread(limit, &folder).await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365MailAction::Read { id } => {
+                    let result = client.ms365_mail_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Calendar { action } => match action {
                 Ms365CalendarAction::Upcoming { limit, hours } => {
                     let result = client.ms365_calendar_upcoming(limit, hours).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365CalendarAction::Read { id } => {
+                    let result = client.ms365_calendar_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3433,6 +3433,78 @@ impl fmt::Display for Ms365CalendarUpcomingResponse {
     }
 }
 
+/// Full detail of a single mail message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailReadResponse {
+    pub id: String,
+    pub subject: String,
+    pub from: String,
+    pub to: Vec<String>,
+    pub cc: Vec<String>,
+    pub received_at: String,
+    pub body_preview: String,
+    pub has_attachments: bool,
+    pub importance: String,
+    pub is_read: bool,
+}
+
+impl fmt::Display for Ms365MailReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Subject:     {}", self.subject)?;
+        writeln!(f, "From:        {}", self.from)?;
+        writeln!(f, "To:          {}", self.to.join(", "))?;
+        if !self.cc.is_empty() {
+            writeln!(f, "Cc:          {}", self.cc.join(", "))?;
+        }
+        writeln!(f, "Received:    {}", self.received_at)?;
+        writeln!(f, "Importance:  {}", self.importance)?;
+        writeln!(f, "Read:        {}", if self.is_read { "yes" } else { "no" })?;
+        writeln!(f, "Attachments: {}", if self.has_attachments { "yes" } else { "no" })?;
+        writeln!(f)?;
+        writeln!(f, "{}", self.body_preview)?;
+        Ok(())
+    }
+}
+
+/// Full detail of a single calendar event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365CalendarReadResponse {
+    pub id: String,
+    pub subject: String,
+    pub organizer: String,
+    pub attendees: Vec<String>,
+    pub start: String,
+    pub end: String,
+    pub location: Option<String>,
+    pub body_preview: String,
+    pub is_all_day: bool,
+    pub status: String,
+}
+
+impl fmt::Display for Ms365CalendarReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Subject:    {}", self.subject)?;
+        writeln!(f, "Organizer:  {}", self.organizer)?;
+        if !self.attendees.is_empty() {
+            writeln!(f, "Attendees:  {}", self.attendees.join(", "))?;
+        }
+        if self.is_all_day {
+            writeln!(f, "When:       {} (all day)", self.start)?;
+        } else {
+            writeln!(f, "Start:      {}", self.start)?;
+            writeln!(f, "End:        {}", self.end)?;
+        }
+        let loc = self.location.as_deref().unwrap_or("-");
+        writeln!(f, "Location:   {}", loc)?;
+        writeln!(f, "Status:     {}", self.status)?;
+        if !self.body_preview.is_empty() {
+            writeln!(f)?;
+            writeln!(f, "{}", self.body_preview)?;
+        }
+        Ok(())
+    }
+}
+
 // ── Sandbox ───────────────────────────────────────────────────────
 
 /// Response from `rune sandbox list`.
@@ -5959,6 +6031,115 @@ mod tests {
         let out = render(&resp, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("wizard completed"));
+    }
+
+    #[test]
+    fn render_ms365_mail_read_human() {
+        let r = Ms365MailReadResponse {
+            id: "msg-1".into(),
+            subject: "Quarterly review".into(),
+            from: "alice@example.com".into(),
+            to: vec!["bob@example.com".into(), "carol@example.com".into()],
+            cc: vec!["dave@example.com".into()],
+            received_at: "2026-03-21T10:00:00Z".into(),
+            body_preview: "Please find attached the Q1 numbers.".into(),
+            has_attachments: true,
+            importance: "high".into(),
+            is_read: false,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Subject:     Quarterly review"));
+        assert!(out.contains("From:        alice@example.com"));
+        assert!(out.contains("bob@example.com, carol@example.com"));
+        assert!(out.contains("Cc:          dave@example.com"));
+        assert!(out.contains("Importance:  high"));
+        assert!(out.contains("Read:        no"));
+        assert!(out.contains("Attachments: yes"));
+        assert!(out.contains("Q1 numbers"));
+    }
+
+    #[test]
+    fn render_ms365_mail_read_json() {
+        let r = Ms365MailReadResponse {
+            id: "msg-1".into(),
+            subject: "Test".into(),
+            from: "a@b.com".into(),
+            to: vec!["c@d.com".into()],
+            cc: vec![],
+            received_at: "2026-03-21T10:00:00Z".into(),
+            body_preview: "hello".into(),
+            has_attachments: false,
+            importance: "normal".into(),
+            is_read: true,
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["id"], "msg-1");
+        assert_eq!(v["is_read"], true);
+    }
+
+    #[test]
+    fn render_ms365_calendar_read_human() {
+        let r = Ms365CalendarReadResponse {
+            id: "evt-1".into(),
+            subject: "Sprint planning".into(),
+            organizer: "alice@example.com".into(),
+            attendees: vec!["bob@example.com".into()],
+            start: "2026-03-21T14:00:00Z".into(),
+            end: "2026-03-21T15:00:00Z".into(),
+            location: Some("Room 42".into()),
+            body_preview: "Discuss sprint goals.".into(),
+            is_all_day: false,
+            status: "confirmed".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Subject:    Sprint planning"));
+        assert!(out.contains("Organizer:  alice@example.com"));
+        assert!(out.contains("bob@example.com"));
+        assert!(out.contains("Start:"));
+        assert!(out.contains("End:"));
+        assert!(out.contains("Room 42"));
+        assert!(out.contains("Status:     confirmed"));
+        assert!(out.contains("sprint goals"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_read_all_day() {
+        let r = Ms365CalendarReadResponse {
+            id: "evt-2".into(),
+            subject: "Company holiday".into(),
+            organizer: "hr@example.com".into(),
+            attendees: vec![],
+            start: "2026-03-25".into(),
+            end: "2026-03-25".into(),
+            location: None,
+            body_preview: String::new(),
+            is_all_day: true,
+            status: "confirmed".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("(all day)"));
+        assert!(!out.contains("End:"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_read_json() {
+        let r = Ms365CalendarReadResponse {
+            id: "evt-1".into(),
+            subject: "Test".into(),
+            organizer: "a@b.com".into(),
+            attendees: vec![],
+            start: "2026-03-21T14:00:00Z".into(),
+            end: "2026-03-21T15:00:00Z".into(),
+            location: None,
+            body_preview: String::new(),
+            is_all_day: false,
+            status: "tentative".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["id"], "evt-1");
+        assert_eq!(v["status"], "tentative");
     }
 }
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,22 +676,26 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First parity slice: read-only mail and calendar surfaces.
+First and second parity slices: read-only mail and calendar surfaces, including list and read-detail.
 
 Observed subcommands:
 
 - `ms365 mail unread` — list unread messages from the authenticated mailbox
+- `ms365 mail read --id <msg_id>` — read full detail of a single mail message
 - `ms365 calendar upcoming` — list upcoming calendar events
+- `ms365 calendar read --id <event_id>` — read full detail of a single calendar event
 
 Required concepts:
 - mailbox folder selection (`--folder`)
 - result limiting (`--limit`)
 - calendar look-ahead window (`--hours`)
+- single-item read-detail by ID (`--id`)
+- operator-friendly rich output (headers, attendees, body preview)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–2). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `ms365 mail read --id <msg_id>` and `ms365 calendar read --id <event_id>` commands
- Rich operator-friendly output: headers, attendees, body preview, importance, read/attachment flags, all-day handling
- Client plumbing for `/ms365/mail/messages/{id}` and `/ms365/calendar/events/{id}` gateway endpoints
- Parity inventory updated with second slice status

## Test plan
- [x] 7 new ms365 tests pass (2 CLI parse + 5 output render)
- [x] All 485 rune-cli tests pass
- [ ] Gateway endpoint integration (deferred — shape-only in this slice)

Closes #206 (task 2)