### PR TITLE
feat(cli): add MS365 auth/config inspection and mail folders (issue #206 task 3)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -239,6 +239,11 @@ pub enum Command {
 /// Top-level MS365 subcommands.
 #[derive(Debug, Subcommand)]
 pub enum Ms365Action {
+    /// Inspect Microsoft 365 auth/config readiness.
+    Auth {
+        #[command(subcommand)]
+        action: Ms365AuthAction,
+    },
     /// Mail operations.
     Mail {
         #[command(subcommand)]
@@ -249,6 +254,13 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365CalendarAction,
     },
+}
+
+/// Auth/config inspection subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365AuthAction {
+    /// Show current authentication and configuration status.
+    Status,
 }
 
 /// Mail subcommands.
@@ -269,6 +281,8 @@ pub enum Ms365MailAction {
         #[arg(long)]
         id: String,
     },
+    /// List mail folders in the authenticated mailbox.
+    Folders,
 }
 
 /// Calendar subcommands.
@@ -4686,5 +4700,23 @@ mod subagent_cli_tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_ms365_auth_status() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "auth", "status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Ms365 { action: Ms365Action::Auth { action: Ms365AuthAction::Status } }
+        ));
+    }
+
+    #[test]
+    fn parse_ms365_mail_folders() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "mail", "folders"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Ms365 { action: Ms365Action::Mail { action: Ms365MailAction::Folders } }
+        ));
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2950,6 +2950,16 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_auth_status(&self) -> Result<crate::output::Ms365AuthStatusResponse> {
+        let r = self.http.get(self.url("/ms365/auth/status"))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_mail_folders(&self) -> Result<crate::output::Ms365MailFoldersResponse> {
+        let r = self.http.get(self.url("/ms365/mail/folders"))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365CalendarAction, Ms365MailAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365MailAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1168,6 +1168,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
         },
         Command::Ms365 { action } => match action {
+            Ms365Action::Auth { action } => match action {
+                Ms365AuthAction::Status => {
+                    let result = client.ms365_auth_status().await?;
+                    println!("{}", render(&result, format));
+                }
+            },
             Ms365Action::Mail { action } => match action {
                 Ms365MailAction::Unread { limit, folder } => {
                     let result = client.ms365_mail_unread(limit, &folder).await?;
@@ -1175,6 +1181,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365MailAction::Read { id } => {
                     let result = client.ms365_mail_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365MailAction::Folders => {
+                    let result = client.ms365_mail_folders().await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3505,6 +3505,77 @@ impl fmt::Display for Ms365CalendarReadResponse {
     }
 }
 
+/// Auth/config inspection for Microsoft 365.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365AuthStatusResponse {
+    pub authenticated: bool,
+    pub tenant_id: Option<String>,
+    pub client_id: Option<String>,
+    pub user_principal: Option<String>,
+    pub scopes: Vec<String>,
+    pub token_expires_at: Option<String>,
+    pub token_valid: bool,
+}
+
+impl fmt::Display for Ms365AuthStatusResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "MS365 Auth Status")?;
+        writeln!(f, "  Authenticated: {}", if self.authenticated { "yes" } else { "no" })?;
+        if let Some(t) = &self.tenant_id {
+            writeln!(f, "  Tenant ID:     {t}")?;
+        }
+        if let Some(c) = &self.client_id {
+            writeln!(f, "  Client ID:     {c}")?;
+        }
+        if let Some(u) = &self.user_principal {
+            writeln!(f, "  User:          {u}")?;
+        }
+        if !self.scopes.is_empty() {
+            writeln!(f, "  Scopes:        {}", self.scopes.join(", "))?;
+        }
+        writeln!(f, "  Token valid:   {}", if self.token_valid { "yes" } else { "no" })?;
+        if let Some(exp) = &self.token_expires_at {
+            writeln!(f, "  Token expires: {exp}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A single mail folder summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailFolder {
+    pub id: String,
+    pub display_name: String,
+    pub total_count: u32,
+    pub unread_count: u32,
+}
+
+impl fmt::Display for Ms365MailFolder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "  {} ({} total, {} unread)", self.display_name, self.total_count, self.unread_count)
+    }
+}
+
+/// Response from `rune ms365 mail folders`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailFoldersResponse {
+    pub folders: Vec<Ms365MailFolder>,
+}
+
+impl fmt::Display for Ms365MailFoldersResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Mail folders: {} folder(s)", self.folders.len())?;
+        if self.folders.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for folder in &self.folders {
+                writeln!(f, "{folder}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 // ── Sandbox ───────────────────────────────────────────────────────
 
 /// Response from `rune sandbox list`.
@@ -6140,6 +6211,110 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["id"], "evt-1");
         assert_eq!(v["status"], "tentative");
+    }
+
+    #[test]
+    fn render_ms365_auth_status_human() {
+        let r = Ms365AuthStatusResponse {
+            authenticated: true,
+            tenant_id: Some("tenant-abc".into()),
+            client_id: Some("client-xyz".into()),
+            user_principal: Some("user@example.com".into()),
+            scopes: vec!["Mail.Read".into(), "Calendars.Read".into()],
+            token_expires_at: Some("2026-03-21T12:00:00Z".into()),
+            token_valid: true,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Authenticated: yes"));
+        assert!(out.contains("Tenant ID:     tenant-abc"));
+        assert!(out.contains("Client ID:     client-xyz"));
+        assert!(out.contains("User:          user@example.com"));
+        assert!(out.contains("Mail.Read, Calendars.Read"));
+        assert!(out.contains("Token valid:   yes"));
+        assert!(out.contains("Token expires: 2026-03-21T12:00:00Z"));
+    }
+
+    #[test]
+    fn render_ms365_auth_status_unauthenticated() {
+        let r = Ms365AuthStatusResponse {
+            authenticated: false,
+            tenant_id: None,
+            client_id: None,
+            user_principal: None,
+            scopes: vec![],
+            token_expires_at: None,
+            token_valid: false,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Authenticated: no"));
+        assert!(out.contains("Token valid:   no"));
+        assert!(!out.contains("Tenant ID:"));
+    }
+
+    #[test]
+    fn render_ms365_auth_status_json() {
+        let r = Ms365AuthStatusResponse {
+            authenticated: true,
+            tenant_id: Some("t1".into()),
+            client_id: Some("c1".into()),
+            user_principal: Some("u@e.com".into()),
+            scopes: vec!["Mail.Read".into()],
+            token_expires_at: Some("2026-03-21T12:00:00Z".into()),
+            token_valid: true,
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["authenticated"], true);
+        assert_eq!(v["tenant_id"], "t1");
+        assert_eq!(v["scopes"][0], "Mail.Read");
+    }
+
+    #[test]
+    fn render_ms365_mail_folders_human() {
+        let r = Ms365MailFoldersResponse {
+            folders: vec![
+                Ms365MailFolder {
+                    id: "f1".into(),
+                    display_name: "Inbox".into(),
+                    total_count: 120,
+                    unread_count: 5,
+                },
+                Ms365MailFolder {
+                    id: "f2".into(),
+                    display_name: "Sent Items".into(),
+                    total_count: 80,
+                    unread_count: 0,
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Mail folders: 2 folder(s)"));
+        assert!(out.contains("Inbox (120 total, 5 unread)"));
+        assert!(out.contains("Sent Items (80 total, 0 unread)"));
+    }
+
+    #[test]
+    fn render_ms365_mail_folders_empty() {
+        let r = Ms365MailFoldersResponse { folders: vec![] };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("0 folder(s)"));
+        assert!(out.contains("(none)"));
+    }
+
+    #[test]
+    fn render_ms365_mail_folders_json() {
+        let r = Ms365MailFoldersResponse {
+            folders: vec![Ms365MailFolder {
+                id: "f1".into(),
+                display_name: "Inbox".into(),
+                total_count: 10,
+                unread_count: 2,
+            }],
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["folders"][0]["display_name"], "Inbox");
+        assert_eq!(v["folders"][0]["unread_count"], 2);
     }
 }
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,17 +676,20 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First and second parity slices: read-only mail and calendar surfaces, including list and read-detail.
+First through third parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, and mail folder listing.
 
 Observed subcommands:
 
+- `ms365 auth status` — inspect Microsoft 365 auth/config readiness (tenant, client, token, scopes)
 - `ms365 mail unread` — list unread messages from the authenticated mailbox
 - `ms365 mail read --id <msg_id>` — read full detail of a single mail message
+- `ms365 mail folders` — list mail folders in the authenticated mailbox
 - `ms365 calendar upcoming` — list upcoming calendar events
 - `ms365 calendar read --id <event_id>` — read full detail of a single calendar event
 
 Required concepts:
-- mailbox folder selection (`--folder`)
+- auth/config readiness inspection (tenant, client, scopes, token validity)
+- mailbox folder discovery and selection (`--folder`)
 - result limiting (`--limit`)
 - calendar look-ahead window (`--hours`)
 - single-item read-detail by ID (`--id`)
@@ -695,7 +698,7 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–2). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–3). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `ms365 auth status` command for operator-facing auth/config readiness inspection (tenant ID, client ID, user principal, scopes, token validity/expiry)
- Adds `ms365 mail folders` command to list mail folders in the authenticated mailbox (name, total count, unread count)
- Updates parity inventory to reflect slices 1–3

## Test plan
- [x] 15 MS365 CLI parse + output render tests pass (`cargo test -p rune-cli -- ms365`)
- [x] `cargo check -p rune-cli` clean

Closes #206 (task 3)