### PR TITLE
feat(cli): add MS365 OneDrive files list/read surface (issue #206 task 4)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -226,7 +226,7 @@ pub enum Command {
         #[arg(long)]
         confirm: bool,
     },
-    /// Microsoft 365 integration surfaces (mail, calendar).
+    /// Microsoft 365 integration surfaces (mail, calendar, files).
     #[command(name = "ms365")]
     Ms365 {
         #[command(subcommand)]
@@ -253,6 +253,11 @@ pub enum Ms365Action {
     Calendar {
         #[command(subcommand)]
         action: Ms365CalendarAction,
+    },
+    /// OneDrive file operations.
+    Files {
+        #[command(subcommand)]
+        action: Ms365FilesAction,
     },
 }
 
@@ -300,6 +305,26 @@ pub enum Ms365CalendarAction {
     /// Read a single calendar event by ID.
     Read {
         /// Event ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
+}
+
+/// OneDrive file subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365FilesAction {
+    /// List files in a OneDrive folder.
+    List {
+        /// Folder path (default: root).
+        #[arg(long, default_value = "/")]
+        path: String,
+        /// Maximum number of items to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// Read metadata for a single file by ID.
+    Read {
+        /// File/item ID to retrieve.
         #[arg(long)]
         id: String,
     },

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2960,6 +2960,17 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_files_list(&self, path: &str, limit: u32) -> Result<crate::output::Ms365FilesListResponse> {
+        let r = self.http.get(self.url("/ms365/files"))
+            .query(&[("path", path.to_string()), ("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_files_read(&self, id: &str) -> Result<crate::output::Ms365FileReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/files/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365MailAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1195,6 +1195,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365CalendarAction::Read { id } => {
                     let result = client.ms365_calendar_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Files { action } => match action {
+                Ms365FilesAction::List { path, limit } => {
+                    let result = client.ms365_files_list(&path, limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365FilesAction::Read { id } => {
+                    let result = client.ms365_files_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3576,6 +3576,99 @@ impl fmt::Display for Ms365MailFoldersResponse {
     }
 }
 
+// ── Microsoft 365 Files ───────────────────────────────────────────
+
+/// A single OneDrive file/folder item summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365FileItem {
+    pub id: String,
+    pub name: String,
+    pub size: u64,
+    pub is_folder: bool,
+    pub last_modified: String,
+    pub web_url: Option<String>,
+}
+
+impl fmt::Display for Ms365FileItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = if self.is_folder { "DIR " } else { "FILE" };
+        write!(f, "  {kind}  {:<40} {:>10}  {}", self.name, format_bytes(self.size), self.last_modified)
+    }
+}
+
+/// Response from `rune ms365 files list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365FilesListResponse {
+    pub items: Vec<Ms365FileItem>,
+    pub path: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365FilesListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "OneDrive path: {}  ({} item(s))", self.path, self.total)?;
+        if self.items.is_empty() {
+            writeln!(f, "  (empty)")?;
+        } else {
+            for item in &self.items {
+                writeln!(f, "{item}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 files read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365FileReadResponse {
+    pub id: String,
+    pub name: String,
+    pub size: u64,
+    pub is_folder: bool,
+    pub mime_type: Option<String>,
+    pub last_modified: String,
+    pub created_at: String,
+    pub web_url: Option<String>,
+    pub parent_path: Option<String>,
+    pub download_url: Option<String>,
+}
+
+impl fmt::Display for Ms365FileReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = if self.is_folder { "Folder" } else { "File" };
+        writeln!(f, "── {kind}: {} ──", self.name)?;
+        writeln!(f, "  ID:            {}", self.id)?;
+        writeln!(f, "  Size:          {}", format_bytes(self.size))?;
+        if let Some(ref mime) = self.mime_type {
+            writeln!(f, "  Type:          {mime}")?;
+        }
+        writeln!(f, "  Created:       {}", self.created_at)?;
+        writeln!(f, "  Modified:      {}", self.last_modified)?;
+        if let Some(ref parent) = self.parent_path {
+            writeln!(f, "  Parent:        {parent}")?;
+        }
+        if let Some(ref url) = self.web_url {
+            writeln!(f, "  Web URL:       {url}")?;
+        }
+        if let Some(ref dl) = self.download_url {
+            writeln!(f, "  Download URL:  {dl}")?;
+        }
+        Ok(())
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else if bytes < 1024 * 1024 * 1024 {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("{:.1} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
 // ── Sandbox ───────────────────────────────────────────────────────
 
 /// Response from `rune sandbox list`.

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through third parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, and mail folder listing.
+First through fourth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, and OneDrive file list/read.
 
 Observed subcommands:
 
@@ -686,19 +686,22 @@ Observed subcommands:
 - `ms365 mail folders` — list mail folders in the authenticated mailbox
 - `ms365 calendar upcoming` — list upcoming calendar events
 - `ms365 calendar read --id <event_id>` — read full detail of a single calendar event
+- `ms365 files list` — list files/folders in a OneDrive path
+- `ms365 files read --id <item_id>` — read metadata for a single OneDrive item
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
 - mailbox folder discovery and selection (`--folder`)
 - result limiting (`--limit`)
 - calendar look-ahead window (`--hours`)
+- OneDrive folder path browsing (`--path`)
 - single-item read-detail by ID (`--id`)
-- operator-friendly rich output (headers, attendees, body preview)
+- operator-friendly rich output (headers, attendees, body preview, file metadata)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–3). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–4). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the fourth narrow MS365 parity slice: OneDrive file operations
- New subcommands: `ms365 files list` (browse by path) and `ms365 files read` (item metadata by ID)
- Client plumbing for `GET /ms365/files` and `GET /ms365/files/{id}` gateway endpoints
- Operator-friendly Display output with human-readable file sizes (B/KB/MB/GB)
- Parity inventory updated to reflect slices 1–4

Closes #206 (task 4)

## Test plan
- [x] `cargo check -p rune-cli` passes
- [x] All 493 existing tests pass (`cargo test -p rune-cli`)
- [ ] Manual validation of `rune ms365 files list` / `rune ms365 files read` against live gateway (deferred until gateway Graph integration)