### PR TITLE
feat(cli): add MS365 users/org directory inspection surface (issue #206 task 5)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -259,6 +259,11 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365FilesAction,
     },
+    /// Users and organization inspection.
+    Users {
+        #[command(subcommand)]
+        action: Ms365UsersAction,
+    },
 }
 
 /// Auth/config inspection subcommands.
@@ -325,6 +330,25 @@ pub enum Ms365FilesAction {
     /// Read metadata for a single file by ID.
     Read {
         /// File/item ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
+}
+
+/// Users/org inspection subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365UsersAction {
+    /// Show the authenticated user's profile.
+    Me,
+    /// List users in the organization directory.
+    List {
+        /// Maximum number of users to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// Read a single user's profile by ID or UPN.
+    Read {
+        /// User ID or user principal name.
         #[arg(long)]
         id: String,
     },

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2971,6 +2971,22 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_users_me(&self) -> Result<crate::output::Ms365UserProfileResponse> {
+        let r = self.http.get(self.url("/ms365/users/me"))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_users_list(&self, limit: u32) -> Result<crate::output::Ms365UsersListResponse> {
+        let r = self.http.get(self.url("/ms365/users"))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_users_read(&self, id: &str) -> Result<crate::output::Ms365UserProfileResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/users/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365UsersAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1205,6 +1205,20 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365FilesAction::Read { id } => {
                     let result = client.ms365_files_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Users { action } => match action {
+                Ms365UsersAction::Me => {
+                    let result = client.ms365_users_me().await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365UsersAction::List { limit } => {
+                    let result = client.ms365_users_list(limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365UsersAction::Read { id } => {
+                    let result = client.ms365_users_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3657,6 +3657,82 @@ impl fmt::Display for Ms365FileReadResponse {
     }
 }
 
+// ── MS365 Users/Org ─────────────────────────────────────────────
+
+/// A single user profile (used by `me`, `read`, and inside list responses).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365UserProfileResponse {
+    pub id: String,
+    pub display_name: String,
+    pub user_principal_name: String,
+    pub mail: Option<String>,
+    pub job_title: Option<String>,
+    pub department: Option<String>,
+    pub office_location: Option<String>,
+    pub mobile_phone: Option<String>,
+}
+
+impl fmt::Display for Ms365UserProfileResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "── User: {} ──", self.display_name)?;
+        writeln!(f, "  ID:         {}", self.id)?;
+        writeln!(f, "  UPN:        {}", self.user_principal_name)?;
+        if let Some(ref mail) = self.mail {
+            writeln!(f, "  Mail:       {mail}")?;
+        }
+        if let Some(ref title) = self.job_title {
+            writeln!(f, "  Job title:  {title}")?;
+        }
+        if let Some(ref dept) = self.department {
+            writeln!(f, "  Department: {dept}")?;
+        }
+        if let Some(ref office) = self.office_location {
+            writeln!(f, "  Office:     {office}")?;
+        }
+        if let Some(ref phone) = self.mobile_phone {
+            writeln!(f, "  Phone:      {phone}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Summary user entry for list responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365UserSummary {
+    pub id: String,
+    pub display_name: String,
+    pub user_principal_name: String,
+    pub job_title: Option<String>,
+}
+
+impl fmt::Display for Ms365UserSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let title = self.job_title.as_deref().unwrap_or("–");
+        write!(f, "  {} <{}> — {title}", self.display_name, self.user_principal_name)
+    }
+}
+
+/// Response from `rune ms365 users list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365UsersListResponse {
+    pub users: Vec<Ms365UserSummary>,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365UsersListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Directory users: {} user(s)", self.total)?;
+        if self.users.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for u in &self.users {
+                writeln!(f, "{u}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes} B")
@@ -6408,6 +6484,117 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["folders"][0]["display_name"], "Inbox");
         assert_eq!(v["folders"][0]["unread_count"], 2);
+    }
+
+    #[test]
+    fn render_ms365_user_profile_human() {
+        let r = Ms365UserProfileResponse {
+            id: "u-1".into(),
+            display_name: "Alice Smith".into(),
+            user_principal_name: "alice@example.com".into(),
+            mail: Some("alice@example.com".into()),
+            job_title: Some("Engineer".into()),
+            department: Some("Platform".into()),
+            office_location: Some("Building 5".into()),
+            mobile_phone: Some("+1-555-0100".into()),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("User: Alice Smith"));
+        assert!(out.contains("ID:         u-1"));
+        assert!(out.contains("UPN:        alice@example.com"));
+        assert!(out.contains("Mail:       alice@example.com"));
+        assert!(out.contains("Job title:  Engineer"));
+        assert!(out.contains("Department: Platform"));
+        assert!(out.contains("Office:     Building 5"));
+        assert!(out.contains("Phone:      +1-555-0100"));
+    }
+
+    #[test]
+    fn render_ms365_user_profile_minimal() {
+        let r = Ms365UserProfileResponse {
+            id: "u-2".into(),
+            display_name: "Bob".into(),
+            user_principal_name: "bob@example.com".into(),
+            mail: None,
+            job_title: None,
+            department: None,
+            office_location: None,
+            mobile_phone: None,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("User: Bob"));
+        assert!(out.contains("UPN:        bob@example.com"));
+        assert!(!out.contains("Job title:"));
+        assert!(!out.contains("Department:"));
+    }
+
+    #[test]
+    fn render_ms365_user_profile_json() {
+        let r = Ms365UserProfileResponse {
+            id: "u-1".into(),
+            display_name: "Alice".into(),
+            user_principal_name: "alice@example.com".into(),
+            mail: Some("alice@example.com".into()),
+            job_title: Some("Engineer".into()),
+            department: None,
+            office_location: None,
+            mobile_phone: None,
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["id"], "u-1");
+        assert_eq!(v["display_name"], "Alice");
+        assert_eq!(v["job_title"], "Engineer");
+    }
+
+    #[test]
+    fn render_ms365_users_list_human() {
+        let r = Ms365UsersListResponse {
+            users: vec![
+                Ms365UserSummary {
+                    id: "u-1".into(),
+                    display_name: "Alice".into(),
+                    user_principal_name: "alice@example.com".into(),
+                    job_title: Some("Engineer".into()),
+                },
+                Ms365UserSummary {
+                    id: "u-2".into(),
+                    display_name: "Bob".into(),
+                    user_principal_name: "bob@example.com".into(),
+                    job_title: None,
+                },
+            ],
+            total: 2,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Directory users: 2 user(s)"));
+        assert!(out.contains("Alice <alice@example.com> — Engineer"));
+        assert!(out.contains("Bob <bob@example.com>"));
+    }
+
+    #[test]
+    fn render_ms365_users_list_empty() {
+        let r = Ms365UsersListResponse { users: vec![], total: 0 };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("0 user(s)"));
+        assert!(out.contains("(none)"));
+    }
+
+    #[test]
+    fn render_ms365_users_list_json() {
+        let r = Ms365UsersListResponse {
+            users: vec![Ms365UserSummary {
+                id: "u-1".into(),
+                display_name: "Alice".into(),
+                user_principal_name: "alice@example.com".into(),
+                job_title: Some("Engineer".into()),
+            }],
+            total: 1,
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["users"][0]["display_name"], "Alice");
+        assert_eq!(v["total"], 1);
     }
 }
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through fourth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, and OneDrive file list/read.
+First through fifth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, and users/org directory inspection.
 
 Observed subcommands:
 
@@ -688,6 +688,9 @@ Observed subcommands:
 - `ms365 calendar read --id <event_id>` — read full detail of a single calendar event
 - `ms365 files list` — list files/folders in a OneDrive path
 - `ms365 files read --id <item_id>` — read metadata for a single OneDrive item
+- `ms365 users me` — show authenticated user's profile
+- `ms365 users list` — list users in the organization directory
+- `ms365 users read --id <user_id>` — read a single user's profile by ID or UPN
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -696,12 +699,13 @@ Required concepts:
 - calendar look-ahead window (`--hours`)
 - OneDrive folder path browsing (`--path`)
 - single-item read-detail by ID (`--id`)
-- operator-friendly rich output (headers, attendees, body preview, file metadata)
+- users/org directory inspection (me, list, read by ID/UPN)
+- operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–4). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–5). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the **users/org** family as the fifth narrow MS365 parity slice (issue #206)
- `ms365 users me` — show authenticated user's profile
- `ms365 users list --limit N` — list users in the organization directory
- `ms365 users read --id <user_id>` — read a single user profile by ID or UPN
- Client plumbing hits `/ms365/users/me`, `/ms365/users`, `/ms365/users/{id}` gateway endpoints
- Human and JSON output modes with operator-friendly formatting
- Parity inventory updated to reflect slices 1–5

## Test plan
- [x] 21 MS365 output tests pass (`cargo test -p rune-cli --lib -- ms365`)
- [x] `cargo check -p rune-cli` clean
- [ ] Verify gateway endpoints when Graph integration is wired up