### PR TITLE
feat(cli): add MS365 Planner plans/tasks inspection surface (issue #206 task 6)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -264,6 +264,11 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365UsersAction,
     },
+    /// Planner plans and tasks.
+    Planner {
+        #[command(subcommand)]
+        action: Ms365PlannerAction,
+    },
 }
 
 /// Auth/config inspection subcommands.
@@ -349,6 +354,33 @@ pub enum Ms365UsersAction {
     /// Read a single user's profile by ID or UPN.
     Read {
         /// User ID or user principal name.
+        #[arg(long)]
+        id: String,
+    },
+}
+
+/// Planner subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365PlannerAction {
+    /// List plans accessible to the authenticated user.
+    Plans {
+        /// Maximum number of plans to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// List tasks in a plan.
+    Tasks {
+        /// Plan ID to list tasks from.
+        #[arg(long)]
+        plan_id: String,
+        /// Maximum number of tasks to return.
+        #[arg(long, default_value_t = 50)]
+        limit: u32,
+    },
+    /// Read a single task by ID.
+    #[command(name = "task-read")]
+    TaskRead {
+        /// Task ID to retrieve.
         #[arg(long)]
         id: String,
     },
@@ -4758,6 +4790,40 @@ mod subagent_cli_tests {
             cli.command,
             Command::Ms365 { action: Ms365Action::Auth { action: Ms365AuthAction::Status } }
         ));
+    }
+
+    #[test]
+    fn parse_ms365_planner_plans() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "plans"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::Plans { limit } } } => {
+                assert_eq!(limit, 25);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_planner_tasks() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "tasks", "--plan-id", "p1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::Tasks { plan_id, limit } } } => {
+                assert_eq!(plan_id, "p1");
+                assert_eq!(limit, 50);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_planner_task_read() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "task-read", "--id", "t1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::TaskRead { id } } } => {
+                assert_eq!(id, "t1");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2987,6 +2987,23 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_planner_plans(&self, limit: u32) -> Result<crate::output::Ms365PlannerPlansResponse> {
+        let r = self.http.get(self.url("/ms365/planner/plans"))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_planner_tasks(&self, plan_id: &str, limit: u32) -> Result<crate::output::Ms365PlannerTasksResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/planner/plans/{plan_id}/tasks")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_planner_task_read(&self, id: &str) -> Result<crate::output::Ms365PlannerTaskReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/planner/tasks/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365UsersAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365UsersAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1219,6 +1219,20 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365UsersAction::Read { id } => {
                     let result = client.ms365_users_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Planner { action } => match action {
+                Ms365PlannerAction::Plans { limit } => {
+                    let result = client.ms365_planner_plans(limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365PlannerAction::Tasks { plan_id, limit } => {
+                    let result = client.ms365_planner_tasks(&plan_id, limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365PlannerAction::TaskRead { id } => {
+                    let result = client.ms365_planner_task_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3733,6 +3733,128 @@ impl fmt::Display for Ms365UsersListResponse {
     }
 }
 
+// ── Planner ──────────────────────────────────────────────────────
+
+/// Summary plan entry for list responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerPlan {
+    pub id: String,
+    pub title: String,
+    pub owner: Option<String>,
+    pub created_at: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let owner = self.owner.as_deref().unwrap_or("–");
+        write!(f, "  {} — owner: {owner}", self.title)
+    }
+}
+
+/// Response from `rune ms365 planner plans`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerPlansResponse {
+    pub plans: Vec<Ms365PlannerPlan>,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365PlannerPlansResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Planner plans: {} plan(s)", self.total)?;
+        if self.plans.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for p in &self.plans {
+                writeln!(f, "{p}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Summary task entry for list responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTaskSummary {
+    pub id: String,
+    pub title: String,
+    pub percent_complete: u8,
+    pub assigned_to: Option<String>,
+    pub due_date: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerTaskSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let assignee = self.assigned_to.as_deref().unwrap_or("unassigned");
+        let due = self.due_date.as_deref().unwrap_or("no due date");
+        write!(f, "  [{}%] {} — {assignee}, {due}", self.percent_complete, self.title)
+    }
+}
+
+/// Response from `rune ms365 planner tasks`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTasksResponse {
+    pub tasks: Vec<Ms365PlannerTaskSummary>,
+    pub plan_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365PlannerTasksResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Plan {} — {} task(s)", self.plan_id, self.total)?;
+        if self.tasks.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for t in &self.tasks {
+                writeln!(f, "{t}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 planner task-read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTaskReadResponse {
+    pub id: String,
+    pub title: String,
+    pub plan_id: String,
+    pub bucket_id: Option<String>,
+    pub percent_complete: u8,
+    pub assigned_to: Option<String>,
+    pub due_date: Option<String>,
+    pub created_at: Option<String>,
+    pub priority: Option<u8>,
+    pub description: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerTaskReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "── Task: {} ──", self.title)?;
+        writeln!(f, "  ID:        {}", self.id)?;
+        writeln!(f, "  Plan:      {}", self.plan_id)?;
+        if let Some(ref bucket) = self.bucket_id {
+            writeln!(f, "  Bucket:    {bucket}")?;
+        }
+        writeln!(f, "  Progress:  {}%", self.percent_complete)?;
+        if let Some(ref assignee) = self.assigned_to {
+            writeln!(f, "  Assigned:  {assignee}")?;
+        }
+        if let Some(ref due) = self.due_date {
+            writeln!(f, "  Due:       {due}")?;
+        }
+        if let Some(pri) = self.priority {
+            writeln!(f, "  Priority:  {pri}")?;
+        }
+        if let Some(ref created) = self.created_at {
+            writeln!(f, "  Created:   {created}")?;
+        }
+        if let Some(ref desc) = self.description {
+            writeln!(f, "  Description: {desc}")?;
+        }
+        Ok(())
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes} B")


### PR DESCRIPTION
## Summary
- Adds `rune ms365 planner plans`, `rune ms365 planner tasks`, and `rune ms365 planner task-read` subcommands for assistant-facing Planner inspection
- Includes CLI parsing, gateway client methods, response types with Display impls, and dispatch wiring
- Sixth narrow MS365 parity slice following mail/calendar/files/users

## Test plan
- [x] 3 new CLI parse tests (`parse_ms365_planner_plans`, `parse_ms365_planner_tasks`, `parse_ms365_planner_task_read`)
- [x] Full CLI test suite passes (502 tests, 0 failures)
- [x] `cargo build -p rune-cli` succeeds cleanly

Closes #206 (task 6)