### PR TITLE
docs(parity): add MS365 Planner plans/tasks to parity inventory (issue #206 task 6)

### DIFF
--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through fifth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, and users/org directory inspection.
+First through sixth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, and Planner plans/tasks inspection.
 
 Observed subcommands:
 
@@ -691,6 +691,9 @@ Observed subcommands:
 - `ms365 users me` — show authenticated user's profile
 - `ms365 users list` — list users in the organization directory
 - `ms365 users read --id <user_id>` — read a single user's profile by ID or UPN
+- `ms365 planner plans` — list Planner plans for the authenticated user
+- `ms365 planner tasks --plan-id <plan_id>` — list tasks within a Planner plan
+- `ms365 planner task-read --id <task_id>` — read full detail of a single Planner task
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -700,12 +703,13 @@ Required concepts:
 - OneDrive folder path browsing (`--path`)
 - single-item read-detail by ID (`--id`)
 - users/org directory inspection (me, list, read by ID/UPN)
-- operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles)
+- Planner plan discovery and task enumeration by plan
+- operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–5). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–6). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the Planner plans/tasks commands (`ms365 planner plans`, `ms365 planner tasks`, `ms365 planner task-read`) to the parity inventory documentation
- Updates parity status from slices 1–5 to slices 1–6
- Adds Planner plan discovery and task enumeration to required concepts

Closes #206 (task 6 — Planner/tasks slice).

Note: The CLI/client/output implementation shipped in PR #215. This PR adds the missing parity inventory documentation.

## Test plan
- [x] All 3 `ms365_planner` CLI parse tests pass
- [x] Parity inventory accurately reflects the implemented commands