### PR TITLE
feat(cli): add MS365 To-Do lists/tasks inspection surface (issue #206 task 7)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -269,6 +269,11 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365PlannerAction,
     },
+    /// Microsoft To-Do lists and tasks.
+    Todo {
+        #[command(subcommand)]
+        action: Ms365TodoAction,
+    },
 }
 
 /// Auth/config inspection subcommands.
@@ -380,6 +385,36 @@ pub enum Ms365PlannerAction {
     /// Read a single task by ID.
     #[command(name = "task-read")]
     TaskRead {
+        /// Task ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
+}
+
+/// Microsoft To-Do subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365TodoAction {
+    /// List To-Do task lists.
+    Lists {
+        /// Maximum number of lists to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// List tasks in a To-Do list.
+    Tasks {
+        /// Task list ID to list tasks from.
+        #[arg(long)]
+        list_id: String,
+        /// Maximum number of tasks to return.
+        #[arg(long, default_value_t = 50)]
+        limit: u32,
+    },
+    /// Read a single To-Do task by ID.
+    #[command(name = "task-read")]
+    TaskRead {
+        /// Task list ID that contains the task.
+        #[arg(long)]
+        list_id: String,
         /// Task ID to retrieve.
         #[arg(long)]
         id: String,
@@ -4833,5 +4868,40 @@ mod subagent_cli_tests {
             cli.command,
             Command::Ms365 { action: Ms365Action::Mail { action: Ms365MailAction::Folders } }
         ));
+    }
+
+    #[test]
+    fn parse_ms365_todo_lists() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "todo", "lists"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::Lists { limit } } } => {
+                assert_eq!(limit, 25);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_todo_tasks() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "todo", "tasks", "--list-id", "lst1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::Tasks { list_id, limit } } } => {
+                assert_eq!(list_id, "lst1");
+                assert_eq!(limit, 50);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_todo_task_read() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "todo", "task-read", "--list-id", "lst1", "--id", "task1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::TaskRead { list_id, id } } } => {
+                assert_eq!(list_id, "lst1");
+                assert_eq!(id, "task1");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -3004,6 +3004,23 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_todo_lists(&self, limit: u32) -> Result<crate::output::Ms365TodoListsResponse> {
+        let r = self.http.get(self.url("/ms365/todo/lists"))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_todo_tasks(&self, list_id: &str, limit: u32) -> Result<crate::output::Ms365TodoTasksResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_todo_task_read(&self, list_id: &str, id: &str) -> Result<crate::output::Ms365TodoTaskReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365UsersAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1233,6 +1233,20 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365PlannerAction::TaskRead { id } => {
                     let result = client.ms365_planner_task_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Todo { action } => match action {
+                Ms365TodoAction::Lists { limit } => {
+                    let result = client.ms365_todo_lists(limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365TodoAction::Tasks { list_id, limit } => {
+                    let result = client.ms365_todo_tasks(&list_id, limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365TodoAction::TaskRead { list_id, id } => {
+                    let result = client.ms365_todo_task_read(&list_id, &id).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3855,6 +3855,126 @@ impl fmt::Display for Ms365PlannerTaskReadResponse {
     }
 }
 
+// ── Microsoft 365 To-Do ──────────────────────────────────────────
+
+/// A single To-Do task list summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TodoList {
+    pub id: String,
+    pub display_name: String,
+    pub is_owner: bool,
+    pub is_shared: bool,
+}
+
+impl fmt::Display for Ms365TodoList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let shared = if self.is_shared { " (shared)" } else { "" };
+        write!(f, "  {}{shared}", self.display_name)
+    }
+}
+
+/// Response from `rune ms365 todo lists`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TodoListsResponse {
+    pub lists: Vec<Ms365TodoList>,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365TodoListsResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "To-Do lists: {} list(s)", self.total)?;
+        if self.lists.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for l in &self.lists {
+                writeln!(f, "{l}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Summary task entry for To-Do task list responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TodoTaskSummary {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub importance: String,
+    pub due_date: Option<String>,
+}
+
+impl fmt::Display for Ms365TodoTaskSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let due = self.due_date.as_deref().unwrap_or("no due date");
+        write!(f, "  [{}] {} — {}, {due}", self.status, self.title, self.importance)
+    }
+}
+
+/// Response from `rune ms365 todo tasks`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TodoTasksResponse {
+    pub tasks: Vec<Ms365TodoTaskSummary>,
+    pub list_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365TodoTasksResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "To-Do list {} — {} task(s)", self.list_id, self.total)?;
+        if self.tasks.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for t in &self.tasks {
+                writeln!(f, "{t}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 todo task-read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TodoTaskReadResponse {
+    pub id: String,
+    pub title: String,
+    pub list_id: String,
+    pub status: String,
+    pub importance: String,
+    pub is_reminder_on: bool,
+    pub due_date: Option<String>,
+    pub completed_at: Option<String>,
+    pub created_at: Option<String>,
+    pub body_preview: Option<String>,
+}
+
+impl fmt::Display for Ms365TodoTaskReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "── To-Do: {} ──", self.title)?;
+        writeln!(f, "  ID:         {}", self.id)?;
+        writeln!(f, "  List:       {}", self.list_id)?;
+        writeln!(f, "  Status:     {}", self.status)?;
+        writeln!(f, "  Importance: {}", self.importance)?;
+        writeln!(f, "  Reminder:   {}", if self.is_reminder_on { "yes" } else { "no" })?;
+        if let Some(ref due) = self.due_date {
+            writeln!(f, "  Due:        {due}")?;
+        }
+        if let Some(ref completed) = self.completed_at {
+            writeln!(f, "  Completed:  {completed}")?;
+        }
+        if let Some(ref created) = self.created_at {
+            writeln!(f, "  Created:    {created}")?;
+        }
+        if let Some(ref body) = self.body_preview {
+            if !body.is_empty() {
+                writeln!(f)?;
+                writeln!(f, "{body}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes} B")

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through fifth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, and users/org directory inspection.
+First through seventh parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, and To-Do lists/tasks.
 
 Observed subcommands:
 
@@ -691,6 +691,12 @@ Observed subcommands:
 - `ms365 users me` — show authenticated user's profile
 - `ms365 users list` — list users in the organization directory
 - `ms365 users read --id <user_id>` — read a single user's profile by ID or UPN
+- `ms365 planner plans` — list Planner plans accessible to the authenticated user
+- `ms365 planner tasks --plan-id <id>` — list tasks in a Planner plan
+- `ms365 planner task-read --id <id>` — read a single Planner task by ID
+- `ms365 todo lists` — list Microsoft To-Do task lists
+- `ms365 todo tasks --list-id <id>` — list tasks in a To-Do list
+- `ms365 todo task-read --list-id <id> --id <id>` — read a single To-Do task by ID
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -700,12 +706,14 @@ Required concepts:
 - OneDrive folder path browsing (`--path`)
 - single-item read-detail by ID (`--id`)
 - users/org directory inspection (me, list, read by ID/UPN)
-- operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles)
+- Planner plan discovery and task enumeration by plan ID
+- To-Do list discovery and task enumeration by list ID
+- operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–5). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–7). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `ms365 todo lists`, `ms365 todo tasks`, and `ms365 todo task-read` subcommands for Microsoft To-Do inspection
- Client plumbing for `/ms365/todo/lists`, `/ms365/todo/lists/{id}/tasks`, and `/ms365/todo/lists/{id}/tasks/{id}` gateway endpoints
- Operator-friendly output with status, importance, due dates, reminders, and body preview
- Parity inventory updated to reflect slices 1–7 (including Planner from task 6)

## Test plan
- [x] 3 new CLI parse tests pass (`parse_ms365_todo_lists`, `parse_ms365_todo_tasks`, `parse_ms365_todo_task_read`)
- [x] All 10 MS365 parse tests pass
- [x] `cargo check -p rune-cli` clean

Closes #206 (task 7)