### PR TITLE
feat(cli): add MS365 SharePoint/sites inspection surface (issue #206 task 8)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -274,6 +274,11 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365TodoAction,
     },
+    /// SharePoint sites inspection.
+    Sites {
+        #[command(subcommand)]
+        action: Ms365SitesAction,
+    },
 }
 
 /// Auth/config inspection subcommands.
@@ -418,6 +423,45 @@ pub enum Ms365TodoAction {
         /// Task ID to retrieve.
         #[arg(long)]
         id: String,
+    },
+}
+
+/// SharePoint sites subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365SitesAction {
+    /// List SharePoint sites accessible to the authenticated user.
+    List {
+        /// Maximum number of sites to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// Read details of a single SharePoint site by ID.
+    Read {
+        /// Site ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
+    /// List document libraries in a SharePoint site.
+    Lists {
+        /// Site ID to list libraries from.
+        #[arg(long)]
+        site_id: String,
+        /// Maximum number of lists to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// List items in a SharePoint list/library.
+    #[command(name = "list-items")]
+    ListItems {
+        /// Site ID that contains the list.
+        #[arg(long)]
+        site_id: String,
+        /// List ID to enumerate items from.
+        #[arg(long)]
+        list_id: String,
+        /// Maximum number of items to return.
+        #[arg(long, default_value_t = 50)]
+        limit: u32,
     },
 }
 

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -3022,6 +3022,30 @@ impl GatewayClient {
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
 
+    pub async fn ms365_sites_list(&self, limit: u32) -> Result<crate::output::Ms365SitesListResponse> {
+        let r = self.http.get(self.url("/ms365/sites"))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_sites_read(&self, id: &str) -> Result<crate::output::Ms365SiteReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/sites/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_sites_lists(&self, site_id: &str, limit: u32) -> Result<crate::output::Ms365SiteListsResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/sites/{site_id}/lists")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_sites_list_items(&self, site_id: &str, list_id: &str, limit: u32) -> Result<crate::output::Ms365SiteListItemsResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/sites/{site_id}/lists/{list_id}/items")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {
         let r = self.http.post(self.url("/setup")).send().await.context("gateway")?;

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1247,6 +1247,24 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365TodoAction::TaskRead { list_id, id } => {
                     let result = client.ms365_todo_task_read(&list_id, &id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Sites { action } => match action {
+                Ms365SitesAction::List { limit } => {
+                    let result = client.ms365_sites_list(limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365SitesAction::Read { id } => {
+                    let result = client.ms365_sites_read(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365SitesAction::Lists { site_id, limit } => {
+                    let result = client.ms365_sites_lists(&site_id, limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365SitesAction::ListItems { site_id, list_id, limit } => {
+                    let result = client.ms365_sites_list_items(&site_id, &list_id, limit).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3975,6 +3975,147 @@ impl fmt::Display for Ms365TodoTaskReadResponse {
     }
 }
 
+// ── SharePoint Sites ─────────────────────────────────────────
+
+/// Summary of a SharePoint site (used in list responses).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteSummary {
+    pub id: String,
+    pub display_name: String,
+    pub web_url: Option<String>,
+    pub description: Option<String>,
+}
+
+impl fmt::Display for Ms365SiteSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let url = self.web_url.as_deref().unwrap_or("-");
+        write!(f, "  {} — {url}", self.display_name)
+    }
+}
+
+/// Response from `rune ms365 sites list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SitesListResponse {
+    pub sites: Vec<Ms365SiteSummary>,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365SitesListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "SharePoint sites: {} site(s)", self.total)?;
+        for s in &self.sites {
+            writeln!(f, "{s}")?;
+            writeln!(f, "    id: {}", s.id)?;
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 sites read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteReadResponse {
+    pub id: String,
+    pub display_name: String,
+    pub web_url: Option<String>,
+    pub description: Option<String>,
+    pub created_at: Option<String>,
+    pub last_modified_at: Option<String>,
+}
+
+impl fmt::Display for Ms365SiteReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "── Site: {} ──", self.display_name)?;
+        writeln!(f, "  ID:       {}", self.id)?;
+        if let Some(ref url) = self.web_url {
+            writeln!(f, "  URL:      {url}")?;
+        }
+        if let Some(ref desc) = self.description {
+            if !desc.is_empty() {
+                writeln!(f, "  Desc:     {desc}")?;
+            }
+        }
+        if let Some(ref created) = self.created_at {
+            writeln!(f, "  Created:  {created}")?;
+        }
+        if let Some(ref modified) = self.last_modified_at {
+            writeln!(f, "  Modified: {modified}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Summary of a SharePoint list/library.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteListSummary {
+    pub id: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    pub list_type: Option<String>,
+}
+
+impl fmt::Display for Ms365SiteListSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = self.list_type.as_deref().unwrap_or("list");
+        write!(f, "  {} ({kind})", self.display_name)
+    }
+}
+
+/// Response from `rune ms365 sites lists`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteListsResponse {
+    pub lists: Vec<Ms365SiteListSummary>,
+    pub site_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365SiteListsResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Site {} — {} list(s)", self.site_id, self.total)?;
+        for l in &self.lists {
+            writeln!(f, "{l}")?;
+            writeln!(f, "    id: {}", l.id)?;
+        }
+        Ok(())
+    }
+}
+
+/// Summary of a SharePoint list item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteListItemSummary {
+    pub id: String,
+    pub name: Option<String>,
+    pub content_type: Option<String>,
+    pub created_at: Option<String>,
+}
+
+impl fmt::Display for Ms365SiteListItemSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = self.name.as_deref().unwrap_or("(untitled)");
+        let ct = self.content_type.as_deref().unwrap_or("-");
+        write!(f, "  {name} [{ct}]")
+    }
+}
+
+/// Response from `rune ms365 sites list-items`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365SiteListItemsResponse {
+    pub items: Vec<Ms365SiteListItemSummary>,
+    pub site_id: String,
+    pub list_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365SiteListItemsResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Site {} / list {} — {} item(s)", self.site_id, self.list_id, self.total)?;
+        for item in &self.items {
+            writeln!(f, "{item}")?;
+            writeln!(f, "    id: {}", item.id)?;
+        }
+        Ok(())
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes} B")

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through seventh parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, and To-Do lists/tasks.
+First through eighth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, and SharePoint sites inspection.
 
 Observed subcommands:
 
@@ -697,6 +697,10 @@ Observed subcommands:
 - `ms365 todo lists` — list Microsoft To-Do task lists
 - `ms365 todo tasks --list-id <id>` — list tasks in a To-Do list
 - `ms365 todo task-read --list-id <id> --id <id>` — read a single To-Do task by ID
+- `ms365 sites list` — list SharePoint sites accessible to the authenticated user
+- `ms365 sites read --id <site_id>` — read details of a single SharePoint site
+- `ms365 sites lists --site-id <id>` — list document libraries/lists in a SharePoint site
+- `ms365 sites list-items --site-id <id> --list-id <id>` — list items in a SharePoint list/library
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -708,12 +712,13 @@ Required concepts:
 - users/org directory inspection (me, list, read by ID/UPN)
 - Planner plan discovery and task enumeration by plan ID
 - To-Do list discovery and task enumeration by list ID
+- SharePoint site discovery, detail read, list/library enumeration, and list item browsing
 - operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–7). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8). Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds read-only SharePoint/sites inspection surface to the MS365 CLI family (issue #206, task 8)
- New subcommands: `ms365 sites list`, `ms365 sites read`, `ms365 sites lists`, `ms365 sites list-items`
- Client plumbing for gateway API endpoints (`/ms365/sites/*`)
- Operator-friendly human and JSON output for all four commands
- Parity inventory updated to reflect slice 8

## Test plan
- [x] `cargo check -p rune-cli` passes clean
- [x] `cargo test -p rune-cli` — all 505 tests pass
- [ ] Manual verification against live gateway once Graph integration lands

Closes #206 (task 8)