### PR TITLE
feat(cli): add MS365 Teams inspection surface (issue #206 task 9)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -279,6 +279,11 @@ pub enum Ms365Action {
         #[command(subcommand)]
         action: Ms365SitesAction,
     },
+    /// Microsoft Teams inspection.
+    Teams {
+        #[command(subcommand)]
+        action: Ms365TeamsAction,
+    },
 }
 
 /// Auth/config inspection subcommands.
@@ -461,6 +466,48 @@ pub enum Ms365SitesAction {
         list_id: String,
         /// Maximum number of items to return.
         #[arg(long, default_value_t = 50)]
+        limit: u32,
+    },
+}
+
+/// Microsoft Teams subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Ms365TeamsAction {
+    /// List teams the authenticated user belongs to.
+    List {
+        /// Maximum number of teams to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
+    /// List channels in a team.
+    Channels {
+        /// Team ID to list channels from.
+        #[arg(long)]
+        team_id: String,
+        /// Maximum number of channels to return.
+        #[arg(long, default_value_t = 50)]
+        limit: u32,
+    },
+    /// Read details of a single channel.
+    #[command(name = "channel-read")]
+    ChannelRead {
+        /// Team ID that contains the channel.
+        #[arg(long)]
+        team_id: String,
+        /// Channel ID to retrieve.
+        #[arg(long)]
+        id: String,
+    },
+    /// List recent messages in a channel.
+    Messages {
+        /// Team ID that contains the channel.
+        #[arg(long)]
+        team_id: String,
+        /// Channel ID to list messages from.
+        #[arg(long)]
+        channel_id: String,
+        /// Maximum number of messages to return.
+        #[arg(long, default_value_t = 25)]
         limit: u32,
     },
 }
@@ -4944,6 +4991,54 @@ mod subagent_cli_tests {
             Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::TaskRead { list_id, id } } } => {
                 assert_eq!(list_id, "lst1");
                 assert_eq!(id, "task1");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_teams_list() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "list"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::List { limit } } } => {
+                assert_eq!(limit, 25);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_teams_channels() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "channels", "--team-id", "t1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::Channels { team_id, limit } } } => {
+                assert_eq!(team_id, "t1");
+                assert_eq!(limit, 50);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_teams_channel_read() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "channel-read", "--team-id", "t1", "--id", "ch1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::ChannelRead { team_id, id } } } => {
+                assert_eq!(team_id, "t1");
+                assert_eq!(id, "ch1");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_teams_messages() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "messages", "--team-id", "t1", "--channel-id", "ch1"]).unwrap();
+        match cli.command {
+            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::Messages { team_id, channel_id, limit } } } => {
+                assert_eq!(team_id, "t1");
+                assert_eq!(channel_id, "ch1");
+                assert_eq!(limit, 25);
             }
             other => panic!("unexpected: {other:?}"),
         }

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -3046,6 +3046,30 @@ impl GatewayClient {
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
 
+    pub async fn ms365_teams_list(&self, limit: u32) -> Result<crate::output::Ms365TeamsListResponse> {
+        let r = self.http.get(self.url("/ms365/teams"))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_teams_channels(&self, team_id: &str, limit: u32) -> Result<crate::output::Ms365TeamsChannelsResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_teams_channel_read(&self, team_id: &str, id: &str) -> Result<crate::output::Ms365TeamsChannelReadResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels/{id}")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_teams_messages(&self, team_id: &str, channel_id: &str, limit: u32) -> Result<crate::output::Ms365TeamsMessagesResponse> {
+        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels/{channel_id}/messages")))
+            .query(&[("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {
         let r = self.http.post(self.url("/setup")).send().await.context("gateway")?;

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -29,7 +29,7 @@ use cli::{
     ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
     GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
     MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
+    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction, Ms365TeamsAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
     SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
     BackupAction, UpdateAction,
@@ -1247,6 +1247,24 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 Ms365TodoAction::TaskRead { list_id, id } => {
                     let result = client.ms365_todo_task_read(&list_id, &id).await?;
+                    println!("{}", render(&result, format));
+                }
+            },
+            Ms365Action::Teams { action } => match action {
+                Ms365TeamsAction::List { limit } => {
+                    let result = client.ms365_teams_list(limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365TeamsAction::Channels { team_id, limit } => {
+                    let result = client.ms365_teams_channels(&team_id, limit).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365TeamsAction::ChannelRead { team_id, id } => {
+                    let result = client.ms365_teams_channel_read(&team_id, &id).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365TeamsAction::Messages { team_id, channel_id, limit } => {
+                    let result = client.ms365_teams_messages(&team_id, &channel_id, limit).await?;
                     println!("{}", render(&result, format));
                 }
             },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -4116,6 +4116,150 @@ impl fmt::Display for Ms365SiteListItemsResponse {
     }
 }
 
+// ── Teams ────────────────────────────────────────────────────
+
+/// Summary of a Microsoft Teams team (used in list responses).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamSummary {
+    pub id: String,
+    pub display_name: String,
+    pub description: Option<String>,
+}
+
+impl fmt::Display for Ms365TeamSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description.as_deref().unwrap_or("-");
+        write!(f, "  {} — {desc}", self.display_name)
+    }
+}
+
+/// Response from `rune ms365 teams list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamsListResponse {
+    pub teams: Vec<Ms365TeamSummary>,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365TeamsListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Teams: {} team(s)", self.total)?;
+        for t in &self.teams {
+            writeln!(f, "{t}")?;
+            writeln!(f, "    id: {}", t.id)?;
+        }
+        Ok(())
+    }
+}
+
+/// Summary of a Teams channel (used in list responses).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamChannelSummary {
+    pub id: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    pub membership_type: Option<String>,
+}
+
+impl fmt::Display for Ms365TeamChannelSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = self.membership_type.as_deref().unwrap_or("standard");
+        write!(f, "  {} ({kind})", self.display_name)
+    }
+}
+
+/// Response from `rune ms365 teams channels`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamsChannelsResponse {
+    pub channels: Vec<Ms365TeamChannelSummary>,
+    pub team_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365TeamsChannelsResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Team {} — {} channel(s)", self.team_id, self.total)?;
+        for ch in &self.channels {
+            writeln!(f, "{ch}")?;
+            writeln!(f, "    id: {}", ch.id)?;
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 teams channel-read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamsChannelReadResponse {
+    pub id: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    pub membership_type: Option<String>,
+    pub web_url: Option<String>,
+    pub created_at: Option<String>,
+    pub team_id: String,
+}
+
+impl fmt::Display for Ms365TeamsChannelReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "── Channel: {} ──", self.display_name)?;
+        writeln!(f, "  ID:         {}", self.id)?;
+        writeln!(f, "  Team:       {}", self.team_id)?;
+        if let Some(ref desc) = self.description {
+            if !desc.is_empty() {
+                writeln!(f, "  Desc:       {desc}")?;
+            }
+        }
+        if let Some(ref kind) = self.membership_type {
+            writeln!(f, "  Type:       {kind}")?;
+        }
+        if let Some(ref url) = self.web_url {
+            writeln!(f, "  URL:        {url}")?;
+        }
+        if let Some(ref created) = self.created_at {
+            writeln!(f, "  Created:    {created}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Summary of a Teams channel message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamMessageSummary {
+    pub id: String,
+    pub sender: Option<String>,
+    pub created_at: Option<String>,
+    pub subject: Option<String>,
+    pub preview: Option<String>,
+}
+
+impl fmt::Display for Ms365TeamMessageSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let sender = self.sender.as_deref().unwrap_or("(unknown)");
+        let preview = self.preview.as_deref().unwrap_or("");
+        let ts = self.created_at.as_deref().unwrap_or("-");
+        write!(f, "  [{ts}] {sender}: {preview}")
+    }
+}
+
+/// Response from `rune ms365 teams messages`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365TeamsMessagesResponse {
+    pub messages: Vec<Ms365TeamMessageSummary>,
+    pub team_id: String,
+    pub channel_id: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365TeamsMessagesResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Team {} / channel {} — {} message(s)", self.team_id, self.channel_id, self.total)?;
+        for msg in &self.messages {
+            writeln!(f, "{msg}")?;
+            writeln!(f, "    id: {}", msg.id)?;
+        }
+        Ok(())
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         format!("{bytes} B")

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through eighth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, and SharePoint sites inspection.
+First through ninth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, and Teams inspection.
 
 Observed subcommands:
 
@@ -701,6 +701,10 @@ Observed subcommands:
 - `ms365 sites read --id <site_id>` — read details of a single SharePoint site
 - `ms365 sites lists --site-id <id>` — list document libraries/lists in a SharePoint site
 - `ms365 sites list-items --site-id <id> --list-id <id>` — list items in a SharePoint list/library
+- `ms365 teams list` — list Teams the authenticated user belongs to
+- `ms365 teams channels --team-id <id>` — list channels in a team
+- `ms365 teams channel-read --team-id <id> --id <id>` — read details of a single channel
+- `ms365 teams messages --team-id <id> --channel-id <id>` — list recent messages in a channel
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -713,6 +717,7 @@ Required concepts:
 - Planner plan discovery and task enumeration by plan ID
 - To-Do list discovery and task enumeration by list ID
 - SharePoint site discovery, detail read, list/library enumeration, and list item browsing
+- Teams discovery, channel enumeration, channel detail, and channel message listing
 - operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 


### PR DESCRIPTION
## Summary
- Adds narrow Microsoft Teams inspection slice: `teams list`, `teams channels`, `teams channel-read`, `teams messages`
- Client plumbing for Teams gateway/API endpoints (`/ms365/teams/...`)
- Operator-friendly Display output with team/channel/message formatting
- 4 CLI parse tests covering all Teams subcommands
- Parity inventory updated to reflect ninth MS365 slice

Closes #206 (task 9)

## Test plan
- [x] `cargo check -p rune-cli` passes
- [x] All 14 MS365 CLI parse tests pass (10 existing + 4 new Teams tests)
- [ ] Manual smoke test against live MS365 tenant (if available)