### PR TITLE
feat(cli): add MS365 mail send/reply/forward surface (issue #206 task 10)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -313,6 +313,45 @@ pub enum Ms365MailAction {
     },
     /// List mail folders in the authenticated mailbox.
     Folders,
+    /// Send a new mail message.
+    Send {
+        /// Recipient email address(es), comma-separated.
+        #[arg(long, required = true)]
+        to: String,
+        /// Message subject.
+        #[arg(long)]
+        subject: String,
+        /// Message body (plain text).
+        #[arg(long)]
+        body: String,
+        /// CC recipient email address(es), comma-separated.
+        #[arg(long)]
+        cc: Option<String>,
+    },
+    /// Reply to an existing mail message.
+    Reply {
+        /// Message ID to reply to.
+        #[arg(long)]
+        id: String,
+        /// Reply body (plain text).
+        #[arg(long)]
+        body: String,
+        /// Reply to all recipients instead of just the sender.
+        #[arg(long)]
+        reply_all: bool,
+    },
+    /// Forward an existing mail message.
+    Forward {
+        /// Message ID to forward.
+        #[arg(long)]
+        id: String,
+        /// Recipient email address(es), comma-separated.
+        #[arg(long, required = true)]
+        to: String,
+        /// Optional comment to include with the forwarded message.
+        #[arg(long)]
+        comment: Option<String>,
+    },
 }
 
 /// Calendar subcommands.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2960,6 +2960,40 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_mail_send(&self, to: &[String], subject: &str, body: &str, cc: &[String]) -> Result<crate::output::Ms365MailSendResponse> {
+        let payload = serde_json::json!({
+            "to": to,
+            "subject": subject,
+            "body": body,
+            "cc": cc,
+        });
+        let r = self.http.post(self.url("/ms365/mail/send"))
+            .json(&payload)
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_mail_reply(&self, id: &str, body: &str, reply_all: bool) -> Result<crate::output::Ms365MailReplyResponse> {
+        let payload = serde_json::json!({
+            "body": body,
+            "reply_all": reply_all,
+        });
+        let r = self.http.post(self.url(&format!("/ms365/mail/messages/{id}/reply")))
+            .json(&payload)
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_mail_forward(&self, id: &str, to: &[String], comment: Option<&str>) -> Result<crate::output::Ms365MailForwardResponse> {
+        let mut payload = serde_json::json!({
+            "to": to,
+        });
+        if let Some(c) = comment {
+            payload["comment"] = serde_json::json!(c);
+        }
+        let r = self.http.post(self.url(&format!("/ms365/mail/messages/{id}/forward")))
+            .json(&payload)
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
     pub async fn ms365_files_list(&self, path: &str, limit: u32) -> Result<crate::output::Ms365FilesListResponse> {
         let r = self.http.get(self.url("/ms365/files"))
             .query(&[("path", path.to_string()), ("limit", limit.to_string())])

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1187,6 +1187,21 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_mail_folders().await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365MailAction::Send { to, subject, body, cc } => {
+                    let to: Vec<String> = to.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                    let cc: Vec<String> = cc.unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                    let result = client.ms365_mail_send(&to, &subject, &body, &cc).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365MailAction::Reply { id, body, reply_all } => {
+                    let result = client.ms365_mail_reply(&id, &body, reply_all).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365MailAction::Forward { id, to, comment } => {
+                    let to: Vec<String> = to.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                    let result = client.ms365_mail_forward(&id, &to, comment.as_deref()).await?;
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Calendar { action } => match action {
                 Ms365CalendarAction::Upcoming { limit, hours } => {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3576,6 +3576,48 @@ impl fmt::Display for Ms365MailFoldersResponse {
     }
 }
 
+/// Response from `rune ms365 mail send`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailSendResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365MailSendResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
+/// Response from `rune ms365 mail reply`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailReplyResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365MailReplyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
+/// Response from `rune ms365 mail forward`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailForwardResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365MailForwardResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
 // ── Microsoft 365 Files ───────────────────────────────────────────
 
 /// A single OneDrive file/folder item summary.
@@ -7011,6 +7053,30 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["folders"][0]["display_name"], "Inbox");
         assert_eq!(v["folders"][0]["unread_count"], 2);
+    }
+
+    #[test]
+    fn render_ms365_mail_send_human() {
+        let r = Ms365MailSendResponse { success: true, message: "Message sent".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Message sent"));
+    }
+
+    #[test]
+    fn render_ms365_mail_reply_human() {
+        let r = Ms365MailReplyResponse { success: true, message: "Reply sent".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Reply sent"));
+    }
+
+    #[test]
+    fn render_ms365_mail_forward_human() {
+        let r = Ms365MailForwardResponse { success: true, message: "Message forwarded".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Message forwarded"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add , , and  CLI surfaces
- add matching gateway client plumbing and operator-friendly output types
- keep the slice narrowly focused on Microsoft 365 mail mutation flows

Part of #206

## Test plan
- [x] cargo test -p rune-cli -- ms365
- [ ] merge-path CI
