### PR TITLE
feat(cli): add MS365 mail attachment list/read surface (#206)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -368,6 +368,19 @@ pub enum Ms365MailAction {
         #[arg(long)]
         id: String,
     },
+    /// Download attachment content to a local file.
+    #[command(name = "attachment-download")]
+    AttachmentDownload {
+        /// Message ID that owns the attachment.
+        #[arg(long)]
+        message_id: String,
+        /// Attachment ID to download.
+        #[arg(long)]
+        id: String,
+        /// Output file path (defaults to attachment name in current directory).
+        #[arg(long)]
+        output: Option<String>,
+    },
 }
 
 /// Calendar subcommands.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -3004,6 +3004,21 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    /// Download raw attachment content. Returns (filename, bytes).
+    pub async fn ms365_mail_attachment_download(&self, message_id: &str, attachment_id: &str) -> Result<(String, Vec<u8>)> {
+        let meta: crate::output::Ms365MailAttachmentReadResponse = {
+            let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments/{attachment_id}")))
+                .send().await.context("gateway")?;
+            if r.status().is_success() { r.json().await.context("json")? } else { bail!("HTTP {}", r.status()); }
+        };
+        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments/{attachment_id}/content")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() {
+            Ok((meta.name, r.bytes().await.context("bytes")?.to_vec()))
+        } else {
+            bail!("HTTP {}", r.status());
+        }
+    }
     pub async fn ms365_files_list(&self, path: &str, limit: u32) -> Result<crate::output::Ms365FilesListResponse> {
         let r = self.http.get(self.url("/ms365/files"))
             .query(&[("path", path.to_string()), ("limit", limit.to_string())])

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1210,6 +1210,19 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_mail_attachment_read(&message_id, &id).await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365MailAction::AttachmentDownload { message_id, id, output } => {
+                    let (filename, bytes) = client.ms365_mail_attachment_download(&message_id, &id).await?;
+                    let dest = output.unwrap_or_else(|| filename.clone());
+                    tokio::fs::write(&dest, &bytes).await
+                        .with_context(|| format!("failed to write attachment to {dest}"))?;
+                    let result = crate::output::Ms365MailAttachmentDownloadResponse {
+                        attachment_id: id,
+                        filename,
+                        size: bytes.len() as u64,
+                        saved_to: dest,
+                    };
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Calendar { action } => match action {
                 Ms365CalendarAction::Upcoming { limit, hours } => {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3687,6 +3687,25 @@ impl fmt::Display for Ms365MailAttachmentReadResponse {
     }
 }
 
+/// Response for `ms365 mail attachment-download`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365MailAttachmentDownloadResponse {
+    pub attachment_id: String,
+    pub filename: String,
+    pub size: u64,
+    pub saved_to: String,
+}
+
+impl fmt::Display for Ms365MailAttachmentDownloadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "✓ Downloaded: {}", self.filename)?;
+        writeln!(f, "  Attachment: {}", self.attachment_id)?;
+        writeln!(f, "  Size:       {}", format_bytes(self.size))?;
+        writeln!(f, "  Saved to:   {}", self.saved_to)?;
+        Ok(())
+    }
+}
+
 // ── Microsoft 365 Files ───────────────────────────────────────────
 
 /// A single OneDrive file/folder item summary.
@@ -7215,6 +7234,35 @@ mod tests {
         assert_eq!(v["total"], 1);
         assert_eq!(v["attachments"][0]["name"], "doc.docx");
         assert_eq!(v["attachments"][0]["size"], 51200);
+    }
+
+    #[test]
+    fn render_ms365_mail_attachment_download_human() {
+        let r = Ms365MailAttachmentDownloadResponse {
+            attachment_id: "att-1".into(),
+            filename: "report.pdf".into(),
+            size: 204800,
+            saved_to: "/tmp/report.pdf".into(),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Downloaded: report.pdf"));
+        assert!(out.contains("200.0 KB"));
+        assert!(out.contains("/tmp/report.pdf"));
+    }
+
+    #[test]
+    fn render_ms365_mail_attachment_download_json() {
+        let r = Ms365MailAttachmentDownloadResponse {
+            attachment_id: "att-1".into(),
+            filename: "report.pdf".into(),
+            size: 204800,
+            saved_to: "/tmp/report.pdf".into(),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["filename"], "report.pdf");
+        assert_eq!(v["size"], 204800);
+        assert_eq!(v["saved_to"], "/tmp/report.pdf");
     }
 
     #[test]

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read.
+First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download.
 
 Observed subcommands:
 
@@ -707,6 +707,7 @@ Observed subcommands:
 - `ms365 teams messages --team-id <id> --channel-id <id>` — list recent messages in a channel
 - `ms365 mail attachments --id <msg_id>` — list attachments on a mail message
 - `ms365 mail attachment-read --message-id <msg_id> --id <att_id>` — read metadata of a single mail attachment
+- `ms365 mail attachment-download --message-id <msg_id> --id <att_id> [--output <path>]` — download attachment content to a local file
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -720,7 +721,7 @@ Required concepts:
 - To-Do list discovery and task enumeration by list ID
 - SharePoint site discovery, detail read, list/library enumeration, and list item browsing
 - Teams discovery, channel enumeration, channel detail, and channel message listing
-- mail attachment listing by message ID and single-attachment metadata read
+- mail attachment listing by message ID, single-attachment metadata read, and content download
 - operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 


### PR DESCRIPTION
## Summary
- Adds `ms365 mail attachments --id <msg_id>` to list attachments on a message
- Adds `ms365 mail attachment-read --message-id <msg_id> --id <att_id>` to inspect single attachment metadata
- Adds `ms365 mail attachment-download --message-id <msg_id> --id <att_id> [--output <path>]` to download content to a local file
- Client plumbing points at expected gateway `/ms365/mail/messages/{id}/attachments` endpoints
- Parity inventory updated to reflect the new commands

Closes #206 (attachment/download slice)

## Test plan
- [x] `cargo check -p rune-cli` passes
- [x] 5 unit tests pass (`cargo test -p rune-cli -- ms365_mail_attachment`)
- [ ] Manual smoke test against a live MS365 tenant (deferred to gateway integration)