### PR TITLE
feat(cli): add MS365 calendar create/delete/respond surface (#206)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -401,6 +401,45 @@ pub enum Ms365CalendarAction {
         #[arg(long)]
         id: String,
     },
+    /// Create a new calendar event.
+    Create {
+        /// Event subject/title.
+        #[arg(long)]
+        subject: String,
+        /// Start date-time (ISO 8601, e.g. 2026-03-21T14:00:00).
+        #[arg(long)]
+        start: String,
+        /// End date-time (ISO 8601, e.g. 2026-03-21T15:00:00).
+        #[arg(long)]
+        end: String,
+        /// Attendee email address(es), comma-separated.
+        #[arg(long)]
+        attendees: Option<String>,
+        /// Location description.
+        #[arg(long)]
+        location: Option<String>,
+        /// Event body/description (plain text).
+        #[arg(long)]
+        body: Option<String>,
+    },
+    /// Delete a calendar event by ID.
+    Delete {
+        /// Event ID to delete.
+        #[arg(long)]
+        id: String,
+    },
+    /// Respond to a calendar event invitation (accept, decline, or tentatively accept).
+    Respond {
+        /// Event ID to respond to.
+        #[arg(long)]
+        id: String,
+        /// Response: accept, decline, or tentative.
+        #[arg(long)]
+        response: String,
+        /// Optional comment to include with the response.
+        #[arg(long)]
+        comment: Option<String>,
+    },
 }
 
 /// OneDrive file subcommands.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -2950,6 +2950,41 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_calendar_create(&self, subject: &str, start: &str, end: &str, attendees: &[String], location: Option<&str>, body: Option<&str>) -> Result<crate::output::Ms365CalendarCreateResponse> {
+        let mut payload = serde_json::json!({
+            "subject": subject,
+            "start": start,
+            "end": end,
+            "attendees": attendees,
+        });
+        if let Some(loc) = location {
+            payload["location"] = serde_json::json!(loc);
+        }
+        if let Some(b) = body {
+            payload["body"] = serde_json::json!(b);
+        }
+        let r = self.http.post(self.url("/ms365/calendar/events"))
+            .json(&payload)
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_calendar_delete(&self, id: &str) -> Result<crate::output::Ms365CalendarDeleteResponse> {
+        let r = self.http.post(self.url(&format!("/ms365/calendar/events/{id}/delete")))
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
+    pub async fn ms365_calendar_respond(&self, id: &str, response: &str, comment: Option<&str>) -> Result<crate::output::Ms365CalendarRespondResponse> {
+        let mut payload = serde_json::json!({
+            "response": response,
+        });
+        if let Some(c) = comment {
+            payload["comment"] = serde_json::json!(c);
+        }
+        let r = self.http.post(self.url(&format!("/ms365/calendar/events/{id}/respond")))
+            .json(&payload)
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
     pub async fn ms365_auth_status(&self) -> Result<crate::output::Ms365AuthStatusResponse> {
         let r = self.http.get(self.url("/ms365/auth/status"))
             .send().await.context("gateway")?;

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1233,6 +1233,19 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_calendar_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365CalendarAction::Create { subject, start, end, attendees, location, body } => {
+                    let attendees: Vec<String> = attendees.unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                    let result = client.ms365_calendar_create(&subject, &start, &end, &attendees, location.as_deref(), body.as_deref()).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365CalendarAction::Delete { id } => {
+                    let result = client.ms365_calendar_delete(&id).await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365CalendarAction::Respond { id, response, comment } => {
+                    let result = client.ms365_calendar_respond(&id, &response, comment.as_deref()).await?;
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Files { action } => match action {
                 Ms365FilesAction::List { path, limit } => {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3505,6 +3505,48 @@ impl fmt::Display for Ms365CalendarReadResponse {
     }
 }
 
+/// Response from `rune ms365 calendar create`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365CalendarCreateResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365CalendarCreateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
+/// Response from `rune ms365 calendar delete`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365CalendarDeleteResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365CalendarDeleteResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
+/// Response from `rune ms365 calendar respond`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365CalendarRespondResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl fmt::Display for Ms365CalendarRespondResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        write!(f, "{icon} {}", self.message)
+    }
+}
+
 /// Auth/config inspection for Microsoft 365.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ms365AuthStatusResponse {
@@ -7165,6 +7207,47 @@ mod tests {
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Message forwarded"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_create_human() {
+        let r = Ms365CalendarCreateResponse { success: true, message: "Event created".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Event created"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_create_failure() {
+        let r = Ms365CalendarCreateResponse { success: false, message: "Failed to create event".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✗"));
+        assert!(out.contains("Failed to create event"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_delete_human() {
+        let r = Ms365CalendarDeleteResponse { success: true, message: "Event deleted".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Event deleted"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_respond_human() {
+        let r = Ms365CalendarRespondResponse { success: true, message: "Response sent: accepted".into() };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Response sent: accepted"));
+    }
+
+    #[test]
+    fn render_ms365_calendar_create_json() {
+        let r = Ms365CalendarCreateResponse { success: true, message: "Event created".into() };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["message"], "Event created");
     }
 
     #[test]

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download.
+First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download. Eleventh and twelfth slices: mail send/reply/forward and calendar create/delete/respond mutations.
 
 Observed subcommands:
 
@@ -708,6 +708,9 @@ Observed subcommands:
 - `ms365 mail attachments --id <msg_id>` — list attachments on a mail message
 - `ms365 mail attachment-read --message-id <msg_id> --id <att_id>` — read metadata of a single mail attachment
 - `ms365 mail attachment-download --message-id <msg_id> --id <att_id> [--output <path>]` — download attachment content to a local file
+- `ms365 calendar create --subject <s> --start <dt> --end <dt> [--attendees <emails>] [--location <loc>] [--body <text>]` — create a new calendar event
+- `ms365 calendar delete --id <event_id>` — delete a calendar event by ID
+- `ms365 calendar respond --id <event_id> --response <accept|decline|tentative> [--comment <text>]` — respond to a calendar event invitation
 
 Required concepts:
 - auth/config readiness inspection (tenant, client, scopes, token validity)
@@ -722,12 +725,15 @@ Required concepts:
 - SharePoint site discovery, detail read, list/library enumeration, and list item browsing
 - Teams discovery, channel enumeration, channel detail, and channel message listing
 - mail attachment listing by message ID, single-attachment metadata read, and content download
+- calendar event creation (subject, start/end, attendees, location, body)
+- calendar event deletion by ID
+- calendar invitation response (accept, decline, tentative) with optional comment
 - operator-friendly rich output (headers, attendees, body preview, file metadata, user profiles, task progress)
 - JSON and human-readable output
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–8, 10). Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12). Calendar mutation surface (create/delete/respond) added in slice 12. Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds calendar mutation commands: `create`, `delete`, and `respond` to the `ms365 calendar` subcommand family
- Client plumbing for corresponding gateway endpoints (POST to `/ms365/calendar/events`, `.../delete`, `.../respond`)
- Operator-friendly `✓`/`✗` output matching existing mail mutation pattern
- Parity inventory updated to reflect slice 12

## Commands added
- `ms365 calendar create --subject <s> --start <dt> --end <dt> [--attendees <emails>] [--location <loc>] [--body <text>]`
- `ms365 calendar delete --id <event_id>`
- `ms365 calendar respond --id <event_id> --response <accept|decline|tentative> [--comment <text>]`

## Test plan
- [x] 5 new render tests (create human, create failure, delete human, respond human, create json)
- [x] Full rune-cli suite: 522 passed, 0 failed
- [ ] Gateway integration (deferred — no Graph backend yet)