### PR TITLE
feat(cli): add MS365 OneDrive file search surface (#206)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -460,6 +460,15 @@ pub enum Ms365FilesAction {
         #[arg(long)]
         id: String,
     },
+    /// Search for files in OneDrive by name or content.
+    Search {
+        /// Search query string.
+        #[arg(long)]
+        query: String,
+        /// Maximum number of results to return.
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+    },
 }
 
 /// Users/org inspection subcommands.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -3065,6 +3065,12 @@ impl GatewayClient {
             .send().await.context("gateway")?;
         if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
     }
+    pub async fn ms365_files_search(&self, query: &str, limit: u32) -> Result<crate::output::Ms365FilesSearchResponse> {
+        let r = self.http.get(self.url("/ms365/files/search"))
+            .query(&[("query", query.to_string()), ("limit", limit.to_string())])
+            .send().await.context("gateway")?;
+        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    }
     pub async fn ms365_users_me(&self) -> Result<crate::output::Ms365UserProfileResponse> {
         let r = self.http.get(self.url("/ms365/users/me"))
             .send().await.context("gateway")?;

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1256,6 +1256,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_files_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365FilesAction::Search { query, limit } => {
+                    let result = client.ms365_files_search(&query, limit).await?;
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Users { action } => match action {
                 Ms365UsersAction::Me => {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -3829,6 +3829,48 @@ impl fmt::Display for Ms365FileReadResponse {
     }
 }
 
+/// A single search-result item returned by OneDrive search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365FileSearchItem {
+    pub id: String,
+    pub name: String,
+    pub size: u64,
+    pub is_folder: bool,
+    pub last_modified: String,
+    pub web_url: Option<String>,
+    pub parent_path: Option<String>,
+}
+
+impl fmt::Display for Ms365FileSearchItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = if self.is_folder { "DIR " } else { "FILE" };
+        let parent = self.parent_path.as_deref().unwrap_or("");
+        write!(f, "  {kind}  {:<40} {:>10}  {}  {}", self.name, format_bytes(self.size), self.last_modified, parent)
+    }
+}
+
+/// Response from `rune ms365 files search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365FilesSearchResponse {
+    pub items: Vec<Ms365FileSearchItem>,
+    pub query: String,
+    pub total: u32,
+}
+
+impl fmt::Display for Ms365FilesSearchResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "OneDrive search: \"{}\"  ({} result(s))", self.query, self.total)?;
+        if self.items.is_empty() {
+            writeln!(f, "  (no matches)")?;
+        } else {
+            for item in &self.items {
+                writeln!(f, "{item}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 // ── MS365 Users/Org ─────────────────────────────────────────────
 
 /// A single user profile (used by `me`, `read`, and inside list responses).
@@ -7457,6 +7499,62 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["users"][0]["display_name"], "Alice");
         assert_eq!(v["total"], 1);
+    }
+
+    #[test]
+    fn render_ms365_files_search_human() {
+        let r = Ms365FilesSearchResponse {
+            items: vec![Ms365FileSearchItem {
+                id: "item-1".into(),
+                name: "report.docx".into(),
+                size: 2048,
+                is_folder: false,
+                last_modified: "2026-03-20T10:00:00Z".into(),
+                web_url: Some("https://example.com/report.docx".into()),
+                parent_path: Some("/Documents".into()),
+            }],
+            query: "report".into(),
+            total: 1,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("OneDrive search: \"report\""));
+        assert!(out.contains("1 result(s)"));
+        assert!(out.contains("report.docx"));
+        assert!(out.contains("FILE"));
+        assert!(out.contains("/Documents"));
+    }
+
+    #[test]
+    fn render_ms365_files_search_empty() {
+        let r = Ms365FilesSearchResponse {
+            items: vec![],
+            query: "nonexistent".into(),
+            total: 0,
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("(no matches)"));
+    }
+
+    #[test]
+    fn render_ms365_files_search_json() {
+        let r = Ms365FilesSearchResponse {
+            items: vec![Ms365FileSearchItem {
+                id: "item-1".into(),
+                name: "notes.txt".into(),
+                size: 512,
+                is_folder: false,
+                last_modified: "2026-03-20T10:00:00Z".into(),
+                web_url: None,
+                parent_path: None,
+            }],
+            query: "notes".into(),
+            total: 1,
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["query"], "notes");
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["items"][0]["name"], "notes.txt");
     }
 }
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download. Eleventh and twelfth slices: mail send/reply/forward and calendar create/delete/respond mutations.
+First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download. Eleventh and twelfth slices: mail send/reply/forward and calendar create/delete/respond mutations. Thirteenth slice: OneDrive file search.
 
 Observed subcommands:
 
@@ -688,6 +688,7 @@ Observed subcommands:
 - `ms365 calendar read --id <event_id>` — read full detail of a single calendar event
 - `ms365 files list` — list files/folders in a OneDrive path
 - `ms365 files read --id <item_id>` — read metadata for a single OneDrive item
+- `ms365 files search --query <text> [--limit <n>]` — search OneDrive files by name or content
 - `ms365 users me` — show authenticated user's profile
 - `ms365 users list` — list users in the organization directory
 - `ms365 users read --id <user_id>` — read a single user's profile by ID or UPN
@@ -717,7 +718,7 @@ Required concepts:
 - mailbox folder discovery and selection (`--folder`)
 - result limiting (`--limit`)
 - calendar look-ahead window (`--hours`)
-- OneDrive folder path browsing (`--path`)
+- OneDrive folder path browsing (`--path`) and file search (`--query`)
 - single-item read-detail by ID (`--id`)
 - users/org directory inspection (me, list, read by ID/UPN)
 - Planner plan discovery and task enumeration by plan ID
@@ -733,7 +734,7 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12). Calendar mutation surface (create/delete/respond) added in slice 12. Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Gateway endpoint and Graph integration deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `ms365 files search --query <text> [--limit <n>]` command for searching OneDrive files by name or content
- Extends the existing files list/read surface with search capability (slice 13 of #206)
- Client plumbing calls `GET /ms365/files/search` with query and limit parameters
- Operator-friendly output shows kind (DIR/FILE), name, size, modified date, and parent path

## Changes
- **cli.rs**: `Search` variant on `Ms365FilesAction` with `--query` and `--limit` args
- **client.rs**: `ms365_files_search()` method
- **output.rs**: `Ms365FileSearchItem` and `Ms365FilesSearchResponse` structs with Display impls
- **lib.rs**: dispatch for the new search command
- **PARITY-INVENTORY.md**: updated for slice 13

## Test plan
- [x] 3 new tests: human rendering, empty results, JSON rendering
- [x] All 47 MS365 tests pass
- [x] `cargo check -p rune-cli` clean