### PR TITLE
feat(gateway): add ms365 auth status backend slice (#233)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,12 @@ run_migrations = true
 [channels]
 # telegram_token = "YOUR_BOT_TOKEN"
 
+[ms365]
+# tenant_id = "00000000-0000-0000-0000-000000000000"
+# client_id = "11111111-1111-1111-1111-111111111111"
+# user_principal = "user@example.com"
+# scopes = ["User.Read", "Mail.Read", "Calendars.Read"]
+
 [models]
 default_model = "oc-01-anthropic/claude-sonnet-4-6"
 

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -26,6 +26,8 @@ pub struct AppConfig {
     pub models: ModelsConfig,
     pub channels: ChannelsConfig,
     #[serde(default)]
+    pub ms365: Ms365Config,
+    #[serde(default)]
     pub agents: AgentsConfig,
     #[serde(default)]
     pub runtime: RuntimeConfig,
@@ -376,6 +378,19 @@ impl Default for GatewayConfig {
             tls: TlsConfig::default(),
         }
     }
+}
+
+/// Microsoft 365 configuration used by the gateway status surface.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ms365Config {
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub client_id: Option<String>,
+    #[serde(default)]
+    pub user_principal: Option<String>,
+    #[serde(default)]
+    pub scopes: Vec<String>,
 }
 
 /// TLS termination settings for the gateway.

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -3533,6 +3533,36 @@ pub async fn get_tool_execution(Path(id): Path<String>) -> Result<Json<Value>, G
     )))
 }
 
+// ── Microsoft 365 ───────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct Ms365AuthStatusResponse {
+    pub authenticated: bool,
+    pub tenant_id: Option<String>,
+    pub client_id: Option<String>,
+    pub user_principal: Option<String>,
+    pub scopes: Vec<String>,
+    pub token_expires_at: Option<String>,
+    pub token_valid: bool,
+}
+
+/// `GET /ms365/auth/status` — return Microsoft 365 auth/config readiness.
+pub async fn ms365_auth_status(
+    State(state): State<AppState>,
+) -> Result<Json<Ms365AuthStatusResponse>, GatewayError> {
+    let config = state.config.read().await;
+
+    Ok(Json(Ms365AuthStatusResponse {
+        authenticated: false,
+        tenant_id: config.ms365.tenant_id.clone(),
+        client_id: config.ms365.client_id.clone(),
+        user_principal: config.ms365.user_principal.clone(),
+        scopes: config.ms365.scopes.clone(),
+        token_expires_at: None,
+        token_valid: false,
+    }))
+}
+
 // ── Auth ────────────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -403,6 +403,8 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/stt/transcribe", post(routes::stt_transcribe))
         .route("/stt/enable", post(routes::stt_enable))
         .route("/stt/disable", post(routes::stt_disable))
+        // Microsoft 365 routes
+        .route("/ms365/auth/status", get(routes::ms365_auth_status))
         // Config editor routes
         .route(
             "/config",

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -2635,6 +2635,90 @@ async fn health_is_public_even_with_auth() {
 }
 
 #[tokio::test]
+async fn ms365_auth_status_returns_unconfigured_response() {
+    let app = build_test_app(None);
+
+    let response = app
+        .oneshot(
+            Request::get("/ms365/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["authenticated"], false);
+    assert_eq!(json["tenant_id"], Value::Null);
+    assert_eq!(json["client_id"], Value::Null);
+    assert_eq!(json["user_principal"], Value::Null);
+    assert_eq!(json["scopes"], serde_json::json!([]));
+    assert_eq!(json["token_valid"], false);
+    assert_eq!(json["token_expires_at"], Value::Null);
+}
+
+#[tokio::test]
+async fn ms365_auth_status_returns_configured_response() {
+    let mut config = AppConfig::default();
+    config.ms365.tenant_id = Some("tenant-123".to_string());
+    config.ms365.client_id = Some("client-456".to_string());
+    config.ms365.user_principal = Some("user@example.com".to_string());
+    config.ms365.scopes = vec!["Mail.Read".to_string(), "Calendars.Read".to_string()];
+
+    let app = build_test_app_with_config(config, None);
+
+    let response = app
+        .oneshot(
+            Request::get("/ms365/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["authenticated"], false);
+    assert_eq!(json["tenant_id"], "tenant-123");
+    assert_eq!(json["client_id"], "client-456");
+    assert_eq!(json["user_principal"], "user@example.com");
+    assert_eq!(
+        json["scopes"],
+        serde_json::json!(["Mail.Read", "Calendars.Read"])
+    );
+    assert_eq!(json["token_valid"], false);
+    assert_eq!(json["token_expires_at"], Value::Null);
+}
+
+#[tokio::test]
+async fn ms365_auth_status_requires_auth_when_gateway_token_enabled() {
+    let app = build_test_app(Some(TEST_AUTH_TOKEN.to_string()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ms365/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::get("/ms365/auth/status")
+                .header(header::AUTHORIZATION, format!("Bearer {TEST_AUTH_TOKEN}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn device_management_requires_gateway_token_even_when_auth_enabled() {
     let app = build_test_app(Some(TEST_AUTH_TOKEN.to_string()));
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -736,7 +736,7 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Gateway endpoint and Graph integration deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Backend foundation begins with `/ms365/auth/status` only; the rest of the gateway `/ms365` family and Graph integration remain deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the first real server-side Microsoft 365 backend slice: `GET /ms365/auth/status`
- introduce a minimal `ms365` config surface for truthful readiness reporting
- add protected gateway route coverage for configured/unconfigured/auth-required behavior
- update parity docs to mark backend foundation as beginning with `/ms365/auth/status`

## Validation
- `CARGO_NET_OFFLINE=true cargo test -p rune-config --lib -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test -p rune-gateway --test route_tests -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo clippy --workspace --all-targets -- -D warnings`

## Unblocks
- #232
- narrows the remaining parent scope on #206
