### PR TITLE
feat(gateway): add ms365 planner mutation routes (#235)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -27,6 +27,7 @@ use rune_config::{
     AppConfig, MemoryLevel, ModelBootstrap, PathsProfile, RuntimeMode, StorageBackend,
 };
 use rune_core::ToolCategory;
+use rune_gateway::ms365::GraphMs365PlannerService;
 use rune_gateway::{Services, init_logging, start};
 use rune_mcp::discovery::McpServerConfig as RuntimeMcpServerConfig;
 use rune_mcp::{McpManager, McpToolExecutor};
@@ -704,6 +705,7 @@ async fn build_services(
         process_manager,
         capabilities,
         device_repo,
+        ms365_planner_service: Arc::new(GraphMs365PlannerService::new()),
     };
 
     Ok((services, embedded_pg, session_loop))
@@ -1425,7 +1427,9 @@ impl ToolExecutor for AppToolExecutor {
             "memory_search" | "memory_get" => self.memory.execute(call).await,
             "memory_write" => {
                 // Append to today's daily note file (memory/YYYY-MM-DD.md)
-                let text = call.arguments.get("text")
+                let text = call
+                    .arguments
+                    .get("text")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
@@ -1467,16 +1471,14 @@ impl ToolExecutor for AppToolExecutor {
             }
             "sessions_spawn" | "sessions_send" => self.spawn.execute(call).await,
             "subagents" => self.subagents.execute(call).await,
-            "web_fetch" => {
-                match rune_tools::web_fetch_tool::WebFetchToolExecutor::new() {
-                    Ok(executor) => executor.execute(call).await,
-                    Err(e) => Err(e),
-                }
-            }
+            "web_fetch" => match rune_tools::web_fetch_tool::WebFetchToolExecutor::new() {
+                Ok(executor) => executor.execute(call).await,
+                Err(e) => Err(e),
+            },
             "git" => {
-                rune_tools::git_tool::GitToolExecutor::new(
-                    self.workspace_root.clone()
-                ).execute(call).await
+                rune_tools::git_tool::GitToolExecutor::new(self.workspace_root.clone())
+                    .execute(call)
+                    .await
             }
             other if other.contains("__") => match &self.mcp {
                 Some(mcp) => mcp.execute(call).await,

--- a/crates/rune-gateway/src/lib.rs
+++ b/crates/rune-gateway/src/lib.rs
@@ -5,6 +5,7 @@ mod auth;
 mod error;
 pub mod events;
 mod logging;
+pub mod ms365;
 pub mod pairing;
 mod routes;
 mod server;
@@ -24,7 +25,6 @@ pub use server::{GatewayHandle, Services, build_router, start};
 pub use state::{AppState, SessionEvent};
 pub use supervisor::BackgroundSupervisor;
 pub(crate) use supervisor::{SupervisorDeps, run_job_lifecycle};
-
 
 pub fn telegram_adapter_from_token(token: &str) -> rune_channels::TelegramAdapter {
     rune_channels::TelegramAdapter::new(token)

--- a/crates/rune-gateway/src/ms365.rs
+++ b/crates/rune-gateway/src/ms365.rs
@@ -1,0 +1,513 @@
+//! Microsoft 365 gateway services.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+const GRAPH_BASE_URL_ENV: &str = "RUNE_MS365_GRAPH_BASE_URL";
+const ACCESS_TOKEN_ENV: &str = "RUNE_MS365_ACCESS_TOKEN";
+const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.microsoft.com/v1.0";
+
+/// Gateway request for creating a Planner task.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreatePlannerTaskRequest {
+    pub plan_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub bucket_id: Option<String>,
+    #[serde(default)]
+    pub assigned_to: Option<String>,
+    #[serde(default)]
+    pub due_date: Option<String>,
+    #[serde(default)]
+    pub priority: Option<u8>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl CreatePlannerTaskRequest {
+    pub fn validate(&self) -> Result<(), Ms365PlannerServiceError> {
+        if self.plan_id.trim().is_empty() {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task plan_id is required".to_string(),
+            ));
+        }
+        if self.title.trim().is_empty() {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task title is required".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Gateway request for updating a Planner task.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdatePlannerTaskRequest {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub bucket_id: Option<String>,
+    #[serde(default)]
+    pub assigned_to: Option<String>,
+    #[serde(default)]
+    pub due_date: Option<String>,
+    #[serde(default)]
+    pub priority: Option<u8>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl UpdatePlannerTaskRequest {
+    pub fn validate(&self) -> Result<(), Ms365PlannerServiceError> {
+        if !self.has_changes() {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task update requires at least one mutable field".to_string(),
+            ));
+        }
+
+        if let Some(title) = &self.title
+            && title.trim().is_empty()
+        {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task title cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn has_changes(&self) -> bool {
+        self.title.is_some()
+            || self.bucket_id.is_some()
+            || self.assigned_to.is_some()
+            || self.due_date.is_some()
+            || self.priority.is_some()
+            || self.description.is_some()
+    }
+}
+
+/// Gateway-facing Planner task shape used by mutation routes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlannerTask {
+    pub id: String,
+    pub title: String,
+    pub plan_id: String,
+    pub bucket_id: Option<String>,
+    pub percent_complete: u8,
+    pub assigned_to: Option<String>,
+    pub due_date: Option<String>,
+    pub created_at: Option<String>,
+    pub priority: Option<u8>,
+    pub description: Option<String>,
+}
+
+/// Errors surfaced by the Planner service boundary.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum Ms365PlannerServiceError {
+    #[error("{0}")]
+    Validation(String),
+    #[error("{0}")]
+    NotConfigured(String),
+    #[error("unauthorized")]
+    Unauthorized,
+    #[error("{0}")]
+    Forbidden(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("{0}")]
+    Upstream(String),
+}
+
+#[async_trait]
+pub trait Ms365PlannerService: Send + Sync {
+    async fn create_task(
+        &self,
+        request: CreatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError>;
+
+    async fn update_task(
+        &self,
+        id: &str,
+        request: UpdatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError>;
+
+    async fn complete_task(&self, id: &str) -> Result<PlannerTask, Ms365PlannerServiceError>;
+}
+
+/// Planner mutation service backed by Microsoft Graph.
+pub struct GraphMs365PlannerService {
+    client: Client,
+}
+
+impl Default for GraphMs365PlannerService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphMs365PlannerService {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    fn graph_base_url(&self) -> String {
+        std::env::var(GRAPH_BASE_URL_ENV)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_GRAPH_BASE_URL.to_string())
+            .trim_end_matches('/')
+            .to_string()
+    }
+
+    fn access_token(&self) -> Result<String, Ms365PlannerServiceError> {
+        std::env::var(ACCESS_TOKEN_ENV)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| value.trim().to_string())
+            .ok_or_else(|| {
+                Ms365PlannerServiceError::NotConfigured(format!(
+                    "Planner backend requires {ACCESS_TOKEN_ENV} to call Microsoft Graph"
+                ))
+            })
+    }
+
+    fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+    ) -> Result<reqwest::RequestBuilder, Ms365PlannerServiceError> {
+        let token = self.access_token()?;
+        let url = format!("{}{}", self.graph_base_url(), path);
+        Ok(self
+            .client
+            .request(method, url)
+            .bearer_auth(token)
+            .header(reqwest::header::ACCEPT, "application/json"))
+    }
+
+    async fn send_json<T: serde::de::DeserializeOwned>(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> Result<T, Ms365PlannerServiceError> {
+        let response = builder
+            .send()
+            .await
+            .map_err(|error| Ms365PlannerServiceError::Upstream(error.to_string()))?;
+
+        if response.status().is_success() {
+            response
+                .json::<T>()
+                .await
+                .map_err(|error| Ms365PlannerServiceError::Upstream(error.to_string()))
+        } else {
+            Err(map_graph_error(response).await)
+        }
+    }
+
+    async fn patch_json(
+        &self,
+        path: &str,
+        if_match: &str,
+        body: Value,
+    ) -> Result<(), Ms365PlannerServiceError> {
+        let response = self
+            .request(reqwest::Method::PATCH, path)?
+            .header(reqwest::header::IF_MATCH, if_match)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| Ms365PlannerServiceError::Upstream(error.to_string()))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_graph_error(response).await)
+        }
+    }
+
+    async fn fetch_task(&self, id: &str) -> Result<GraphPlannerTask, Ms365PlannerServiceError> {
+        self.send_json(self.request(reqwest::Method::GET, &format!("/planner/tasks/{id}"))?)
+            .await
+    }
+
+    async fn fetch_task_details(
+        &self,
+        id: &str,
+    ) -> Result<GraphPlannerTaskDetails, Ms365PlannerServiceError> {
+        self.send_json(self.request(
+            reqwest::Method::GET,
+            &format!("/planner/tasks/{id}/details"),
+        )?)
+        .await
+    }
+
+    async fn read_task(&self, id: &str) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        let task = self.fetch_task(id).await?;
+        let details = self.fetch_task_details(id).await?;
+        Ok(PlannerTask::from_graph(task, details))
+    }
+}
+
+#[async_trait]
+impl Ms365PlannerService for GraphMs365PlannerService {
+    async fn create_task(
+        &self,
+        request: CreatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        request.validate()?;
+
+        let mut body = Map::new();
+        body.insert("planId".to_string(), json!(request.plan_id.trim()));
+        body.insert("title".to_string(), json!(request.title.trim()));
+
+        if let Some(bucket_id) = request
+            .bucket_id
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            body.insert("bucketId".to_string(), json!(bucket_id.trim()));
+        }
+
+        if let Some(due_date) = request
+            .due_date
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            body.insert("dueDateTime".to_string(), json!(due_date.trim()));
+        }
+
+        if let Some(priority) = request.priority {
+            body.insert("priority".to_string(), json!(priority));
+        }
+
+        if let Some(assignee) = request
+            .assigned_to
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            body.insert(
+                "assignments".to_string(),
+                planner_assignments_value(assignee),
+            );
+        }
+
+        let created: GraphPlannerTask = self
+            .send_json(
+                self.request(reqwest::Method::POST, "/planner/tasks")?
+                    .json(&Value::Object(body)),
+            )
+            .await?;
+
+        if let Some(description) = request.description {
+            let trimmed = description.trim().to_string();
+            if !trimmed.is_empty() {
+                let details = self.fetch_task_details(&created.id).await?;
+                self.patch_json(
+                    &format!("/planner/tasks/{}/details", created.id),
+                    details.etag.as_deref().ok_or_else(|| {
+                        Ms365PlannerServiceError::Upstream(
+                            "planner task details response missing etag".to_string(),
+                        )
+                    })?,
+                    json!({ "description": trimmed }),
+                )
+                .await?;
+            }
+        }
+
+        self.read_task(&created.id).await
+    }
+
+    async fn update_task(
+        &self,
+        id: &str,
+        request: UpdatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        if id.trim().is_empty() {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task id is required".to_string(),
+            ));
+        }
+        request.validate()?;
+
+        let task_id = id.trim();
+        let mut task_patch = Map::new();
+
+        if let Some(title) = &request.title {
+            task_patch.insert("title".to_string(), json!(title.trim()));
+        }
+
+        if let Some(bucket_id) = request
+            .bucket_id
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            task_patch.insert("bucketId".to_string(), json!(bucket_id.trim()));
+        }
+
+        if let Some(due_date) = request
+            .due_date
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            task_patch.insert("dueDateTime".to_string(), json!(due_date.trim()));
+        }
+
+        if let Some(priority) = request.priority {
+            task_patch.insert("priority".to_string(), json!(priority));
+        }
+
+        if let Some(assignee) = request
+            .assigned_to
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            task_patch.insert(
+                "assignments".to_string(),
+                planner_assignments_value(assignee),
+            );
+        }
+
+        if !task_patch.is_empty() {
+            let current = self.fetch_task(task_id).await?;
+            self.patch_json(
+                &format!("/planner/tasks/{task_id}"),
+                current.etag.as_deref().ok_or_else(|| {
+                    Ms365PlannerServiceError::Upstream(
+                        "planner task response missing etag".to_string(),
+                    )
+                })?,
+                Value::Object(task_patch),
+            )
+            .await?;
+        }
+
+        if let Some(description) = request.description {
+            let details = self.fetch_task_details(task_id).await?;
+            self.patch_json(
+                &format!("/planner/tasks/{task_id}/details"),
+                details.etag.as_deref().ok_or_else(|| {
+                    Ms365PlannerServiceError::Upstream(
+                        "planner task details response missing etag".to_string(),
+                    )
+                })?,
+                json!({ "description": description.trim() }),
+            )
+            .await?;
+        }
+
+        self.read_task(task_id).await
+    }
+
+    async fn complete_task(&self, id: &str) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        if id.trim().is_empty() {
+            return Err(Ms365PlannerServiceError::Validation(
+                "planner task id is required".to_string(),
+            ));
+        }
+
+        let task_id = id.trim();
+        let current = self.fetch_task(task_id).await?;
+        self.patch_json(
+            &format!("/planner/tasks/{task_id}"),
+            current.etag.as_deref().ok_or_else(|| {
+                Ms365PlannerServiceError::Upstream("planner task response missing etag".to_string())
+            })?,
+            json!({ "percentComplete": 100 }),
+        )
+        .await?;
+
+        self.read_task(task_id).await
+    }
+}
+
+fn planner_assignments_value(assignee: &str) -> Value {
+    json!({
+        assignee.trim(): {
+            "@odata.type": "microsoft.graph.plannerAssignment",
+            "orderHint": " !"
+        }
+    })
+}
+
+async fn map_graph_error(response: reqwest::Response) -> Ms365PlannerServiceError {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    let message = graph_error_message(&body)
+        .unwrap_or_else(|| format!("Microsoft Graph planner request failed with HTTP {status}"));
+
+    match status {
+        reqwest::StatusCode::BAD_REQUEST => Ms365PlannerServiceError::Validation(message),
+        reqwest::StatusCode::UNAUTHORIZED => Ms365PlannerServiceError::Unauthorized,
+        reqwest::StatusCode::FORBIDDEN => Ms365PlannerServiceError::Forbidden(message),
+        reqwest::StatusCode::NOT_FOUND => Ms365PlannerServiceError::NotFound(message),
+        _ => Ms365PlannerServiceError::Upstream(message),
+    }
+}
+
+fn graph_error_message(body: &str) -> Option<String> {
+    let json = serde_json::from_str::<Value>(body).ok()?;
+    json.get("error")
+        .and_then(|value| value.get("message"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphPlannerTask {
+    id: String,
+    title: String,
+    #[serde(rename = "planId")]
+    plan_id: String,
+    #[serde(rename = "bucketId")]
+    bucket_id: Option<String>,
+    #[serde(rename = "percentComplete", default)]
+    percent_complete: u8,
+    #[serde(rename = "dueDateTime")]
+    due_date: Option<String>,
+    #[serde(rename = "createdDateTime")]
+    created_at: Option<String>,
+    priority: Option<u8>,
+    #[serde(default)]
+    assignments: HashMap<String, Value>,
+    #[serde(rename = "@odata.etag")]
+    etag: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphPlannerTaskDetails {
+    description: Option<String>,
+    #[serde(rename = "@odata.etag")]
+    etag: Option<String>,
+}
+
+impl PlannerTask {
+    fn from_graph(task: GraphPlannerTask, details: GraphPlannerTaskDetails) -> Self {
+        let assigned_to = if task.assignments.is_empty() {
+            None
+        } else {
+            let mut assignees = task.assignments.into_keys().collect::<Vec<_>>();
+            assignees.sort();
+            assignees.into_iter().next()
+        };
+
+        Self {
+            id: task.id,
+            title: task.title,
+            plan_id: task.plan_id,
+            bucket_id: task.bucket_id,
+            percent_complete: task.percent_complete,
+            assigned_to,
+            due_date: task.due_date,
+            created_at: task.created_at,
+            priority: task.priority,
+            description: details.description,
+        }
+    }
+}

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -25,6 +25,9 @@ use rune_tools::process_tool::{PersistedProcessInfo, ProcessInfo};
 use serde_json::Value;
 
 use crate::error::GatewayError;
+use crate::ms365::{
+    CreatePlannerTaskRequest, Ms365PlannerServiceError, PlannerTask, UpdatePlannerTaskRequest,
+};
 use crate::pairing::{DeviceRole, PairingError, PairingRequest, StoredPairedDevice};
 use crate::state::{AppState, SessionEvent};
 use crate::ws::active_ws_connections;
@@ -240,10 +243,7 @@ pub async fn spa_index() -> Response {
     spa_response_for_path("")
 }
 
-pub async fn spa_handler(
-    headers: axum::http::HeaderMap,
-    uri: axum::http::Uri,
-) -> Response {
+pub async fn spa_handler(headers: axum::http::HeaderMap, uri: axum::http::Uri) -> Response {
     let path = uri.path().trim_start_matches('/');
 
     // If the request is for an API path or doesn't accept HTML, return 404
@@ -1480,10 +1480,7 @@ pub async fn agent_steer(
         .map_err(|_| GatewayError::SessionNotFound(format!("agent session {id} not found")))?;
 
     let now = chrono::Utc::now();
-    let note = format!(
-        "[steer] operator instruction injected: {}",
-        body.message
-    );
+    let note = format!("[steer] operator instruction injected: {}", body.message);
 
     // Append a status_note transcript item for auditability.
     state
@@ -1527,10 +1524,7 @@ pub async fn agent_steer(
     Ok(Json(AgentSteerResponse {
         session_id: id.to_string(),
         accepted: true,
-        detail: format!(
-            "steering instruction delivered to session {}",
-            id
-        ),
+        detail: format!("steering instruction delivered to session {}", id),
     }))
 }
 
@@ -2226,18 +2220,14 @@ pub async fn kill_process(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, GatewayError> {
-    state
-        .process_manager
-        .kill(&id)
-        .await
-        .map_err(|e| match e {
-            rune_tools::ToolError::ExecutionFailed(message)
-                if message.contains("process not found") =>
-            {
-                GatewayError::BadRequest(message)
-            }
-            other => GatewayError::Internal(other.to_string()),
-        })?;
+    state.process_manager.kill(&id).await.map_err(|e| match e {
+        rune_tools::ToolError::ExecutionFailed(message)
+            if message.contains("process not found") =>
+        {
+            GatewayError::BadRequest(message)
+        }
+        other => GatewayError::Internal(other.to_string()),
+    })?;
 
     Ok(Json(ActionResponse {
         success: true,
@@ -2511,20 +2501,19 @@ pub async fn telegram_webhook(
                             );
                             if let Ok(file_resp) = client.get(&download_url).send().await {
                                 if let Ok(bytes) = file_resp.bytes().await {
-                                    let mime_type = media_mime
-                                        .clone()
-                                        .unwrap_or_else(|| {
-                                            if message.get("voice").is_some() {
-                                                "audio/ogg".to_string()
-                                            } else if message.get("audio").is_some() {
-                                                "audio/mpeg".to_string()
-                                            } else {
-                                                "audio/ogg".to_string()
-                                            }
-                                        });
+                                    let mime_type = media_mime.clone().unwrap_or_else(|| {
+                                        if message.get("voice").is_some() {
+                                            "audio/ogg".to_string()
+                                        } else if message.get("audio").is_some() {
+                                            "audio/mpeg".to_string()
+                                        } else {
+                                            "audio/ogg".to_string()
+                                        }
+                                    });
 
                                     let engine = engine_lock.read().await;
-                                    if let Ok(result) = engine.transcribe(&bytes, &mime_type).await {
+                                    if let Ok(result) = engine.transcribe(&bytes, &mime_type).await
+                                    {
                                         if let Some(root) = payload.as_object_mut() {
                                             root.insert(
                                                 "media_transcription".to_string(),
@@ -2561,12 +2550,18 @@ pub async fn telegram_webhook(
             .get("chat")
             .and_then(|chat| chat.get("id"))
             .and_then(|id| id.as_i64())
-            .ok_or_else(|| GatewayError::BadRequest("telegram message missing chat.id".to_string()))?;
+            .ok_or_else(|| {
+                GatewayError::BadRequest("telegram message missing chat.id".to_string())
+            })?;
 
         let sender = message
             .get("from")
-            .and_then(|from| from.get("username").and_then(|v| v.as_str()).map(str::to_string)
-                .or_else(|| from.get("id").map(|v| v.to_string())))
+            .and_then(|from| {
+                from.get("username")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .or_else(|| from.get("id").map(|v| v.to_string()))
+            })
             .unwrap_or_else(|| "unknown".to_string());
 
         let routing_key = format!("{}:{}", chat_id, sender);
@@ -2614,10 +2609,13 @@ pub async fn telegram_webhook(
             if content.trim().is_empty() {
                 content = transcribed.to_string();
             } else {
-                content = format!("{}
+                content = format!(
+                    "{}
 
 [Voice transcription]
-{}", content, transcribed);
+{}",
+                    content, transcribed
+                );
             }
         }
 
@@ -2648,7 +2646,8 @@ pub async fn telegram_webhook(
                     .map(|id| id.to_string())
                     .unwrap_or_default();
                 let client = reqwest::Client::new();
-                let send_url = format!("https://api.telegram.org/bot{}/sendMessage", expected_token);
+                let send_url =
+                    format!("https://api.telegram.org/bot{}/sendMessage", expected_token);
                 let mut params = serde_json::json!({
                     "chat_id": chat_id,
                     "text": reply,
@@ -3222,10 +3221,9 @@ pub async fn tts_synthesize(
     .map_err(|e| GatewayError::Internal(e.to_string()))?;
 
     if body.channel.as_deref() == Some("telegram") {
-        let chat_id = body
-            .chat_id
-            .as_deref()
-            .ok_or_else(|| GatewayError::BadRequest("chat_id is required for Telegram TTS delivery".to_string()))?;
+        let chat_id = body.chat_id.as_deref().ok_or_else(|| {
+            GatewayError::BadRequest("chat_id is required for Telegram TTS delivery".to_string())
+        })?;
         let bot_token = state
             .config
             .read()
@@ -3234,7 +3232,8 @@ pub async fn tts_synthesize(
             .telegram_token
             .clone()
             .ok_or_else(|| GatewayError::BadRequest("Telegram not configured".to_string()))?;
-        let adapter: rune_channels::TelegramAdapter = crate::telegram_adapter_from_token(&bot_token);
+        let adapter: rune_channels::TelegramAdapter =
+            crate::telegram_adapter_from_token(&bot_token);
         let receipt = adapter
             .send_audio_bytes(
                 chat_id,
@@ -3563,6 +3562,68 @@ pub async fn ms365_auth_status(
     }))
 }
 
+#[derive(Serialize)]
+pub struct Ms365PlannerTaskMutationResponse {
+    pub task: PlannerTask,
+}
+
+/// `POST /ms365/planner/tasks` — create a Microsoft Planner task.
+pub async fn ms365_planner_create_task(
+    State(state): State<AppState>,
+    Json(request): Json<CreatePlannerTaskRequest>,
+) -> Result<(StatusCode, Json<Ms365PlannerTaskMutationResponse>), GatewayError> {
+    let task = state
+        .ms365_planner_service
+        .create_task(request)
+        .await
+        .map_err(map_ms365_planner_service_error)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(Ms365PlannerTaskMutationResponse { task }),
+    ))
+}
+
+/// `POST /ms365/planner/tasks/{id}` — update a Microsoft Planner task.
+pub async fn ms365_planner_update_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(request): Json<UpdatePlannerTaskRequest>,
+) -> Result<Json<Ms365PlannerTaskMutationResponse>, GatewayError> {
+    let task = state
+        .ms365_planner_service
+        .update_task(&id, request)
+        .await
+        .map_err(map_ms365_planner_service_error)?;
+
+    Ok(Json(Ms365PlannerTaskMutationResponse { task }))
+}
+
+/// `POST /ms365/planner/tasks/{id}/complete` — mark a Microsoft Planner task complete.
+pub async fn ms365_planner_complete_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Ms365PlannerTaskMutationResponse>, GatewayError> {
+    let task = state
+        .ms365_planner_service
+        .complete_task(&id)
+        .await
+        .map_err(map_ms365_planner_service_error)?;
+
+    Ok(Json(Ms365PlannerTaskMutationResponse { task }))
+}
+
+fn map_ms365_planner_service_error(error: Ms365PlannerServiceError) -> GatewayError {
+    match error {
+        Ms365PlannerServiceError::Validation(message)
+        | Ms365PlannerServiceError::NotFound(message) => GatewayError::BadRequest(message),
+        Ms365PlannerServiceError::NotConfigured(message)
+        | Ms365PlannerServiceError::Upstream(message) => GatewayError::Internal(message),
+        Ms365PlannerServiceError::Unauthorized => GatewayError::Unauthorized,
+        Ms365PlannerServiceError::Forbidden(message) => GatewayError::Forbidden(message),
+    }
+}
+
 // ── Auth ────────────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -3770,7 +3831,11 @@ fn probe_writable(dir: &std::path::Path) -> bool {
     }
 }
 
-fn gateway_path_hint(path: &std::path::Path, mode: &rune_config::RuntimeMode, writable: bool) -> String {
+fn gateway_path_hint(
+    path: &std::path::Path,
+    mode: &rune_config::RuntimeMode,
+    writable: bool,
+) -> String {
     match (mode, writable) {
         (rune_config::RuntimeMode::Standalone, false) => {
             format!("Fix permissions: chmod u+w {}", path.display())
@@ -3984,7 +4049,11 @@ fn build_configure_items(
     let provider_count = config.models.providers.len();
     items.push(ConfigureItem {
         name: "model_providers".into(),
-        status: if provider_count > 0 { "configured" } else { "needed" },
+        status: if provider_count > 0 {
+            "configured"
+        } else {
+            "needed"
+        },
         message: if provider_count > 0 {
             format!("{provider_count} provider(s) configured")
         } else {
@@ -4030,7 +4099,11 @@ fn build_configure_items(
     // TTS / STT (optional)
     items.push(ConfigureItem {
         name: "tts".into(),
-        status: if tts_available { "configured" } else { "skipped" },
+        status: if tts_available {
+            "configured"
+        } else {
+            "skipped"
+        },
         message: if tts_available {
             "TTS engine available".into()
         } else {
@@ -4039,7 +4112,11 @@ fn build_configure_items(
     });
     items.push(ConfigureItem {
         name: "stt".into(),
-        status: if stt_available { "configured" } else { "skipped" },
+        status: if stt_available {
+            "configured"
+        } else {
+            "skipped"
+        },
         message: if stt_available {
             "STT engine available".into()
         } else {
@@ -4051,7 +4128,11 @@ fn build_configure_items(
     let ch = &capabilities.channels;
     items.push(ConfigureItem {
         name: "channels".into(),
-        status: if ch.is_empty() { "skipped" } else { "configured" },
+        status: if ch.is_empty() {
+            "skipped"
+        } else {
+            "configured"
+        },
         message: if ch.is_empty() {
             "no channels enabled (optional)".into()
         } else {
@@ -4130,7 +4211,10 @@ mod tests {
     fn hint_standalone_missing_path() {
         let p = PathBuf::from("/home/user/.rune/db");
         let hint = gateway_path_hint(&p, &rune_config::RuntimeMode::Standalone, true);
-        assert!(hint.contains("mkdir -p"), "expected mkdir hint, got: {hint}");
+        assert!(
+            hint.contains("mkdir -p"),
+            "expected mkdir hint, got: {hint}"
+        );
     }
 
     #[test]
@@ -4144,10 +4228,7 @@ mod tests {
     fn hint_server_missing_path() {
         let p = PathBuf::from("/data/db");
         let hint = gateway_path_hint(&p, &rune_config::RuntimeMode::Server, true);
-        assert!(
-            hint.contains("volume"),
-            "expected volume hint, got: {hint}"
-        );
+        assert!(hint.contains("volume"), "expected volume hint, got: {hint}");
     }
 
     #[test]
@@ -4166,7 +4247,8 @@ mod tests {
         let base = tmp.path().to_path_buf();
         // Create all 9 subdirs
         for sub in &[
-            "db", "sessions", "memory", "media", "skills", "plugins", "logs", "backups", "config", "secrets",
+            "db", "sessions", "memory", "media", "skills", "plugins", "logs", "backups", "config",
+            "secrets",
         ] {
             std::fs::create_dir(base.join(sub)).unwrap();
         }
@@ -4189,7 +4271,11 @@ mod tests {
         let checks = storage_path_checks(&config);
         assert_eq!(checks.len(), 10);
         for c in &checks {
-            assert_eq!(c.status, "pass", "expected pass for {}: {}", c.name, c.message);
+            assert_eq!(
+                c.status, "pass",
+                "expected pass for {}: {}",
+                c.name, c.message
+            );
         }
     }
 
@@ -4215,7 +4301,11 @@ mod tests {
         };
         let checks = storage_path_checks(&config);
         for c in &checks {
-            assert_eq!(c.status, "warn", "expected warn for {}: {}", c.name, c.message);
+            assert_eq!(
+                c.status, "warn",
+                "expected warn for {}: {}",
+                c.name, c.message
+            );
         }
     }
 }

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -14,8 +14,8 @@ use tracing::info;
 use rune_config::{AppConfig, Capabilities};
 use rune_models::ModelProvider;
 use rune_runtime::{
-    HookRegistry, PluginLoader, PluginRegistry,
-    SessionEngine, SkillLoader, SkillRegistry, TurnExecutor,
+    HookRegistry, PluginLoader, PluginRegistry, SessionEngine, SkillLoader, SkillRegistry,
+    TurnExecutor,
     heartbeat::HeartbeatRunner,
     scheduler::{ReminderStore, Scheduler},
 };
@@ -32,6 +32,7 @@ use tokio::sync::RwLock;
 
 use crate::auth::bearer_auth;
 use crate::error::GatewayError;
+use crate::ms365::Ms365PlannerService;
 use crate::pairing::DeviceRegistry;
 use crate::routes;
 use crate::state::{AppState, SessionEvent};
@@ -80,6 +81,7 @@ pub struct Services {
     pub process_manager: ProcessManager,
     pub capabilities: Capabilities,
     pub device_repo: Arc<dyn DeviceRepo>,
+    pub ms365_planner_service: Arc<dyn Ms365PlannerService>,
 }
 
 /// Start the gateway HTTP server.
@@ -134,7 +136,13 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         .map(|key| {
             let provider: Box<dyn rune_stt::SttProvider> = Box::new(OpenAiStt::new(
                 key,
-                services.config.media.stt.base_url.clone().unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                services
+                    .config
+                    .media
+                    .stt
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
                 services.config.media.stt.api_version.clone(),
                 services.config.media.stt.model.clone(),
             ));
@@ -192,37 +200,40 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         event_tx,
         tts_engine,
         stt_engine,
+        ms365_planner_service: services.ms365_planner_service,
     };
 
     // Build operator delivery for heartbeat/scheduled output to Telegram.
     // Looks up the operator's chat_id from the most recent Channel session's
     // channel_ref (format: "{chat_id}:{sender}").
-    let operator_delivery: Option<Arc<dyn crate::supervisor::OperatorDelivery>> =
-        if let Some(ref tg_token) = tg_token_for_delivery {
-            let session_repo = &state.session_repo;
-            let chat_id = session_repo
-                .list(50, 0)
-                .await
-                .ok()
-                .and_then(|sessions| {
-                    sessions.into_iter()
-                        .find(|s| s.channel_ref.is_some())
-                        .and_then(|s| s.channel_ref)
-                        .and_then(|r| r.split(':').next().map(String::from))
-                });
-            if let Some(chat_id) = chat_id {
-                info!(chat_id = %chat_id, "heartbeat delivery target resolved from session DB");
-                Some(Arc::new(crate::supervisor::TelegramOperatorDelivery::new(
-                    tg_token.clone(),
-                    chat_id,
-                )))
-            } else {
-                info!("no Telegram sessions found yet — heartbeat delivery will be configured after first message");
-                None
-            }
+    let operator_delivery: Option<Arc<dyn crate::supervisor::OperatorDelivery>> = if let Some(
+        ref tg_token,
+    ) =
+        tg_token_for_delivery
+    {
+        let session_repo = &state.session_repo;
+        let chat_id = session_repo.list(50, 0).await.ok().and_then(|sessions| {
+            sessions
+                .into_iter()
+                .find(|s| s.channel_ref.is_some())
+                .and_then(|s| s.channel_ref)
+                .and_then(|r| r.split(':').next().map(String::from))
+        });
+        if let Some(chat_id) = chat_id {
+            info!(chat_id = %chat_id, "heartbeat delivery target resolved from session DB");
+            Some(Arc::new(crate::supervisor::TelegramOperatorDelivery::new(
+                tg_token.clone(),
+                chat_id,
+            )))
         } else {
+            info!(
+                "no Telegram sessions found yet — heartbeat delivery will be configured after first message"
+            );
             None
-        };
+        }
+    } else {
+        None
+    };
 
     let supervisor_deps = SupervisorDeps {
         heartbeat: state.heartbeat.clone(),
@@ -239,9 +250,7 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
     let app = build_router(state, auth_token);
 
     // Validate TLS config before attempting to bind.
-    tls_config
-        .validate()
-        .map_err(GatewayError::Internal)?;
+    tls_config.validate().map_err(GatewayError::Internal)?;
 
     let mut supervisor = BackgroundSupervisor::new();
     supervisor.start(supervisor_deps);
@@ -320,7 +329,10 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/api/dashboard/summary", get(routes::dashboard_summary))
         .route("/api/dashboard/models", get(routes::dashboard_models))
         .route("/api/dashboard/sessions", get(routes::dashboard_sessions))
-        .route("/api/dashboard/diagnostics", get(routes::dashboard_diagnostics))
+        .route(
+            "/api/dashboard/diagnostics",
+            get(routes::dashboard_diagnostics),
+        )
         .route("/cron/status", get(routes::cron_status))
         .route("/cron", get(routes::cron_list).post(routes::cron_add))
         .route("/cron/wake", post(routes::cron_wake))
@@ -405,6 +417,18 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/stt/disable", post(routes::stt_disable))
         // Microsoft 365 routes
         .route("/ms365/auth/status", get(routes::ms365_auth_status))
+        .route(
+            "/ms365/planner/tasks",
+            post(routes::ms365_planner_create_task),
+        )
+        .route(
+            "/ms365/planner/tasks/{id}",
+            post(routes::ms365_planner_update_task),
+        )
+        .route(
+            "/ms365/planner/tasks/{id}/complete",
+            post(routes::ms365_planner_complete_task),
+        )
         // Config editor routes
         .route(
             "/config",

--- a/crates/rune-gateway/src/state.rs
+++ b/crates/rune-gateway/src/state.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use rune_config::{AppConfig, Capabilities};
 use rune_models::ModelProvider;
 use rune_runtime::{
-    HookRegistry, PluginLoader, PluginRegistry,
-    SessionEngine, SkillLoader, SkillRegistry, TurnExecutor,
+    HookRegistry, PluginLoader, PluginRegistry, SessionEngine, SkillLoader, SkillRegistry,
+    TurnExecutor,
     heartbeat::HeartbeatRunner,
     scheduler::{ReminderStore, Scheduler},
 };
@@ -19,6 +19,7 @@ use rune_tools::process_tool::ProcessManager;
 use rune_tts::TtsEngine;
 use tokio::sync::{RwLock, broadcast};
 
+use crate::ms365::Ms365PlannerService;
 use crate::pairing::DeviceRegistry;
 
 /// Events emitted for WebSocket subscribers.
@@ -87,4 +88,6 @@ pub struct AppState {
     pub tts_engine: Option<Arc<RwLock<TtsEngine>>>,
     /// Speech-to-text engine (constructed when STT API key is configured).
     pub stt_engine: Option<Arc<RwLock<SttEngine>>>,
+    /// Microsoft 365 Planner mutation backend.
+    pub ms365_planner_service: Arc<dyn Ms365PlannerService>,
 }

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -34,6 +34,10 @@ use rune_tools::process_tool::ProcessManager;
 use rune_tools::{ToolCall, ToolError, ToolExecutor, ToolRegistry, ToolResult};
 use std::collections::HashMap;
 
+use rune_gateway::ms365::{
+    CreatePlannerTaskRequest, Ms365PlannerService, Ms365PlannerServiceError, PlannerTask,
+    UpdatePlannerTaskRequest,
+};
 use rune_gateway::{AppState, SessionEvent, build_router, pairing::DeviceRegistry};
 
 fn test_capabilities(tool_count: usize) -> Arc<Capabilities> {
@@ -723,6 +727,104 @@ impl ToolExecutor for FakeToolExecutor {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PlannerMutationCall {
+    Create(CreatePlannerTaskRequest),
+    Update {
+        id: String,
+        request: UpdatePlannerTaskRequest,
+    },
+    Complete {
+        id: String,
+    },
+}
+
+#[derive(Debug)]
+struct FakeMs365PlannerService {
+    create_response: Result<PlannerTask, Ms365PlannerServiceError>,
+    update_response: Result<PlannerTask, Ms365PlannerServiceError>,
+    complete_response: Result<PlannerTask, Ms365PlannerServiceError>,
+    calls: Mutex<Vec<PlannerMutationCall>>,
+}
+
+impl Default for FakeMs365PlannerService {
+    fn default() -> Self {
+        Self {
+            create_response: Err(Ms365PlannerServiceError::NotConfigured(
+                "test planner service not configured".to_string(),
+            )),
+            update_response: Err(Ms365PlannerServiceError::NotConfigured(
+                "test planner service not configured".to_string(),
+            )),
+            complete_response: Err(Ms365PlannerServiceError::NotConfigured(
+                "test planner service not configured".to_string(),
+            )),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl FakeMs365PlannerService {
+    fn with_create_response(response: Result<PlannerTask, Ms365PlannerServiceError>) -> Self {
+        Self {
+            create_response: response,
+            ..Self::default()
+        }
+    }
+
+    fn with_update_response(response: Result<PlannerTask, Ms365PlannerServiceError>) -> Self {
+        Self {
+            update_response: response,
+            ..Self::default()
+        }
+    }
+
+    fn with_complete_response(response: Result<PlannerTask, Ms365PlannerServiceError>) -> Self {
+        Self {
+            complete_response: response,
+            ..Self::default()
+        }
+    }
+
+    async fn calls(&self) -> Vec<PlannerMutationCall> {
+        self.calls.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl Ms365PlannerService for FakeMs365PlannerService {
+    async fn create_task(
+        &self,
+        request: CreatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        self.calls
+            .lock()
+            .await
+            .push(PlannerMutationCall::Create(request));
+        self.create_response.clone()
+    }
+
+    async fn update_task(
+        &self,
+        id: &str,
+        request: UpdatePlannerTaskRequest,
+    ) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        self.calls.lock().await.push(PlannerMutationCall::Update {
+            id: id.to_string(),
+            request,
+        });
+        self.update_response.clone()
+    }
+
+    async fn complete_task(&self, id: &str) -> Result<PlannerTask, Ms365PlannerServiceError> {
+        self.calls
+            .lock()
+            .await
+            .push(PlannerMutationCall::Complete { id: id.to_string() });
+        self.complete_response.clone()
+    }
+}
+
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 const TEST_AUTH_TOKEN: &str = "test-secret-token";
@@ -735,9 +837,21 @@ fn build_test_app_with_config(config: AppConfig, auth_token: Option<String>) -> 
     build_test_app_parts(config, auth_token).0
 }
 
+fn test_ms365_planner_service() -> Arc<dyn Ms365PlannerService> {
+    Arc::new(FakeMs365PlannerService::default())
+}
+
 fn build_test_app_parts(
+    config: AppConfig,
+    auth_token: Option<String>,
+) -> (axum::Router, Arc<MemDeviceRepo>) {
+    build_test_app_parts_with_planner_service(config, auth_token, test_ms365_planner_service())
+}
+
+fn build_test_app_parts_with_planner_service(
     mut config: AppConfig,
     auth_token: Option<String>,
+    ms365_planner_service: Arc<dyn Ms365PlannerService>,
 ) -> (axum::Router, Arc<MemDeviceRepo>) {
     let session_repo = Arc::new(MemSessionRepo::new());
     let turn_repo = Arc::new(MemTurnRepo::new());
@@ -812,6 +926,7 @@ fn build_test_app_parts(
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service,
     };
 
     (build_router(state, auth_token), device_repo)
@@ -825,6 +940,21 @@ async fn body_json(response: axum::http::Response<Body>) -> Value {
 async fn body_text(response: axum::http::Response<Body>) -> String {
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+fn sample_planner_task(id: &str) -> PlannerTask {
+    PlannerTask {
+        id: id.to_string(),
+        title: "Draft release notes".to_string(),
+        plan_id: "plan-123".to_string(),
+        bucket_id: Some("bucket-456".to_string()),
+        percent_complete: 25,
+        assigned_to: Some("user-789".to_string()),
+        due_date: Some("2026-03-30T12:00:00Z".to_string()),
+        created_at: Some("2026-03-22T10:15:00Z".to_string()),
+        priority: Some(5),
+        description: Some("Collect user-facing changes.".to_string()),
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -900,6 +1030,7 @@ async fn ws_rpc_status_matches_http_status_basics() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let main_permit = lane_queue.acquire(Lane::Main).await;
@@ -1002,6 +1133,7 @@ enabled: true
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1116,6 +1248,7 @@ async fn status_reports_configured_lane_capacities() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -1207,6 +1340,7 @@ async fn ws_rpc_runtime_lanes_reports_lane_queue_stats() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let main_permit = lane_queue.acquire(Lane::Main).await;
@@ -1332,6 +1466,7 @@ async fn ws_rpc_health_reports_session_count() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1436,6 +1571,7 @@ async fn ws_rpc_cron_list_and_get_surface_delivery_mode() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1559,6 +1695,7 @@ async fn ws_rpc_session_status_surfaces_defaults_and_usage() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1699,6 +1836,7 @@ async fn ws_rpc_session_get_includes_last_turn_timestamps() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1786,6 +1924,7 @@ async fn ws_rpc_session_status_rejects_invalid_uuid() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -1870,6 +2009,7 @@ async fn ws_handle_text_message_subscribe_unsubscribe_and_errors() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -2014,6 +2154,7 @@ async fn ws_handle_text_message_supports_event_and_global_subscriptions() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -2154,6 +2295,7 @@ async fn ws_subscribe_bumps_state_version_once_and_non_subscription_rpc_does_not
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -2259,6 +2401,7 @@ async fn ws_handle_text_message_dispatches_rpc_errors() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -2716,6 +2859,211 @@ async fn ms365_auth_status_requires_auth_when_gateway_token_enabled() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ms365_planner_create_task_forwards_request_and_returns_created_task() {
+    let planner_service = Arc::new(FakeMs365PlannerService::with_create_response(Ok(
+        sample_planner_task("task-create-1"),
+    )));
+    let (app, _device_repo) = build_test_app_parts_with_planner_service(
+        AppConfig::default(),
+        None,
+        planner_service.clone(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/planner/tasks")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "plan_id": "plan-123",
+                        "title": "Draft release notes",
+                        "bucket_id": "bucket-456",
+                        "assigned_to": "user-789",
+                        "due_date": "2026-03-30T12:00:00Z",
+                        "priority": 5,
+                        "description": "Collect user-facing changes."
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let json = body_json(response).await;
+    assert_eq!(json["task"]["id"], "task-create-1");
+    assert_eq!(json["task"]["plan_id"], "plan-123");
+    assert_eq!(json["task"]["title"], "Draft release notes");
+    assert_eq!(json["task"]["percent_complete"], 25);
+
+    let calls = planner_service.calls().await;
+    assert_eq!(
+        calls,
+        vec![PlannerMutationCall::Create(CreatePlannerTaskRequest {
+            plan_id: "plan-123".to_string(),
+            title: "Draft release notes".to_string(),
+            bucket_id: Some("bucket-456".to_string()),
+            assigned_to: Some("user-789".to_string()),
+            due_date: Some("2026-03-30T12:00:00Z".to_string()),
+            priority: Some(5),
+            description: Some("Collect user-facing changes.".to_string()),
+        })]
+    );
+}
+
+#[tokio::test]
+async fn ms365_planner_update_task_forwards_request_and_returns_updated_task() {
+    let planner_service = Arc::new(FakeMs365PlannerService::with_update_response(Ok(
+        sample_planner_task("task-update-1"),
+    )));
+    let (app, _device_repo) = build_test_app_parts_with_planner_service(
+        AppConfig::default(),
+        None,
+        planner_service.clone(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/planner/tasks/task-update-1")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "title": "Finalize release notes",
+                        "description": "Ship the final draft."
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["task"]["id"], "task-update-1");
+    assert_eq!(json["task"]["title"], "Draft release notes");
+
+    let calls = planner_service.calls().await;
+    assert_eq!(
+        calls,
+        vec![PlannerMutationCall::Update {
+            id: "task-update-1".to_string(),
+            request: UpdatePlannerTaskRequest {
+                title: Some("Finalize release notes".to_string()),
+                bucket_id: None,
+                assigned_to: None,
+                due_date: None,
+                priority: None,
+                description: Some("Ship the final draft.".to_string()),
+            },
+        }]
+    );
+}
+
+#[tokio::test]
+async fn ms365_planner_update_task_rejects_empty_patch() {
+    let planner_service = Arc::new(FakeMs365PlannerService::with_update_response(Err(
+        Ms365PlannerServiceError::Validation(
+            "planner task update requires at least one mutable field".to_string(),
+        ),
+    )));
+    let (app, _device_repo) =
+        build_test_app_parts_with_planner_service(AppConfig::default(), None, planner_service);
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/planner/tasks/task-update-1")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert!(
+        json["message"]
+            .as_str()
+            .unwrap()
+            .contains("planner task update requires at least one mutable field")
+    );
+}
+
+#[tokio::test]
+async fn ms365_planner_complete_task_forwards_id_and_returns_completed_task() {
+    let mut task = sample_planner_task("task-complete-1");
+    task.percent_complete = 100;
+
+    let planner_service = Arc::new(FakeMs365PlannerService::with_complete_response(Ok(task)));
+    let (app, _device_repo) = build_test_app_parts_with_planner_service(
+        AppConfig::default(),
+        None,
+        planner_service.clone(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/planner/tasks/task-complete-1/complete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["task"]["id"], "task-complete-1");
+    assert_eq!(json["task"]["percent_complete"], 100);
+
+    let calls = planner_service.calls().await;
+    assert_eq!(
+        calls,
+        vec![PlannerMutationCall::Complete {
+            id: "task-complete-1".to_string(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn ms365_planner_mutation_routes_require_auth_when_gateway_token_enabled() {
+    let app = build_test_app(Some(TEST_AUTH_TOKEN.to_string()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ms365/planner/tasks")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "plan_id": "plan-123",
+                        "title": "Draft release notes"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/planner/tasks/task-complete-1/complete")
+                .header(header::AUTHORIZATION, format!("Bearer {TEST_AUTH_TOKEN}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 #[tokio::test]
@@ -3706,6 +4054,7 @@ async fn send_message_and_transcript_with_shared_state() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -3930,6 +4279,7 @@ async fn get_session_status_surfaces_subagent_metadata() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -4767,8 +5117,7 @@ enabled: false
 #[tokio::test]
 async fn skills_detail_route_returns_skill_and_missing_error() {
     let mut config = AppConfig::default();
-    let skills_dir =
-        std::env::temp_dir().join(format!("rune-gw-skill-detail-{}", Uuid::now_v7()));
+    let skills_dir = std::env::temp_dir().join(format!("rune-gw-skill-detail-{}", Uuid::now_v7()));
     std::fs::create_dir_all(skills_dir.join("alpha")).unwrap();
     std::fs::write(
         skills_dir.join("alpha/SKILL.md"),
@@ -4804,7 +5153,10 @@ enabled: true
     assert_eq!(json["name"], "alpha");
     assert_eq!(json["description"], "Alpha skill");
     assert_eq!(json["enabled"], true);
-    assert_eq!(json["source_dir"], skills_dir.join("alpha").display().to_string());
+    assert_eq!(
+        json["source_dir"],
+        skills_dir.join("alpha").display().to_string()
+    );
     assert!(
         json["binary_path"]
             .as_str()
@@ -4927,6 +5279,7 @@ async fn list_sessions_filters_by_channel_and_activity() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -5175,6 +5528,7 @@ async fn reminders_list_includes_outcome_fields() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -5274,6 +5628,7 @@ async fn reminders_cancel_returns_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -5388,6 +5743,7 @@ async fn agent_steer_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -5406,16 +5762,23 @@ async fn agent_steer_success() {
     let json = body_json(response).await;
     assert_eq!(json["session_id"], agent_id.to_string());
     assert_eq!(json["accepted"], true);
-    assert!(json["detail"].as_str().unwrap().contains("steering instruction delivered"));
+    assert!(
+        json["detail"]
+            .as_str()
+            .unwrap()
+            .contains("steering instruction delivered")
+    );
 
     // Verify transcript got a status_note.
     let items = transcript_repo.list_by_session(agent_id).await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].kind, "status_note");
-    assert!(items[0].payload["content"]
-        .as_str()
-        .unwrap()
-        .contains("focus on tests"));
+    assert!(
+        items[0].payload["content"]
+            .as_str()
+            .unwrap()
+            .contains("focus on tests")
+    );
 
     // Verify metadata was updated.
     let session = session_repo.find_by_id(agent_id).await.unwrap();
@@ -5528,6 +5891,7 @@ async fn agent_kill_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let app = build_router(state, None);
@@ -5557,10 +5921,12 @@ async fn agent_kill_success() {
     let items = transcript_repo.list_by_session(agent_id).await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].kind, "status_note");
-    assert!(items[0].payload["content"]
-        .as_str()
-        .unwrap()
-        .contains("no longer needed"));
+    assert!(
+        items[0].payload["content"]
+            .as_str()
+            .unwrap()
+            .contains("no longer needed")
+    );
 }
 
 #[tokio::test]
@@ -5671,6 +6037,7 @@ async fn ws_rpc_agent_steer_and_kill() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_planner_service: test_ms365_planner_service(),
     };
 
     let dispatcher = RpcDispatcher::new(state);
@@ -5724,11 +6091,7 @@ async fn ws_rpc_agent_steer_and_kill() {
 async fn configure_returns_items_with_default_config() {
     let app = build_test_app(None);
     let response = app
-        .oneshot(
-            Request::post("/configure")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::post("/configure").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -5737,7 +6100,12 @@ async fn configure_returns_items_with_default_config() {
 
     // With default config: no providers, no auth → success should be false
     assert_eq!(json["success"], false);
-    assert!(json["detail"].as_str().unwrap().contains("need configuration"));
+    assert!(
+        json["detail"]
+            .as_str()
+            .unwrap()
+            .contains("need configuration")
+    );
 
     // Items array should exist and contain expected keys
     let items = json["items"].as_array().unwrap();
@@ -5752,7 +6120,10 @@ async fn configure_returns_items_with_default_config() {
     assert!(names.contains(&"mcp_servers"));
 
     // model_providers should be "needed" with default config
-    let mp = items.iter().find(|i| i["name"] == "model_providers").unwrap();
+    let mp = items
+        .iter()
+        .find(|i| i["name"] == "model_providers")
+        .unwrap();
     assert_eq!(mp["status"], "needed");
 }
 
@@ -5760,11 +6131,7 @@ async fn configure_returns_items_with_default_config() {
 async fn setup_returns_same_shape_as_configure() {
     let app = build_test_app(None);
     let response = app
-        .oneshot(
-            Request::post("/setup")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::post("/setup").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -5808,7 +6175,10 @@ async fn configure_with_providers_reports_configured() {
     let items = json["items"].as_array().unwrap();
 
     // model_providers should be "configured"
-    let mp = items.iter().find(|i| i["name"] == "model_providers").unwrap();
+    let mp = items
+        .iter()
+        .find(|i| i["name"] == "model_providers")
+        .unwrap();
     assert_eq!(mp["status"], "configured");
     assert!(mp["message"].as_str().unwrap().contains("1 provider"));
 

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -736,7 +736,7 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Backend foundation begins with `/ms365/auth/status` only; the rest of the gateway `/ms365` family and Graph integration remain deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Backend foundation now includes `/ms365/auth/status` plus Planner mutation routes for task create/update/complete to unblock #232; the rest of the gateway `/ms365` family remains deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the real server-side Planner mutation backend routes:
  - `POST /ms365/planner/tasks`
  - `POST /ms365/planner/tasks/:id`
  - `POST /ms365/planner/tasks/:id/complete`
- wire gateway/server/state to the new Planner backend service layer
- add focused route tests for auth and request/response forwarding
- update parity docs to record the shipped backend planner mutation foundation

## Validation
- `CARGO_NET_OFFLINE=true cargo check -p rune-gateway`
- focused gateway route tests in the worktree

## Unblocks
- #232
