### PR TITLE
feat(cli): add ms365 planner mutation surface (#232)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -524,6 +524,57 @@ pub enum Ms365PlannerAction {
         #[arg(long)]
         id: String,
     },
+    /// Create a new Planner task.
+    Create {
+        /// Plan ID that will own the task.
+        #[arg(long)]
+        plan_id: String,
+        /// Task title.
+        #[arg(long)]
+        title: String,
+        /// Optional bucket ID for the new task.
+        #[arg(long)]
+        bucket_id: Option<String>,
+        /// Optional due date-time (ISO 8601).
+        #[arg(long)]
+        due_date: Option<String>,
+        /// Optional task description/body.
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Update Planner task details or progress.
+    #[command(group(
+        ArgGroup::new("planner_task_update_changes")
+            .required(true)
+            .multiple(true)
+            .args(["title", "bucket_id", "due_date", "description", "percent_complete"])
+    ))]
+    Update {
+        /// Task ID to update.
+        #[arg(long)]
+        id: String,
+        /// New task title.
+        #[arg(long)]
+        title: Option<String>,
+        /// New bucket ID.
+        #[arg(long)]
+        bucket_id: Option<String>,
+        /// New due date-time (ISO 8601).
+        #[arg(long)]
+        due_date: Option<String>,
+        /// New task description/body.
+        #[arg(long)]
+        description: Option<String>,
+        /// Progress percentage from 0 to 100.
+        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+        percent_complete: Option<u8>,
+    },
+    /// Mark a Planner task complete.
+    Complete {
+        /// Task ID to mark complete.
+        #[arg(long)]
+        id: String,
+    },
 }
 
 /// Microsoft To-Do subcommands.
@@ -704,26 +755,40 @@ pub enum PluginsAction {
     /// List installed plugins.
     List,
     /// Show details for a specific plugin.
-    Info { /// Plugin name.
-        name: String },
+    Info {
+        /// Plugin name.
+        name: String,
+    },
     /// Install a plugin from a path or URL.
-    Install { /// Plugin source (local path or URL).
-        source: String },
+    Install {
+        /// Plugin source (local path or URL).
+        source: String,
+    },
     /// Uninstall a plugin.
-    Uninstall { /// Plugin name.
-        name: String },
+    Uninstall {
+        /// Plugin name.
+        name: String,
+    },
     /// Enable an installed plugin.
-    Enable { /// Plugin name.
-        name: String },
+    Enable {
+        /// Plugin name.
+        name: String,
+    },
     /// Disable an installed plugin.
-    Disable { /// Plugin name.
-        name: String },
+    Disable {
+        /// Plugin name.
+        name: String,
+    },
     /// Update an installed plugin.
-    Update { /// Plugin name.
-        name: String },
+    Update {
+        /// Plugin name.
+        name: String,
+    },
     /// Run diagnostic checks on a plugin.
-    Doctor { /// Plugin name.
-        name: String },
+    Doctor {
+        /// Plugin name.
+        name: String,
+    },
 }
 
 /// Hook lifecycle actions.
@@ -732,22 +797,32 @@ pub enum HooksAction {
     /// List configured hooks.
     List,
     /// Show details for a specific hook.
-    Info { /// Hook name.
-        name: String },
+    Info {
+        /// Hook name.
+        name: String,
+    },
     /// Validate hook configuration and report issues.
     Check,
     /// Enable a configured hook.
-    Enable { /// Hook name.
-        name: String },
+    Enable {
+        /// Hook name.
+        name: String,
+    },
     /// Disable a configured hook.
-    Disable { /// Hook name.
-        name: String },
+    Disable {
+        /// Hook name.
+        name: String,
+    },
     /// Install a hook from a path or URL.
-    Install { /// Hook source (local path or URL).
-        source: String },
+    Install {
+        /// Hook source (local path or URL).
+        source: String,
+    },
     /// Update an installed hook.
-    Update { /// Hook name.
-        name: String },
+    Update {
+        /// Hook name.
+        name: String,
+    },
 }
 
 #[derive(Debug, Clone, Args)]
@@ -1816,7 +1891,6 @@ pub enum SecretsAction {
         input: String,
     },
 }
-
 
 #[derive(Debug, Subcommand)]
 pub enum BackupAction {
@@ -3262,7 +3336,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn parse_config_reload() {
         let cli = Cli::try_parse_from(["rune", "config", "reload"]).unwrap();
@@ -3300,7 +3373,9 @@ mod tests {
     fn parse_config_export_default() {
         let cli = Cli::try_parse_from(["rune", "config", "export"]).unwrap();
         match cli.command {
-            Command::Config { action: ConfigAction::Export { output } } => {
+            Command::Config {
+                action: ConfigAction::Export { output },
+            } => {
                 assert_eq!(output, "-");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -3311,7 +3386,9 @@ mod tests {
     fn parse_config_export_file() {
         let cli = Cli::try_parse_from(["rune", "config", "export", "/tmp/out.toml"]).unwrap();
         match cli.command {
-            Command::Config { action: ConfigAction::Export { output } } => {
+            Command::Config {
+                action: ConfigAction::Export { output },
+            } => {
                 assert_eq!(output, "/tmp/out.toml");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -3321,14 +3398,21 @@ mod tests {
     #[test]
     fn parse_process_list() {
         let cli = Cli::try_parse_from(["rune", "process", "list"]).unwrap();
-        assert!(matches!(cli.command, Command::Process { action: ProcessAction::List }));
+        assert!(matches!(
+            cli.command,
+            Command::Process {
+                action: ProcessAction::List
+            }
+        ));
     }
 
     #[test]
     fn parse_process_get() {
         let cli = Cli::try_parse_from(["rune", "process", "get", "abc123"]).unwrap();
         match cli.command {
-            Command::Process { action: ProcessAction::Get { id } } => assert_eq!(id, "abc123"),
+            Command::Process {
+                action: ProcessAction::Get { id },
+            } => assert_eq!(id, "abc123"),
             other => panic!("unexpected command: {other:?}"),
         }
     }
@@ -3337,7 +3421,9 @@ mod tests {
     fn parse_process_kill() {
         let cli = Cli::try_parse_from(["rune", "process", "kill", "abc123"]).unwrap();
         match cli.command {
-            Command::Process { action: ProcessAction::Kill { id } } => assert_eq!(id, "abc123"),
+            Command::Process {
+                action: ProcessAction::Kill { id },
+            } => assert_eq!(id, "abc123"),
             other => panic!("unexpected command: {other:?}"),
         }
     }
@@ -3346,7 +3432,9 @@ mod tests {
     fn parse_process_log() {
         let cli = Cli::try_parse_from(["rune", "process", "log", "abc123"]).unwrap();
         match cli.command {
-            Command::Process { action: ProcessAction::Log { id } } => assert_eq!(id, "abc123"),
+            Command::Process {
+                action: ProcessAction::Log { id },
+            } => assert_eq!(id, "abc123"),
             other => panic!("unexpected command: {other:?}"),
         }
     }
@@ -4046,38 +4134,44 @@ mod tests {
     #[test]
     fn message_edit_requires_message_id_channel_and_text() {
         // Missing --text
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "edit",
-            "--message-id",
-            "msg-1",
-            "--channel",
-            "telegram",
-        ])
-        .is_err());
+        assert!(
+            Cli::try_parse_from([
+                "rune",
+                "message",
+                "edit",
+                "--message-id",
+                "msg-1",
+                "--channel",
+                "telegram",
+            ])
+            .is_err()
+        );
         // Missing --channel
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "edit",
-            "--message-id",
-            "msg-1",
-            "--text",
-            "hello",
-        ])
-        .is_err());
+        assert!(
+            Cli::try_parse_from([
+                "rune",
+                "message",
+                "edit",
+                "--message-id",
+                "msg-1",
+                "--text",
+                "hello",
+            ])
+            .is_err()
+        );
         // Missing --message-id
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "edit",
-            "--channel",
-            "telegram",
-            "--text",
-            "hello",
-        ])
-        .is_err());
+        assert!(
+            Cli::try_parse_from([
+                "rune",
+                "message",
+                "edit",
+                "--channel",
+                "telegram",
+                "--text",
+                "hello",
+            ])
+            .is_err()
+        );
         // Missing all
         assert!(Cli::try_parse_from(["rune", "message", "edit"]).is_err());
     }
@@ -4146,15 +4240,17 @@ mod tests {
 
     #[test]
     fn message_pin_rejects_unpin_flag() {
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "pin",
-            "--message-id",
-            "msg-77",
-            "--unpin"
-        ])
-        .is_err());
+        assert!(
+            Cli::try_parse_from([
+                "rune",
+                "message",
+                "pin",
+                "--message-id",
+                "msg-77",
+                "--unpin"
+            ])
+            .is_err()
+        );
     }
 
     #[test]
@@ -4462,26 +4558,23 @@ mod tests {
     #[test]
     fn message_thread_reply_requires_thread_id_channel_text() {
         assert!(Cli::try_parse_from(["rune", "message", "thread", "reply"]).is_err());
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "thread",
-            "reply",
-            "--thread-id",
-            "thr-1",
-        ])
-        .is_err());
-        assert!(Cli::try_parse_from([
-            "rune",
-            "message",
-            "thread",
-            "reply",
-            "--thread-id",
-            "thr-1",
-            "--channel",
-            "telegram",
-        ])
-        .is_err());
+        assert!(
+            Cli::try_parse_from(["rune", "message", "thread", "reply", "--thread-id", "thr-1",])
+                .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "rune",
+                "message",
+                "thread",
+                "reply",
+                "--thread-id",
+                "thr-1",
+                "--channel",
+                "telegram",
+            ])
+            .is_err()
+        );
     }
 
     // ── Message voice (#74) ────────────────────────────────────────
@@ -4577,10 +4670,10 @@ mod tests {
         assert!(
             Cli::try_parse_from(["rune", "message", "voice", "send", "--text", "hello"]).is_err()
         );
-        assert!(Cli::try_parse_from(
-            ["rune", "message", "voice", "send", "--channel", "telegram",]
-        )
-        .is_err());
+        assert!(
+            Cli::try_parse_from(["rune", "message", "voice", "send", "--channel", "telegram",])
+                .is_err()
+        );
         assert!(Cli::try_parse_from(["rune", "message", "voice", "send"]).is_err());
     }
 
@@ -4854,11 +4947,26 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_agents_spawn() {
-        let cli = Cli::try_parse_from(["rune","agents","spawn","--parent","sess-1","--task","do stuff"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "rune", "agents", "spawn", "--parent", "sess-1", "--task", "do stuff",
+        ])
+        .unwrap();
         match cli.command {
-            Command::Agents { action: AgentsAction::Spawn { parent, task, mode, policy, provider } } => {
-                assert_eq!(parent, "sess-1"); assert_eq!(task, "do stuff");
-                assert_eq!(mode, "default"); assert_eq!(policy, "inherit"); assert!(provider.is_none());
+            Command::Agents {
+                action:
+                    AgentsAction::Spawn {
+                        parent,
+                        task,
+                        mode,
+                        policy,
+                        provider,
+                    },
+            } => {
+                assert_eq!(parent, "sess-1");
+                assert_eq!(task, "do stuff");
+                assert_eq!(mode, "default");
+                assert_eq!(policy, "inherit");
+                assert!(provider.is_none());
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4866,10 +4974,14 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_agents_steer() {
-        let cli = Cli::try_parse_from(["rune","agents","steer","child-1","--message","focus"]).unwrap();
+        let cli = Cli::try_parse_from(["rune", "agents", "steer", "child-1", "--message", "focus"])
+            .unwrap();
         match cli.command {
-            Command::Agents { action: AgentsAction::Steer { id, message } } => {
-                assert_eq!(id, "child-1"); assert_eq!(message, "focus");
+            Command::Agents {
+                action: AgentsAction::Steer { id, message },
+            } => {
+                assert_eq!(id, "child-1");
+                assert_eq!(message, "focus");
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4877,10 +4989,14 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_agents_kill() {
-        let cli = Cli::try_parse_from(["rune","agents","kill","child-1","--reason","timeout"]).unwrap();
+        let cli = Cli::try_parse_from(["rune", "agents", "kill", "child-1", "--reason", "timeout"])
+            .unwrap();
         match cli.command {
-            Command::Agents { action: AgentsAction::Kill { id, reason } } => {
-                assert_eq!(id, "child-1"); assert_eq!(reason.as_deref(), Some("timeout"));
+            Command::Agents {
+                action: AgentsAction::Kill { id, reason },
+            } => {
+                assert_eq!(id, "child-1");
+                assert_eq!(reason.as_deref(), Some("timeout"));
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4888,11 +5004,23 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_agent_run() {
-        let cli = Cli::try_parse_from(["rune","agent","run","--session","s1","--message","go"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "agent", "run", "--session", "s1", "--message", "go"])
+                .unwrap();
         match cli.command {
-            Command::Agent { action: AgentAction::Run { session, message, max_turns, wait } } => {
-                assert_eq!(session, "s1"); assert_eq!(message, "go");
-                assert_eq!(max_turns, 1); assert!(wait);
+            Command::Agent {
+                action:
+                    AgentAction::Run {
+                        session,
+                        message,
+                        max_turns,
+                        wait,
+                    },
+            } => {
+                assert_eq!(session, "s1");
+                assert_eq!(message, "go");
+                assert_eq!(max_turns, 1);
+                assert!(wait);
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4900,10 +5028,15 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_agent_result() {
-        let cli = Cli::try_parse_from(["rune","agent","result","--session","s1","--turn","t1"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "agent", "result", "--session", "s1", "--turn", "t1"])
+                .unwrap();
         match cli.command {
-            Command::Agent { action: AgentAction::Result { session, turn } } => {
-                assert_eq!(session, "s1"); assert_eq!(turn, "t1");
+            Command::Agent {
+                action: AgentAction::Result { session, turn },
+            } => {
+                assert_eq!(session, "s1");
+                assert_eq!(turn, "t1");
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4911,10 +5044,25 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_acp_send() {
-        let cli = Cli::try_parse_from(["rune","acp","send","--from","a","--to","b","--payload",r#"{"x":1}"#]).unwrap();
+        let cli = Cli::try_parse_from([
+            "rune",
+            "acp",
+            "send",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--payload",
+            r#"{"x":1}"#,
+        ])
+        .unwrap();
         match cli.command {
-            Command::Acp { action: AcpAction::Send { from, to, payload } } => {
-                assert_eq!(from, "a"); assert_eq!(to, "b"); assert_eq!(payload, r#"{"x":1}"#);
+            Command::Acp {
+                action: AcpAction::Send { from, to, payload },
+            } => {
+                assert_eq!(from, "a");
+                assert_eq!(to, "b");
+                assert_eq!(payload, r#"{"x":1}"#);
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4922,16 +5070,30 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_acp_inbox() {
-        let cli = Cli::try_parse_from(["rune","acp","inbox","--session","a"]).unwrap();
-        assert!(matches!(cli.command, Command::Acp { action: AcpAction::Inbox { .. } }));
+        let cli = Cli::try_parse_from(["rune", "acp", "inbox", "--session", "a"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Acp {
+                action: AcpAction::Inbox { .. }
+            }
+        ));
     }
 
     #[test]
     fn parse_acp_ack() {
-        let cli = Cli::try_parse_from(["rune","acp","ack","--message-id","m1","--session","a"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "acp", "ack", "--message-id", "m1", "--session", "a"])
+                .unwrap();
         match cli.command {
-            Command::Acp { action: AcpAction::Ack { message_id, session } } => {
-                assert_eq!(message_id, "m1"); assert_eq!(session, "a");
+            Command::Acp {
+                action:
+                    AcpAction::Ack {
+                        message_id,
+                        session,
+                    },
+            } => {
+                assert_eq!(message_id, "m1");
+                assert_eq!(session, "a");
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -4946,14 +5108,21 @@ mod subagent_cli_tests {
     #[test]
     fn parse_backup_create() {
         let cli = Cli::try_parse_from(["rune", "backup", "create"]).unwrap();
-        assert!(matches!(cli.command, Command::Backup { action: BackupAction::Create { label: None } }));
+        assert!(matches!(
+            cli.command,
+            Command::Backup {
+                action: BackupAction::Create { label: None }
+            }
+        ));
     }
 
     #[test]
     fn parse_backup_create_with_label() {
         let cli = Cli::try_parse_from(["rune", "backup", "create", "--label", "nightly"]).unwrap();
         match cli.command {
-            Command::Backup { action: BackupAction::Create { label } } => assert_eq!(label.as_deref(), Some("nightly")),
+            Command::Backup {
+                action: BackupAction::Create { label },
+            } => assert_eq!(label.as_deref(), Some("nightly")),
             other => panic!("unexpected: {other:?}"),
         }
     }
@@ -4961,14 +5130,22 @@ mod subagent_cli_tests {
     #[test]
     fn parse_backup_list() {
         let cli = Cli::try_parse_from(["rune", "backup", "list"]).unwrap();
-        assert!(matches!(cli.command, Command::Backup { action: BackupAction::List }));
+        assert!(matches!(
+            cli.command,
+            Command::Backup {
+                action: BackupAction::List
+            }
+        ));
     }
 
     #[test]
     fn parse_backup_restore() {
-        let cli = Cli::try_parse_from(["rune", "backup", "restore", "bk-001", "--confirm"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "backup", "restore", "bk-001", "--confirm"]).unwrap();
         match cli.command {
-            Command::Backup { action: BackupAction::Restore { id, confirm } } => {
+            Command::Backup {
+                action: BackupAction::Restore { id, confirm },
+            } => {
                 assert_eq!(id, "bk-001");
                 assert!(confirm);
             }
@@ -4979,19 +5156,34 @@ mod subagent_cli_tests {
     #[test]
     fn parse_update_check() {
         let cli = Cli::try_parse_from(["rune", "update", "check"]).unwrap();
-        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Check }));
+        assert!(matches!(
+            cli.command,
+            Command::Update {
+                action: UpdateAction::Check
+            }
+        ));
     }
 
     #[test]
     fn parse_update_apply() {
         let cli = Cli::try_parse_from(["rune", "update", "apply"]).unwrap();
-        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Apply }));
+        assert!(matches!(
+            cli.command,
+            Command::Update {
+                action: UpdateAction::Apply
+            }
+        ));
     }
 
     #[test]
     fn parse_update_status() {
         let cli = Cli::try_parse_from(["rune", "update", "status"]).unwrap();
-        assert!(matches!(cli.command, Command::Update { action: UpdateAction::Status }));
+        assert!(matches!(
+            cli.command,
+            Command::Update {
+                action: UpdateAction::Status
+            }
+        ));
     }
 
     #[test]
@@ -5016,7 +5208,12 @@ mod subagent_cli_tests {
     fn parse_ms365_mail_read() {
         let cli = Cli::try_parse_from(["rune", "ms365", "mail", "read", "--id", "abc123"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Mail { action: Ms365MailAction::Read { id } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Mail {
+                        action: Ms365MailAction::Read { id },
+                    },
+            } => {
                 assert_eq!(id, "abc123");
             }
             other => panic!("unexpected: {other:?}"),
@@ -5025,9 +5222,15 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_calendar_read() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "calendar", "read", "--id", "evt456"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "ms365", "calendar", "read", "--id", "evt456"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Calendar { action: Ms365CalendarAction::Read { id } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Calendar {
+                        action: Ms365CalendarAction::Read { id },
+                    },
+            } => {
                 assert_eq!(id, "evt456");
             }
             other => panic!("unexpected: {other:?}"),
@@ -5039,7 +5242,11 @@ mod subagent_cli_tests {
         let cli = Cli::try_parse_from(["rune", "ms365", "auth", "status"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Ms365 { action: Ms365Action::Auth { action: Ms365AuthAction::Status } }
+            Command::Ms365 {
+                action: Ms365Action::Auth {
+                    action: Ms365AuthAction::Status
+                }
+            }
         ));
     }
 
@@ -5047,7 +5254,12 @@ mod subagent_cli_tests {
     fn parse_ms365_planner_plans() {
         let cli = Cli::try_parse_from(["rune", "ms365", "planner", "plans"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::Plans { limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action: Ms365PlannerAction::Plans { limit },
+                    },
+            } => {
                 assert_eq!(limit, 25);
             }
             other => panic!("unexpected: {other:?}"),
@@ -5056,9 +5268,15 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_planner_tasks() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "tasks", "--plan-id", "p1"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "ms365", "planner", "tasks", "--plan-id", "p1"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::Tasks { plan_id, limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action: Ms365PlannerAction::Tasks { plan_id, limit },
+                    },
+            } => {
                 assert_eq!(plan_id, "p1");
                 assert_eq!(limit, 50);
             }
@@ -5068,10 +5286,124 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_planner_task_read() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "task-read", "--id", "t1"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "ms365", "planner", "task-read", "--id", "t1"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Planner { action: Ms365PlannerAction::TaskRead { id } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action: Ms365PlannerAction::TaskRead { id },
+                    },
+            } => {
                 assert_eq!(id, "t1");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_planner_create() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "ms365",
+            "planner",
+            "create",
+            "--plan-id",
+            "plan-1",
+            "--title",
+            "Write summary",
+            "--bucket-id",
+            "bucket-1",
+            "--due-date",
+            "2026-03-25T12:00:00Z",
+            "--description",
+            "Prepare status update",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action:
+                            Ms365PlannerAction::Create {
+                                plan_id,
+                                title,
+                                bucket_id,
+                                due_date,
+                                description,
+                            },
+                    },
+            } => {
+                assert_eq!(plan_id, "plan-1");
+                assert_eq!(title, "Write summary");
+                assert_eq!(bucket_id.as_deref(), Some("bucket-1"));
+                assert_eq!(due_date.as_deref(), Some("2026-03-25T12:00:00Z"));
+                assert_eq!(description.as_deref(), Some("Prepare status update"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_planner_update() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "ms365",
+            "planner",
+            "update",
+            "--id",
+            "task-1",
+            "--title",
+            "Updated title",
+            "--percent-complete",
+            "60",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action:
+                            Ms365PlannerAction::Update {
+                                id,
+                                title,
+                                bucket_id,
+                                due_date,
+                                description,
+                                percent_complete,
+                            },
+                    },
+            } => {
+                assert_eq!(id, "task-1");
+                assert_eq!(title.as_deref(), Some("Updated title"));
+                assert!(bucket_id.is_none());
+                assert!(due_date.is_none());
+                assert!(description.is_none());
+                assert_eq!(percent_complete, Some(60));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ms365_planner_update_requires_change() {
+        let err = Cli::try_parse_from(["rune", "ms365", "planner", "update", "--id", "task-1"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn parse_ms365_planner_complete() {
+        let cli = Cli::try_parse_from(["rune", "ms365", "planner", "complete", "--id", "task-1"])
+            .unwrap();
+        match cli.command {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Planner {
+                        action: Ms365PlannerAction::Complete { id },
+                    },
+            } => {
+                assert_eq!(id, "task-1");
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -5082,7 +5414,11 @@ mod subagent_cli_tests {
         let cli = Cli::try_parse_from(["rune", "ms365", "mail", "folders"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Ms365 { action: Ms365Action::Mail { action: Ms365MailAction::Folders } }
+            Command::Ms365 {
+                action: Ms365Action::Mail {
+                    action: Ms365MailAction::Folders
+                }
+            }
         ));
     }
 
@@ -5090,7 +5426,12 @@ mod subagent_cli_tests {
     fn parse_ms365_todo_lists() {
         let cli = Cli::try_parse_from(["rune", "ms365", "todo", "lists"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::Lists { limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Todo {
+                        action: Ms365TodoAction::Lists { limit },
+                    },
+            } => {
                 assert_eq!(limit, 25);
             }
             other => panic!("unexpected: {other:?}"),
@@ -5099,9 +5440,15 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_todo_tasks() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "todo", "tasks", "--list-id", "lst1"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "ms365", "todo", "tasks", "--list-id", "lst1"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::Tasks { list_id, limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Todo {
+                        action: Ms365TodoAction::Tasks { list_id, limit },
+                    },
+            } => {
                 assert_eq!(list_id, "lst1");
                 assert_eq!(limit, 50);
             }
@@ -5111,9 +5458,24 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_todo_task_read() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "todo", "task-read", "--list-id", "lst1", "--id", "task1"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "rune",
+            "ms365",
+            "todo",
+            "task-read",
+            "--list-id",
+            "lst1",
+            "--id",
+            "task1",
+        ])
+        .unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Todo { action: Ms365TodoAction::TaskRead { list_id, id } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Todo {
+                        action: Ms365TodoAction::TaskRead { list_id, id },
+                    },
+            } => {
                 assert_eq!(list_id, "lst1");
                 assert_eq!(id, "task1");
             }
@@ -5125,7 +5487,12 @@ mod subagent_cli_tests {
     fn parse_ms365_teams_list() {
         let cli = Cli::try_parse_from(["rune", "ms365", "teams", "list"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::List { limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Teams {
+                        action: Ms365TeamsAction::List { limit },
+                    },
+            } => {
                 assert_eq!(limit, 25);
             }
             other => panic!("unexpected: {other:?}"),
@@ -5134,9 +5501,15 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_teams_channels() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "channels", "--team-id", "t1"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["rune", "ms365", "teams", "channels", "--team-id", "t1"]).unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::Channels { team_id, limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Teams {
+                        action: Ms365TeamsAction::Channels { team_id, limit },
+                    },
+            } => {
                 assert_eq!(team_id, "t1");
                 assert_eq!(limit, 50);
             }
@@ -5146,9 +5519,24 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_teams_channel_read() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "channel-read", "--team-id", "t1", "--id", "ch1"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "rune",
+            "ms365",
+            "teams",
+            "channel-read",
+            "--team-id",
+            "t1",
+            "--id",
+            "ch1",
+        ])
+        .unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::ChannelRead { team_id, id } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Teams {
+                        action: Ms365TeamsAction::ChannelRead { team_id, id },
+                    },
+            } => {
                 assert_eq!(team_id, "t1");
                 assert_eq!(id, "ch1");
             }
@@ -5158,9 +5546,29 @@ mod subagent_cli_tests {
 
     #[test]
     fn parse_ms365_teams_messages() {
-        let cli = Cli::try_parse_from(["rune", "ms365", "teams", "messages", "--team-id", "t1", "--channel-id", "ch1"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "rune",
+            "ms365",
+            "teams",
+            "messages",
+            "--team-id",
+            "t1",
+            "--channel-id",
+            "ch1",
+        ])
+        .unwrap();
         match cli.command {
-            Command::Ms365 { action: Ms365Action::Teams { action: Ms365TeamsAction::Messages { team_id, channel_id, limit } } } => {
+            Command::Ms365 {
+                action:
+                    Ms365Action::Teams {
+                        action:
+                            Ms365TeamsAction::Messages {
+                                team_id,
+                                channel_id,
+                                limit,
+                            },
+                    },
+            } => {
                 assert_eq!(team_id, "t1");
                 assert_eq!(channel_id, "ch1");
                 assert_eq!(limit, 25);

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -10,26 +10,21 @@ use serde_json::json;
 use toml_edit::{DocumentMut, Item, Table, Value};
 
 use crate::output::{
-    ActionResult, AgentDetailResponse, AgentListResponse, AgentSummary,
-    ApprovalListResponse, ApprovalPoliciesResponse, ApprovalPolicySummary,
-    ApprovalRequestSummary, ConfigFileResponse, ConfigGetResponse, ConfigMutationResponse,
-    ConfigValidationResult, CronJobDetailResponse, CronJobSummary, CronListResponse,
-    CronRunSummary, CronRunsResponse, CronStatusResponse, DoctorReport, GatewayCallResponse,
-    GatewayConfigResponse, GatewayDiscoverResponse, GatewayProbeResponse,
-    GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
-    LogsQueryResponse,
-    SystemEventListResponse,
-    ModelScanProviderResult, ModelScanResponse, MessageSearchHit, MessageSearchResponse,
-    MessageSendResponse, ReminderSummary, RemindersListResponse, ScannedModelDetail,
-    SessionDetailResponse, SessionListResponse, SessionStatusCard, SessionSummary,
-    SandboxExplainResponse, SandboxListResponse, SandboxRecreateResponse,
-    SecretsApplyResponse, SecretsAuditResponse, SecretsConfigureResponse, SecretsReloadResponse,
-    SecurityAuditResponse, ConfigureResponse,
-    AgentSpawnResponse, AgentSteerResponse, AgentKillResponse,
-    AgentRunResponse, AgentResultResponse,
-    AcpSendResponse, AcpInboxResponse, AcpInboxMessage, AcpAckResponse,
-    SessionTreeNode, SessionTreeResponse, SkillCheckResponse, SkillInfoResponse,
-    SkillListResponse, SkillSummary, StatusResponse,
+    AcpAckResponse, AcpInboxMessage, AcpInboxResponse, AcpSendResponse, ActionResult,
+    AgentDetailResponse, AgentKillResponse, AgentListResponse, AgentResultResponse,
+    AgentRunResponse, AgentSpawnResponse, AgentSteerResponse, AgentSummary, ApprovalListResponse,
+    ApprovalPoliciesResponse, ApprovalPolicySummary, ApprovalRequestSummary, ConfigFileResponse,
+    ConfigGetResponse, ConfigMutationResponse, ConfigValidationResult, ConfigureResponse,
+    CronJobDetailResponse, CronJobSummary, CronListResponse, CronRunSummary, CronRunsResponse,
+    CronStatusResponse, DoctorReport, GatewayCallResponse, GatewayConfigResponse,
+    GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse,
+    HeartbeatStatusResponse, LogsQueryResponse, MessageSearchHit, MessageSearchResponse,
+    MessageSendResponse, ModelScanProviderResult, ModelScanResponse, ReminderSummary,
+    RemindersListResponse, SandboxExplainResponse, SandboxListResponse, SandboxRecreateResponse,
+    ScannedModelDetail, SecretsApplyResponse, SecretsAuditResponse, SecretsConfigureResponse,
+    SecretsReloadResponse, SecurityAuditResponse, SessionDetailResponse, SessionListResponse,
+    SessionStatusCard, SessionSummary, SessionTreeNode, SessionTreeResponse, SkillCheckResponse,
+    SkillInfoResponse, SkillListResponse, SkillSummary, StatusResponse, SystemEventListResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -610,9 +605,7 @@ impl GatewayClient {
 
     /// Aggregate persisted session-turn token usage. Monetary cost is intentionally not derived yet.
     pub async fn gateway_usage_cost(&self) -> Result<GatewayUsageCostResponse> {
-        let sessions = self
-            .sessions_list(None, None, None, None, 500)
-            .await?;
+        let sessions = self.sessions_list(None, None, None, None, 500).await?;
         let mut total_turns = 0usize;
         let mut prompt_tokens = 0u64;
         let mut completion_tokens = 0u64;
@@ -1153,10 +1146,7 @@ impl GatewayClient {
                 success: true,
                 channel: channel.to_string(),
                 message_id: v["id"].as_str().map(String::from),
-                detail: v["detail"]
-                    .as_str()
-                    .unwrap_or("Message sent")
-                    .to_string(),
+                detail: v["detail"].as_str().unwrap_or("Message sent").to_string(),
             })
         } else {
             let status = resp.status();
@@ -1178,10 +1168,8 @@ impl GatewayClient {
         session: Option<&str>,
         limit: u64,
     ) -> Result<MessageSearchResponse> {
-        let mut params: Vec<(&str, String)> = vec![
-            ("q", query.to_string()),
-            ("limit", limit.to_string()),
-        ];
+        let mut params: Vec<(&str, String)> =
+            vec![("q", query.to_string()), ("limit", limit.to_string())];
         if let Some(ch) = channel {
             params.push(("channel", ch.to_string()));
         }
@@ -1265,10 +1253,7 @@ impl GatewayClient {
                     channel: r["channel"].as_str().unwrap_or("?").to_string(),
                     success: r["success"].as_bool().unwrap_or(false),
                     message_id: r["id"].as_str().map(String::from),
-                    detail: r["detail"]
-                        .as_str()
-                        .unwrap_or("sent")
-                        .to_string(),
+                    detail: r["detail"].as_str().unwrap_or("sent").to_string(),
                 })
                 .collect::<Vec<_>>();
             let succeeded = results.iter().filter(|r| r.success).count();
@@ -1323,10 +1308,7 @@ impl GatewayClient {
                 .context("invalid JSON from POST /messages/react")?;
             Ok(MessageReactResponse {
                 success: true,
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 emoji: v["emoji"].as_str().unwrap_or(emoji).to_string(),
                 removed: v["removed"].as_bool().unwrap_or(remove),
                 detail: v["detail"]
@@ -1382,15 +1364,9 @@ impl GatewayClient {
                 .context("invalid JSON from PATCH /messages/{id}")?;
             Ok(MessageEditResponse {
                 success: true,
-                message_id: v["id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["id"].as_str().unwrap_or(message_id).to_string(),
                 channel: channel.to_string(),
-                detail: v["detail"]
-                    .as_str()
-                    .unwrap_or("Message edited")
-                    .to_string(),
+                detail: v["detail"].as_str().unwrap_or("Message edited").to_string(),
             })
         } else {
             let status = resp.status();
@@ -1440,10 +1416,7 @@ impl GatewayClient {
                 .context("invalid JSON from POST /messages/pin")?;
             Ok(MessagePinResponse {
                 success: true,
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 pinned: !v["unpinned"].as_bool().unwrap_or(unpin),
                 detail: v["detail"]
                     .as_str()
@@ -1493,10 +1466,7 @@ impl GatewayClient {
                 .context("invalid JSON from DELETE /messages/{id}")?;
             Ok(MessageDeleteResponse {
                 success: true,
-                message_id: v["id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["id"].as_str().unwrap_or(message_id).to_string(),
                 channel: channel.to_string(),
                 detail: v["detail"]
                     .as_str()
@@ -1542,14 +1512,8 @@ impl GatewayClient {
                 .context("invalid JSON from GET /messages/{id}")?;
             Ok(MessageReadResponse {
                 success: true,
-                message_id: v["id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
-                channel: v["channel"]
-                    .as_str()
-                    .unwrap_or(channel)
-                    .to_string(),
+                message_id: v["id"].as_str().unwrap_or(message_id).to_string(),
+                channel: v["channel"].as_str().unwrap_or(channel).to_string(),
                 sender: v["sender"].as_str().map(ToString::to_string),
                 text: v["text"].as_str().map(ToString::to_string),
                 timestamp: v["timestamp"].as_str().map(ToString::to_string),
@@ -1617,9 +1581,7 @@ impl GatewayClient {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let total = body["total"]
-                .as_u64()
-                .unwrap_or(messages.len() as u64) as usize;
+            let total = body["total"].as_u64().unwrap_or(messages.len() as u64) as usize;
             Ok(MessageThreadListResponse {
                 thread_id: thread_id.to_string(),
                 total,
@@ -1665,10 +1627,7 @@ impl GatewayClient {
                 success: true,
                 thread_id: thread_id.to_string(),
                 message_id: v["id"].as_str().map(ToString::to_string),
-                detail: v["detail"]
-                    .as_str()
-                    .unwrap_or("Reply sent")
-                    .to_string(),
+                detail: v["detail"].as_str().unwrap_or("Reply sent").to_string(),
             })
         } else {
             let status = resp.status();
@@ -1715,16 +1674,10 @@ impl GatewayClient {
                 .context("invalid JSON from POST /messages/{id}/tags")?;
             Ok(MessageTagResponse {
                 success: true,
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 tag: v["tag"].as_str().unwrap_or(tag).to_string(),
                 added: true,
-                detail: v["detail"]
-                    .as_str()
-                    .unwrap_or("Tag added")
-                    .to_string(),
+                detail: v["detail"].as_str().unwrap_or("Tag added").to_string(),
             })
         } else {
             let status = resp.status();
@@ -1770,16 +1723,10 @@ impl GatewayClient {
                 .context("invalid JSON from DELETE /messages/{id}/tags/{tag}")?;
             Ok(MessageTagResponse {
                 success: true,
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 tag: v["tag"].as_str().unwrap_or(tag).to_string(),
                 added: false,
-                detail: v["detail"]
-                    .as_str()
-                    .unwrap_or("Tag removed")
-                    .to_string(),
+                detail: v["detail"].as_str().unwrap_or("Tag removed").to_string(),
             })
         } else {
             let status = resp.status();
@@ -1831,18 +1778,13 @@ impl GatewayClient {
                 })
                 .unwrap_or_default();
             Ok(MessageTagListResponse {
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 tags,
             })
         } else {
             let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "GET /messages/{message_id}/tags returned HTTP {status}: {body_text}"
-            );
+            anyhow::bail!("GET /messages/{message_id}/tags returned HTTP {status}: {body_text}");
         }
     }
 
@@ -1894,10 +1836,7 @@ impl GatewayClient {
                 })
                 .unwrap_or_default();
             Ok(MessageReactionListResponse {
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
                 reactions,
             })
         } else {
@@ -1938,14 +1877,8 @@ impl GatewayClient {
                 .context("invalid JSON from POST /messages/{id}/ack")?;
             Ok(MessageAckResponse {
                 success: true,
-                message_id: v["message_id"]
-                    .as_str()
-                    .unwrap_or(message_id)
-                    .to_string(),
-                channel: v["channel"]
-                    .as_str()
-                    .unwrap_or(channel)
-                    .to_string(),
+                message_id: v["message_id"].as_str().unwrap_or(message_id).to_string(),
+                channel: v["channel"].as_str().unwrap_or(channel).to_string(),
                 detail: v["detail"]
                     .as_str()
                     .unwrap_or("Message acknowledged")
@@ -1964,9 +1897,7 @@ impl GatewayClient {
     }
 
     /// `GET /tts/status`
-    pub async fn message_voice_status(
-        &self,
-    ) -> Result<crate::output::MessageVoiceStatusResponse> {
+    pub async fn message_voice_status(&self) -> Result<crate::output::MessageVoiceStatusResponse> {
         use crate::output::{MessageVoiceStatusResponse, TtsVoiceDetail};
 
         let resp = self
@@ -2097,10 +2028,7 @@ impl GatewayClient {
     }
 
     /// `POST /sessions` — create a new session via the gateway.
-    pub async fn sessions_create(
-        &self,
-        kind: &str,
-    ) -> Result<SessionDetailResponse> {
+    pub async fn sessions_create(&self, kind: &str) -> Result<SessionDetailResponse> {
         let resp = self
             .http
             .post(self.url("/sessions"))
@@ -2194,7 +2122,10 @@ impl GatewayClient {
     }
 
     /// `GET /sessions/:id/transcript` — fetch full session transcript.
-    pub async fn sessions_transcript(&self, id: &str) -> Result<Vec<crate::output::TranscriptEntry>> {
+    pub async fn sessions_transcript(
+        &self,
+        id: &str,
+    ) -> Result<Vec<crate::output::TranscriptEntry>> {
         let resp = self
             .http
             .get(self.url(&format!("/sessions/{id}/transcript")))
@@ -2280,9 +2211,7 @@ impl GatewayClient {
             Ok(AgentDetailResponse {
                 id: v["id"].as_str().unwrap_or("?").to_string(),
                 status: v["status"].as_str().unwrap_or("unknown").to_string(),
-                parent_session_id: v["requester_session_id"]
-                    .as_str()
-                    .map(String::from),
+                parent_session_id: v["requester_session_id"].as_str().map(String::from),
                 created_at: v["created_at"].as_str().map(String::from),
                 turn_count: v["turn_count"].as_u64().map(|n| n as u32),
                 latest_model: v["latest_model"].as_str().map(String::from),
@@ -2474,7 +2403,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /security/audit")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /security/audit")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2506,7 +2438,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /sandbox/recreate")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /sandbox/recreate")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2521,7 +2456,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /sandbox/explain")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /sandbox/explain")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2538,7 +2476,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /secrets/reload")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /secrets/reload")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2553,7 +2494,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /secrets/audit")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /secrets/audit")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2568,7 +2512,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /secrets/configure")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /secrets/configure")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2584,7 +2531,10 @@ impl GatewayClient {
             .await
             .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            Ok(resp.json().await.context("invalid JSON from /secrets/apply")?)
+            Ok(resp
+                .json()
+                .await
+                .context("invalid JSON from /secrets/apply")?)
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
@@ -2756,11 +2706,7 @@ impl GatewayClient {
     }
 
     /// `GET /agents/:id/turns/:turn_id` — retrieve a turn result.
-    pub async fn agent_result(
-        &self,
-        session: &str,
-        turn: &str,
-    ) -> Result<AgentResultResponse> {
+    pub async fn agent_result(&self, session: &str, turn: &str) -> Result<AgentResultResponse> {
         let resp = self
             .http
             .get(self.url(&format!("/agents/{session}/turns/{turn}")))
@@ -2788,12 +2734,7 @@ impl GatewayClient {
     // ── ACP bridge ───────────────────────────────────────────────────
 
     /// `POST /acp/send` — send an ACP message between sessions.
-    pub async fn acp_send(
-        &self,
-        from: &str,
-        to: &str,
-        payload: &str,
-    ) -> Result<AcpSendResponse> {
+    pub async fn acp_send(&self, from: &str, to: &str, payload: &str) -> Result<AcpSendResponse> {
         let payload_value: serde_json::Value =
             serde_json::from_str(payload).context("invalid JSON payload for ACP send")?;
         let resp = self
@@ -2842,15 +2783,9 @@ impl GatewayClient {
                 .map(|arr| {
                     arr.iter()
                         .map(|m| AcpInboxMessage {
-                            message_id: m["message_id"]
-                                .as_str()
-                                .unwrap_or("?")
-                                .to_string(),
+                            message_id: m["message_id"].as_str().unwrap_or("?").to_string(),
                             from: m["from"].as_str().unwrap_or("?").to_string(),
-                            received_at: m["received_at"]
-                                .as_str()
-                                .unwrap_or("?")
-                                .to_string(),
+                            received_at: m["received_at"].as_str().unwrap_or("?").to_string(),
                             payload: m["payload"].clone(),
                         })
                         .collect()
@@ -2893,64 +2828,187 @@ impl GatewayClient {
 
     // ── Config admin (#30) ──────────────────────────────────────
     pub async fn config_reload(&self) -> Result<crate::output::ConfigReloadResponse> {
-        let r = self.http.post(self.url("/config/reload")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url("/config/reload"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn config_diff(&self) -> Result<crate::output::ConfigDiffResponse> {
-        let r = self.http.get(self.url("/config/diff")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/config/diff"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn config_env(&self) -> Result<crate::output::ConfigEnvResponse> {
-        let r = self.http.get(self.url("/config/env")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/config/env"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn config_export(&self) -> Result<crate::output::ConfigExportResponse> {
-        let r = self.http.get(self.url("/config/export")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/config/export"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 
     // ── Processes (#39) ────────────────────────────────────────
     pub async fn process_list(&self) -> Result<serde_json::Value> {
-        let r = self.http.get(self.url("/processes")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/processes"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn process_get(&self, id: &str) -> Result<serde_json::Value> {
-        let r = self.http.get(self.url(&format!("/processes/{id}"))).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url(&format!("/processes/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn process_log(&self, id: &str) -> Result<String> {
-        let r = self.http.get(self.url(&format!("/processes/{id}/log"))).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.text().await.context("text")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url(&format!("/processes/{id}/log")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.text().await.context("text")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn process_kill(&self, id: &str) -> Result<crate::output::ActionResult> {
-        let r = self.http.post(self.url(&format!("/processes/{id}/kill"))).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url(&format!("/processes/{id}/kill")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 
     // ── Microsoft 365 (#206) ────────────────────────────────────
-    pub async fn ms365_mail_unread(&self, limit: u32, folder: &str) -> Result<crate::output::Ms365MailUnreadResponse> {
-        let r = self.http.get(self.url("/ms365/mail/unread"))
+    pub async fn ms365_mail_unread(
+        &self,
+        limit: u32,
+        folder: &str,
+    ) -> Result<crate::output::Ms365MailUnreadResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/mail/unread"))
             .query(&[("limit", limit.to_string()), ("folder", folder.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_calendar_upcoming(&self, limit: u32, hours: u32) -> Result<crate::output::Ms365CalendarUpcomingResponse> {
-        let r = self.http.get(self.url("/ms365/calendar/upcoming"))
+    pub async fn ms365_calendar_upcoming(
+        &self,
+        limit: u32,
+        hours: u32,
+    ) -> Result<crate::output::Ms365CalendarUpcomingResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/calendar/upcoming"))
             .query(&[("limit", limit.to_string()), ("hours", hours.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn ms365_mail_read(&self, id: &str) -> Result<crate::output::Ms365MailReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/mail/messages/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_calendar_read(&self, id: &str) -> Result<crate::output::Ms365CalendarReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/calendar/events/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_calendar_read(
+        &self,
+        id: &str,
+    ) -> Result<crate::output::Ms365CalendarReadResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/calendar/events/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_calendar_create(&self, subject: &str, start: &str, end: &str, attendees: &[String], location: Option<&str>, body: Option<&str>) -> Result<crate::output::Ms365CalendarCreateResponse> {
+    pub async fn ms365_calendar_create(
+        &self,
+        subject: &str,
+        start: &str,
+        end: &str,
+        attendees: &[String],
+        location: Option<&str>,
+        body: Option<&str>,
+    ) -> Result<crate::output::Ms365CalendarCreateResponse> {
         let mut payload = serde_json::json!({
             "subject": subject,
             "start": start,
@@ -2963,123 +3021,300 @@ impl GatewayClient {
         if let Some(b) = body {
             payload["body"] = serde_json::json!(b);
         }
-        let r = self.http.post(self.url("/ms365/calendar/events"))
+        let r = self
+            .http
+            .post(self.url("/ms365/calendar/events"))
             .json(&payload)
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_calendar_delete(&self, id: &str) -> Result<crate::output::Ms365CalendarDeleteResponse> {
-        let r = self.http.post(self.url(&format!("/ms365/calendar/events/{id}/delete")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_calendar_delete(
+        &self,
+        id: &str,
+    ) -> Result<crate::output::Ms365CalendarDeleteResponse> {
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/calendar/events/{id}/delete")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_calendar_respond(&self, id: &str, response: &str, comment: Option<&str>) -> Result<crate::output::Ms365CalendarRespondResponse> {
+    pub async fn ms365_calendar_respond(
+        &self,
+        id: &str,
+        response: &str,
+        comment: Option<&str>,
+    ) -> Result<crate::output::Ms365CalendarRespondResponse> {
         let mut payload = serde_json::json!({
             "response": response,
         });
         if let Some(c) = comment {
             payload["comment"] = serde_json::json!(c);
         }
-        let r = self.http.post(self.url(&format!("/ms365/calendar/events/{id}/respond")))
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/calendar/events/{id}/respond")))
             .json(&payload)
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn ms365_auth_status(&self) -> Result<crate::output::Ms365AuthStatusResponse> {
-        let r = self.http.get(self.url("/ms365/auth/status"))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/ms365/auth/status"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn ms365_mail_folders(&self) -> Result<crate::output::Ms365MailFoldersResponse> {
-        let r = self.http.get(self.url("/ms365/mail/folders"))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/ms365/mail/folders"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_mail_send(&self, to: &[String], subject: &str, body: &str, cc: &[String]) -> Result<crate::output::Ms365MailSendResponse> {
+    pub async fn ms365_mail_send(
+        &self,
+        to: &[String],
+        subject: &str,
+        body: &str,
+        cc: &[String],
+    ) -> Result<crate::output::Ms365MailSendResponse> {
         let payload = serde_json::json!({
             "to": to,
             "subject": subject,
             "body": body,
             "cc": cc,
         });
-        let r = self.http.post(self.url("/ms365/mail/send"))
+        let r = self
+            .http
+            .post(self.url("/ms365/mail/send"))
             .json(&payload)
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_mail_reply(&self, id: &str, body: &str, reply_all: bool) -> Result<crate::output::Ms365MailReplyResponse> {
+    pub async fn ms365_mail_reply(
+        &self,
+        id: &str,
+        body: &str,
+        reply_all: bool,
+    ) -> Result<crate::output::Ms365MailReplyResponse> {
         let payload = serde_json::json!({
             "body": body,
             "reply_all": reply_all,
         });
-        let r = self.http.post(self.url(&format!("/ms365/mail/messages/{id}/reply")))
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/mail/messages/{id}/reply")))
             .json(&payload)
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_mail_forward(&self, id: &str, to: &[String], comment: Option<&str>) -> Result<crate::output::Ms365MailForwardResponse> {
+    pub async fn ms365_mail_forward(
+        &self,
+        id: &str,
+        to: &[String],
+        comment: Option<&str>,
+    ) -> Result<crate::output::Ms365MailForwardResponse> {
         let mut payload = serde_json::json!({
             "to": to,
         });
         if let Some(c) = comment {
             payload["comment"] = serde_json::json!(c);
         }
-        let r = self.http.post(self.url(&format!("/ms365/mail/messages/{id}/forward")))
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/mail/messages/{id}/forward")))
             .json(&payload)
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_mail_attachments(&self, message_id: &str) -> Result<crate::output::Ms365MailAttachmentsResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_mail_attachments(
+        &self,
+        message_id: &str,
+    ) -> Result<crate::output::Ms365MailAttachmentsResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_mail_attachment_read(&self, message_id: &str, attachment_id: &str) -> Result<crate::output::Ms365MailAttachmentReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments/{attachment_id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_mail_attachment_read(
+        &self,
+        message_id: &str,
+        attachment_id: &str,
+    ) -> Result<crate::output::Ms365MailAttachmentReadResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!(
+                "/ms365/mail/messages/{message_id}/attachments/{attachment_id}"
+            )))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     /// Download raw attachment content. Returns (filename, bytes).
-    pub async fn ms365_mail_attachment_download(&self, message_id: &str, attachment_id: &str) -> Result<(String, Vec<u8>)> {
+    pub async fn ms365_mail_attachment_download(
+        &self,
+        message_id: &str,
+        attachment_id: &str,
+    ) -> Result<(String, Vec<u8>)> {
         let meta: crate::output::Ms365MailAttachmentReadResponse = {
-            let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments/{attachment_id}")))
-                .send().await.context("gateway")?;
-            if r.status().is_success() { r.json().await.context("json")? } else { bail!("HTTP {}", r.status()); }
+            let r = self
+                .http
+                .get(self.url(&format!(
+                    "/ms365/mail/messages/{message_id}/attachments/{attachment_id}"
+                )))
+                .send()
+                .await
+                .context("gateway")?;
+            if r.status().is_success() {
+                r.json().await.context("json")?
+            } else {
+                bail!("HTTP {}", r.status());
+            }
         };
-        let r = self.http.get(self.url(&format!("/ms365/mail/messages/{message_id}/attachments/{attachment_id}/content")))
-            .send().await.context("gateway")?;
+        let r = self
+            .http
+            .get(self.url(&format!(
+                "/ms365/mail/messages/{message_id}/attachments/{attachment_id}/content"
+            )))
+            .send()
+            .await
+            .context("gateway")?;
         if r.status().is_success() {
             Ok((meta.name, r.bytes().await.context("bytes")?.to_vec()))
         } else {
             bail!("HTTP {}", r.status());
         }
     }
-    pub async fn ms365_files_list(&self, path: &str, limit: u32) -> Result<crate::output::Ms365FilesListResponse> {
-        let r = self.http.get(self.url("/ms365/files"))
+    pub async fn ms365_files_list(
+        &self,
+        path: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365FilesListResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/files"))
             .query(&[("path", path.to_string()), ("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn ms365_files_read(&self, id: &str) -> Result<crate::output::Ms365FileReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/files/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/files/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_files_search(&self, query: &str, limit: u32) -> Result<crate::output::Ms365FilesSearchResponse> {
-        let r = self.http.get(self.url("/ms365/files/search"))
+    pub async fn ms365_files_search(
+        &self,
+        query: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365FilesSearchResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/files/search"))
             .query(&[("query", query.to_string()), ("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     /// Download a OneDrive file's content. Returns (filename, bytes).
     pub async fn ms365_files_download(&self, id: &str) -> Result<(String, Vec<u8>)> {
         let meta: crate::output::Ms365FileReadResponse = {
-            let r = self.http.get(self.url(&format!("/ms365/files/{id}")))
-                .send().await.context("gateway")?;
-            if r.status().is_success() { r.json().await.context("json")? } else { bail!("HTTP {}", r.status()); }
+            let r = self
+                .http
+                .get(self.url(&format!("/ms365/files/{id}")))
+                .send()
+                .await
+                .context("gateway")?;
+            if r.status().is_success() {
+                r.json().await.context("json")?
+            } else {
+                bail!("HTTP {}", r.status());
+            }
         };
-        let r = self.http.get(self.url(&format!("/ms365/files/{id}/content")))
-            .send().await.context("gateway")?;
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/files/{id}/content")))
+            .send()
+            .await
+            .context("gateway")?;
         if r.status().is_success() {
             Ok((meta.name, r.bytes().await.context("bytes")?.to_vec()))
         } else {
@@ -3087,137 +3322,497 @@ impl GatewayClient {
         }
     }
     pub async fn ms365_users_me(&self) -> Result<crate::output::Ms365UserProfileResponse> {
-        let r = self.http.get(self.url("/ms365/users/me"))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/ms365/users/me"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_users_list(&self, limit: u32) -> Result<crate::output::Ms365UsersListResponse> {
-        let r = self.http.get(self.url("/ms365/users"))
+    pub async fn ms365_users_list(
+        &self,
+        limit: u32,
+    ) -> Result<crate::output::Ms365UsersListResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/users"))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_users_read(&self, id: &str) -> Result<crate::output::Ms365UserProfileResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/users/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_users_read(
+        &self,
+        id: &str,
+    ) -> Result<crate::output::Ms365UserProfileResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/users/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_planner_plans(&self, limit: u32) -> Result<crate::output::Ms365PlannerPlansResponse> {
-        let r = self.http.get(self.url("/ms365/planner/plans"))
+    pub async fn ms365_planner_plans(
+        &self,
+        limit: u32,
+    ) -> Result<crate::output::Ms365PlannerPlansResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/planner/plans"))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_planner_tasks(&self, plan_id: &str, limit: u32) -> Result<crate::output::Ms365PlannerTasksResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/planner/plans/{plan_id}/tasks")))
+    pub async fn ms365_planner_tasks(
+        &self,
+        plan_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365PlannerTasksResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/planner/plans/{plan_id}/tasks")))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_planner_task_read(&self, id: &str) -> Result<crate::output::Ms365PlannerTaskReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/planner/tasks/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_planner_task_read(
+        &self,
+        id: &str,
+    ) -> Result<crate::output::Ms365PlannerTaskReadResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/planner/tasks/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_todo_lists(&self, limit: u32) -> Result<crate::output::Ms365TodoListsResponse> {
-        let r = self.http.get(self.url("/ms365/todo/lists"))
+    pub async fn ms365_planner_task_create(
+        &self,
+        plan_id: &str,
+        title: &str,
+        bucket_id: Option<&str>,
+        due_date: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<crate::output::Ms365PlannerTaskCreateResponse> {
+        let mut payload = serde_json::json!({
+            "plan_id": plan_id,
+            "title": title,
+        });
+        if let Some(bucket_id) = bucket_id {
+            payload["bucket_id"] = serde_json::json!(bucket_id);
+        }
+        if let Some(due_date) = due_date {
+            payload["due_date"] = serde_json::json!(due_date);
+        }
+        if let Some(description) = description {
+            payload["description"] = serde_json::json!(description);
+        }
+        let r = self
+            .http
+            .post(self.url("/ms365/planner/tasks"))
+            .json(&payload)
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
+    }
+    pub async fn ms365_planner_task_update(
+        &self,
+        id: &str,
+        title: Option<&str>,
+        bucket_id: Option<&str>,
+        due_date: Option<&str>,
+        description: Option<&str>,
+        percent_complete: Option<u8>,
+    ) -> Result<crate::output::Ms365PlannerTaskUpdateResponse> {
+        let mut payload = serde_json::json!({});
+        if let Some(title) = title {
+            payload["title"] = serde_json::json!(title);
+        }
+        if let Some(bucket_id) = bucket_id {
+            payload["bucket_id"] = serde_json::json!(bucket_id);
+        }
+        if let Some(due_date) = due_date {
+            payload["due_date"] = serde_json::json!(due_date);
+        }
+        if let Some(description) = description {
+            payload["description"] = serde_json::json!(description);
+        }
+        if let Some(percent_complete) = percent_complete {
+            payload["percent_complete"] = serde_json::json!(percent_complete);
+        }
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/planner/tasks/{id}")))
+            .json(&payload)
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
+    }
+    pub async fn ms365_planner_task_complete(
+        &self,
+        id: &str,
+    ) -> Result<crate::output::Ms365PlannerTaskCompleteResponse> {
+        let r = self
+            .http
+            .post(self.url(&format!("/ms365/planner/tasks/{id}/complete")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
+    }
+    pub async fn ms365_todo_lists(
+        &self,
+        limit: u32,
+    ) -> Result<crate::output::Ms365TodoListsResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/todo/lists"))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_todo_tasks(&self, list_id: &str, limit: u32) -> Result<crate::output::Ms365TodoTasksResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks")))
+    pub async fn ms365_todo_tasks(
+        &self,
+        list_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365TodoTasksResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks")))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_todo_task_read(&self, list_id: &str, id: &str) -> Result<crate::output::Ms365TodoTaskReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_todo_task_read(
+        &self,
+        list_id: &str,
+        id: &str,
+    ) -> Result<crate::output::Ms365TodoTaskReadResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/todo/lists/{list_id}/tasks/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 
-    pub async fn ms365_sites_list(&self, limit: u32) -> Result<crate::output::Ms365SitesListResponse> {
-        let r = self.http.get(self.url("/ms365/sites"))
+    pub async fn ms365_sites_list(
+        &self,
+        limit: u32,
+    ) -> Result<crate::output::Ms365SitesListResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/sites"))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn ms365_sites_read(&self, id: &str) -> Result<crate::output::Ms365SiteReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/sites/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/sites/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_sites_lists(&self, site_id: &str, limit: u32) -> Result<crate::output::Ms365SiteListsResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/sites/{site_id}/lists")))
+    pub async fn ms365_sites_lists(
+        &self,
+        site_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365SiteListsResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/sites/{site_id}/lists")))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_sites_list_items(&self, site_id: &str, list_id: &str, limit: u32) -> Result<crate::output::Ms365SiteListItemsResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/sites/{site_id}/lists/{list_id}/items")))
+    pub async fn ms365_sites_list_items(
+        &self,
+        site_id: &str,
+        list_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365SiteListItemsResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/sites/{site_id}/lists/{list_id}/items")))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 
-    pub async fn ms365_teams_list(&self, limit: u32) -> Result<crate::output::Ms365TeamsListResponse> {
-        let r = self.http.get(self.url("/ms365/teams"))
+    pub async fn ms365_teams_list(
+        &self,
+        limit: u32,
+    ) -> Result<crate::output::Ms365TeamsListResponse> {
+        let r = self
+            .http
+            .get(self.url("/ms365/teams"))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_teams_channels(&self, team_id: &str, limit: u32) -> Result<crate::output::Ms365TeamsChannelsResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels")))
+    pub async fn ms365_teams_channels(
+        &self,
+        team_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365TeamsChannelsResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/teams/{team_id}/channels")))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_teams_channel_read(&self, team_id: &str, id: &str) -> Result<crate::output::Ms365TeamsChannelReadResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels/{id}")))
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn ms365_teams_channel_read(
+        &self,
+        team_id: &str,
+        id: &str,
+    ) -> Result<crate::output::Ms365TeamsChannelReadResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!("/ms365/teams/{team_id}/channels/{id}")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn ms365_teams_messages(&self, team_id: &str, channel_id: &str, limit: u32) -> Result<crate::output::Ms365TeamsMessagesResponse> {
-        let r = self.http.get(self.url(&format!("/ms365/teams/{team_id}/channels/{channel_id}/messages")))
+    pub async fn ms365_teams_messages(
+        &self,
+        team_id: &str,
+        channel_id: &str,
+        limit: u32,
+    ) -> Result<crate::output::Ms365TeamsMessagesResponse> {
+        let r = self
+            .http
+            .get(self.url(&format!(
+                "/ms365/teams/{team_id}/channels/{channel_id}/messages"
+            )))
             .query(&[("limit", limit.to_string())])
-            .send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 
     // ── Lifecycle (#74, #70) ────────────────────────────────────
     pub async fn setup(&self) -> Result<crate::output::SetupResponse> {
-        let r = self.http.post(self.url("/setup")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url("/setup"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
-    pub async fn backup_create(&self, label: Option<&str>) -> Result<crate::output::BackupCreateResponse> {
-        let mut b = json!({}); if let Some(l) = label { b["label"] = json!(l); }
-        let r = self.http.post(self.url("/backups")).json(&b).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+    pub async fn backup_create(
+        &self,
+        label: Option<&str>,
+    ) -> Result<crate::output::BackupCreateResponse> {
+        let mut b = json!({});
+        if let Some(l) = label {
+            b["label"] = json!(l);
+        }
+        let r = self
+            .http
+            .post(self.url("/backups"))
+            .json(&b)
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn backup_list(&self) -> Result<crate::output::BackupListResponse> {
-        let r = self.http.get(self.url("/backups")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/backups"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn backup_restore(&self, id: &str) -> Result<crate::output::BackupRestoreResponse> {
-        let r = self.http.post(self.url(&format!("/backups/{id}/restore"))).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url(&format!("/backups/{id}/restore")))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn update_check(&self) -> Result<crate::output::UpdateCheckResponse> {
-        let r = self.http.get(self.url("/update/check")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/update/check"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn update_apply(&self) -> Result<crate::output::UpdateApplyResponse> {
-        let r = self.http.post(self.url("/update/apply")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url("/update/apply"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn update_status(&self) -> Result<crate::output::UpdateStatusResponse> {
-        let r = self.http.get(self.url("/update/status")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .get(self.url("/update/status"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
     pub async fn reset(&self) -> Result<crate::output::ResetResponse> {
-        let r = self.http.post(self.url("/reset")).send().await.context("gateway")?;
-        if r.status().is_success() { Ok(r.json().await.context("json")?) } else { bail!("HTTP {}", r.status()); }
+        let r = self
+            .http
+            .post(self.url("/reset"))
+            .send()
+            .await
+            .context("gateway")?;
+        if r.status().is_success() {
+            Ok(r.json().await.context("json")?)
+        } else {
+            bail!("HTTP {}", r.status());
+        }
     }
 }
 
@@ -5169,6 +5764,93 @@ mod tests {
         assert!(resp.detail.contains("Thread not found"));
     }
 
+    #[tokio::test]
+    async fn ms365_planner_task_create_posts_expected_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ms365/planner/tasks"))
+            .and(body_json(json!({
+                "plan_id": "plan-1",
+                "title": "Draft follow-up",
+                "bucket_id": "bucket-1",
+                "due_date": "2026-03-25T12:00:00Z",
+                "description": "Prepare operator summary"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "Planner task created",
+                "task_id": "task-1"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .ms365_planner_task_create(
+                "plan-1",
+                "Draft follow-up",
+                Some("bucket-1"),
+                Some("2026-03-25T12:00:00Z"),
+                Some("Prepare operator summary"),
+            )
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.task_id.as_deref(), Some("task-1"));
+    }
+
+    #[tokio::test]
+    async fn ms365_planner_task_update_posts_only_changed_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ms365/planner/tasks/task-1"))
+            .and(body_json(json!({
+                "title": "Updated summary",
+                "percent_complete": 60
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "Planner task updated",
+                "task_id": "task-1"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client
+            .ms365_planner_task_update(
+                "task-1",
+                Some("Updated summary"),
+                None,
+                None,
+                None,
+                Some(60),
+            )
+            .await
+            .unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.task_id.as_deref(), Some("task-1"));
+    }
+
+    #[tokio::test]
+    async fn ms365_planner_task_complete_posts_expected_route() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ms365/planner/tasks/task-1/complete"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "message": "Planner task completed",
+                "task_id": "task-1"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let resp = client.ms365_planner_task_complete("task-1").await.unwrap();
+        assert!(resp.success);
+        assert_eq!(resp.task_id.as_deref(), Some("task-1"));
+    }
+
     // ── Security ──────────────────────────────────────────────────
 
     #[tokio::test]
@@ -5332,10 +6014,7 @@ mod tests {
             .await;
 
         let client = GatewayClient::new(&server.uri());
-        let resp = client
-            .secrets_apply(json!({"secrets": []}))
-            .await
-            .unwrap();
+        let resp = client.secrets_apply(json!({"secrets": []})).await.unwrap();
         assert!(resp.success);
         assert_eq!(resp.applied, 2);
     }
@@ -5400,7 +6079,10 @@ mod subagent_tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({"session_id":"child-1","parent_session_id":"sess-1","mode":"coding","policy":"inherit","status":"spawned"})))
             .mount(&server).await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.agent_spawn("sess-1","coding","inherit","test",None).await.unwrap();
+        let r = c
+            .agent_spawn("sess-1", "coding", "inherit", "test", None)
+            .await
+            .unwrap();
         assert_eq!(r.session_id, "child-1");
         assert_eq!(r.parent_session_id, "sess-1");
     }
@@ -5408,64 +6090,90 @@ mod subagent_tests {
     #[tokio::test]
     async fn agent_steer_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/agents/child-1/steer"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"accepted":true,"detail":"ok"})))
-            .mount(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/agents/child-1/steer"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"accepted":true,"detail":"ok"})),
+            )
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.agent_steer("child-1","focus").await.unwrap();
+        let r = c.agent_steer("child-1", "focus").await.unwrap();
         assert!(r.accepted);
     }
 
     #[tokio::test]
     async fn agent_steer_404() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/agents/x/steer"))
-            .respond_with(ResponseTemplate::new(404)).mount(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/agents/x/steer"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        assert!(c.agent_steer("x","hi").await.is_err());
+        assert!(c.agent_steer("x", "hi").await.is_err());
     }
 
     #[tokio::test]
     async fn agent_kill_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/agents/child-1/kill"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"killed":true,"detail":"done"})))
-            .mount(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/agents/child-1/kill"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"killed":true,"detail":"done"})),
+            )
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.agent_kill("child-1",Some("timeout")).await.unwrap();
+        let r = c.agent_kill("child-1", Some("timeout")).await.unwrap();
         assert!(r.killed);
     }
 
     #[tokio::test]
     async fn agent_run_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/agents/s1/run"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"turn_id":"t1","status":"completed","output":"ok"})))
-            .mount(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/agents/s1/run"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"turn_id":"t1","status":"completed","output":"ok"})),
+            )
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.agent_run("s1","go",1,true).await.unwrap();
+        let r = c.agent_run("s1", "go", 1, true).await.unwrap();
         assert_eq!(r.turn_id, "t1");
     }
 
     #[tokio::test]
     async fn agent_result_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("GET")).and(path("/agents/s1/turns/t1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"status":"completed","output":"res"})))
-            .mount(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/agents/s1/turns/t1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"status":"completed","output":"res"})),
+            )
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.agent_result("s1","t1").await.unwrap();
+        let r = c.agent_result("s1", "t1").await.unwrap();
         assert_eq!(r.output.as_deref(), Some("res"));
     }
 
     #[tokio::test]
     async fn acp_send_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/acp/send"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message_id":"m1","delivered":true})))
-            .mount(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/acp/send"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"message_id":"m1","delivered":true})),
+            )
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.acp_send("a","b",r#"{"x":1}"#).await.unwrap();
+        let r = c.acp_send("a", "b", r#"{"x":1}"#).await.unwrap();
         assert!(r.delivered);
     }
 
@@ -5483,11 +6191,13 @@ mod subagent_tests {
     #[tokio::test]
     async fn acp_ack_ok() {
         let server = MockServer::start().await;
-        Mock::given(method("POST")).and(path("/acp/ack"))
+        Mock::given(method("POST"))
+            .and(path("/acp/ack"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({"acknowledged":true})))
-            .mount(&server).await;
+            .mount(&server)
+            .await;
         let c = GatewayClient::new(&server.uri());
-        let r = c.acp_ack("m1","a").await.unwrap();
+        let r = c.acp_ack("m1", "a").await.unwrap();
         assert!(r.acknowledged);
     }
 }
@@ -5497,24 +6207,44 @@ mod subagent_tests {
 impl GatewayClient {
     /// `GET /plugins` — list installed plugins.
     pub async fn plugins_list(&self) -> Result<crate::output::PluginListResponse> {
-        let resp = self.http.get(self.url("/plugins")).send().await.context("failed to reach gateway")?;
+        let resp = self
+            .http
+            .get(self.url("/plugins"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
             let v: serde_json::Value = resp.json().await.context("invalid JSON from /plugins")?;
-            let plugins = v["plugins"].as_array().unwrap_or(&vec![]).iter().map(|p| crate::output::PluginSummary {
-                name: p["name"].as_str().unwrap_or("?").to_string(),
-                version: p["version"].as_str().unwrap_or("0.0.0").to_string(),
-                enabled: p["enabled"].as_bool().unwrap_or(false),
-                description: p["description"].as_str().unwrap_or("").to_string(),
-            }).collect();
+            let plugins = v["plugins"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|p| crate::output::PluginSummary {
+                    name: p["name"].as_str().unwrap_or("?").to_string(),
+                    version: p["version"].as_str().unwrap_or("0.0.0").to_string(),
+                    enabled: p["enabled"].as_bool().unwrap_or(false),
+                    description: p["description"].as_str().unwrap_or("").to_string(),
+                })
+                .collect();
             Ok(crate::output::PluginListResponse { plugins })
-        } else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `GET /plugins/:name` — show plugin details.
     pub async fn plugins_info(&self, name: &str) -> Result<crate::output::PluginInfoResponse> {
-        let resp = self.http.get(self.url(&format!("/plugins/{name}"))).send().await.context("failed to reach gateway")?;
+        let resp = self
+            .http
+            .get(self.url(&format!("/plugins/{name}")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let v: serde_json::Value = resp.json().await.context("invalid JSON from /plugins/:name")?;
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /plugins/:name")?;
             Ok(crate::output::PluginInfoResponse {
                 name: v["name"].as_str().unwrap_or("?").to_string(),
                 version: v["version"].as_str().unwrap_or("0.0.0").to_string(),
@@ -5523,46 +6253,82 @@ impl GatewayClient {
                 source: v["source"].as_str().unwrap_or("unknown").to_string(),
                 manifest_valid: v["manifest_valid"].as_bool().unwrap_or(true),
             })
-        } else if resp.status() == reqwest::StatusCode::NOT_FOUND { bail!("Plugin '{name}' not found."); }
-        else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("Plugin '{name}' not found.");
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `POST /plugins/:action` — plugin lifecycle mutation.
-    pub async fn plugins_mutate(&self, action: &str, name_or_source: &str) -> Result<crate::output::PluginMutationResponse> {
-        let resp = self.http.post(self.url(&format!("/plugins/{action}")))
+    pub async fn plugins_mutate(
+        &self,
+        action: &str,
+        name_or_source: &str,
+    ) -> Result<crate::output::PluginMutationResponse> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/plugins/{action}")))
             .json(&serde_json::json!({"name": name_or_source}))
-            .send().await.context("failed to reach gateway")?;
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let v: serde_json::Value = resp.json().await.context("invalid JSON from POST /plugins/:action")?;
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /plugins/:action")?;
             Ok(crate::output::PluginMutationResponse {
                 success: v["success"].as_bool().unwrap_or(true),
                 plugin: v["plugin"].as_str().unwrap_or(name_or_source).to_string(),
                 action: action.to_string(),
                 detail: v["detail"].as_str().unwrap_or("done").to_string(),
             })
-        } else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `GET /hooks` — list configured hooks.
     pub async fn hooks_list(&self) -> Result<crate::output::HookListResponse> {
-        let resp = self.http.get(self.url("/hooks")).send().await.context("failed to reach gateway")?;
+        let resp = self
+            .http
+            .get(self.url("/hooks"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
             let v: serde_json::Value = resp.json().await.context("invalid JSON from /hooks")?;
-            let hooks = v["hooks"].as_array().unwrap_or(&vec![]).iter().map(|h| crate::output::HookSummary {
-                name: h["name"].as_str().unwrap_or("?").to_string(),
-                event: h["event"].as_str().unwrap_or("?").to_string(),
-                enabled: h["enabled"].as_bool().unwrap_or(false),
-                description: h["description"].as_str().unwrap_or("").to_string(),
-            }).collect();
+            let hooks = v["hooks"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|h| crate::output::HookSummary {
+                    name: h["name"].as_str().unwrap_or("?").to_string(),
+                    event: h["event"].as_str().unwrap_or("?").to_string(),
+                    enabled: h["enabled"].as_bool().unwrap_or(false),
+                    description: h["description"].as_str().unwrap_or("").to_string(),
+                })
+                .collect();
             Ok(crate::output::HookListResponse { hooks })
-        } else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `GET /hooks/:name` — show hook details.
     pub async fn hooks_info(&self, name: &str) -> Result<crate::output::HookInfoResponse> {
-        let resp = self.http.get(self.url(&format!("/hooks/{name}"))).send().await.context("failed to reach gateway")?;
+        let resp = self
+            .http
+            .get(self.url(&format!("/hooks/{name}")))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let v: serde_json::Value = resp.json().await.context("invalid JSON from /hooks/:name")?;
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /hooks/:name")?;
             Ok(crate::output::HookInfoResponse {
                 name: v["name"].as_str().unwrap_or("?").to_string(),
                 event: v["event"].as_str().unwrap_or("?").to_string(),
@@ -5570,41 +6336,63 @@ impl GatewayClient {
                 description: v["description"].as_str().unwrap_or("").to_string(),
                 source: v["source"].as_str().unwrap_or("unknown").to_string(),
             })
-        } else if resp.status() == reqwest::StatusCode::NOT_FOUND { bail!("Hook '{name}' not found."); }
-        else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("Hook '{name}' not found.");
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `GET /hooks/check` — validate hook configuration.
     pub async fn hooks_check(&self) -> Result<crate::output::HookCheckResponse> {
-        let resp = self.http.get(self.url("/hooks/check")).send().await.context("failed to reach gateway")?;
+        let resp = self
+            .http
+            .get(self.url("/hooks/check"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let v: serde_json::Value = resp.json().await.context("invalid JSON from /hooks/check")?;
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from /hooks/check")?;
             Ok(crate::output::HookCheckResponse {
                 total: v["total"].as_u64().unwrap_or(0) as usize,
                 valid: v["valid"].as_u64().unwrap_or(0) as usize,
                 invalid: v["invalid"].as_u64().unwrap_or(0) as usize,
                 detail: v["detail"].as_str().unwrap_or("check complete").to_string(),
             })
-        } else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
 
     /// `POST /hooks/:action` — hook lifecycle mutation.
-    pub async fn hooks_mutate(&self, action: &str, name_or_source: &str) -> Result<crate::output::HookMutationResponse> {
-        let resp = self.http.post(self.url(&format!("/hooks/{action}")))
+    pub async fn hooks_mutate(
+        &self,
+        action: &str,
+        name_or_source: &str,
+    ) -> Result<crate::output::HookMutationResponse> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/hooks/{action}")))
             .json(&serde_json::json!({"name": name_or_source}))
-            .send().await.context("failed to reach gateway")?;
+            .send()
+            .await
+            .context("failed to reach gateway")?;
         if resp.status().is_success() {
-            let v: serde_json::Value = resp.json().await.context("invalid JSON from POST /hooks/:action")?;
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .context("invalid JSON from POST /hooks/:action")?;
             Ok(crate::output::HookMutationResponse {
                 success: v["success"].as_bool().unwrap_or(true),
                 hook: v["hook"].as_str().unwrap_or(name_or_source).to_string(),
                 action: action.to_string(),
                 detail: v["detail"].as_str().unwrap_or("done").to_string(),
             })
-        } else { bail!("Gateway returned HTTP {}", resp.status()); }
+        } else {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
     }
-
-
-
-
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod cli;
 pub mod client;
 pub mod doctor;
-pub mod memory;
 mod logs;
+pub mod memory;
 pub mod output;
 
 use anyhow::{Context, Result};
@@ -24,29 +24,27 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 
 pub use cli::Cli;
 use cli::{
-    AcpAction, AgentAction, AgentsAction, ApprovalsAction, HooksAction, ChannelsAction, Command,
-    CompletionAction, CompletionShell,
-    ConfigAction, CronAction, CronDeliveryMode, DoctorAction, GatewayAction,
-    GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction, LogsAction, LogsArgs,
-    MemoryAction, MessageAction, MessageTagAction, MessageThreadAction, MessageVoiceAction,
-    ModelsAction, Ms365Action, Ms365AuthAction, Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction, Ms365TeamsAction, Ms365TodoAction, Ms365UsersAction, ProcessAction,
-    RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction,
-    SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction, PluginsAction,
-    BackupAction, UpdateAction,
+    AcpAction, AgentAction, AgentsAction, ApprovalsAction, BackupAction, ChannelsAction, Command,
+    CompletionAction, CompletionShell, ConfigAction, CronAction, CronDeliveryMode, DoctorAction,
+    GatewayAction, GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction,
+    HooksAction, LogsAction, LogsArgs, MemoryAction, MessageAction, MessageTagAction,
+    MessageThreadAction, MessageVoiceAction, ModelsAction, Ms365Action, Ms365AuthAction,
+    Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction,
+    Ms365TeamsAction, Ms365TodoAction, Ms365UsersAction, PluginsAction, ProcessAction,
+    RemindersAction, SandboxAction, SecretsAction, SecurityAction, SessionsAction, SkillsAction,
+    SystemAction, SystemEventAction, SystemHeartbeatAction, UpdateAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
 };
 use output::{
-    ChannelCapabilitiesResponse, ChannelDetail, ChannelListResponse,
-    ChannelLogFile, ChannelLogsResponse,
-    ChannelResolveResponse, ChannelStatusResponse,
-    DashboardChannelsSummary,
+    ChannelCapabilitiesResponse, ChannelDetail, ChannelListResponse, ChannelLogFile,
+    ChannelLogsResponse, ChannelResolveResponse, ChannelStatusResponse, DashboardChannelsSummary,
     DashboardModelsSummary, DashboardResponse, DashboardSessionsSummary, HeartbeatPresenceResponse,
     ModelAliasDetail, ModelAliasesResponse, ModelAuthProviderDetail, ModelAuthResponse,
     ModelFallbackChainDetail, ModelFallbacksResponse, ModelListResponse, ModelProviderDetail,
-    ModelScanResponse, ModelSetImageResponse, ModelSetResponse, ModelStatusResponse,
-    OutputFormat, TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
+    ModelScanResponse, ModelSetImageResponse, ModelSetResponse, ModelStatusResponse, OutputFormat,
+    TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
 };
 
 /// Initialize a workspace directory with default files.
@@ -815,7 +813,9 @@ async fn init_workspace(
         let spells_toml: Vec<String> = tpl.spells.iter().map(|s| format!("\"{s}\"")).collect();
         let config_content = format!(
             "# Auto-generated from template: {}\n\n[agent]\nmode = \"{}\"\nspells = [{}]\n",
-            tpl.name, tpl.mode, spells_toml.join(", ")
+            tpl.name,
+            tpl.mode,
+            spells_toml.join(", ")
         );
         let config_path = path.join("config.toml");
         if !config_path.exists() {
@@ -974,12 +974,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 since,
             }) => {
                 let result = client
-                    .logs_query(
-                        level.as_deref(),
-                        source.as_deref(),
-                        limit,
-                        since.as_deref(),
-                    )
+                    .logs_query(level.as_deref(), source.as_deref(), limit, since.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1037,28 +1032,68 @@ pub async fn run(cli: Cli) -> Result<()> {
                 since,
             }) => {
                 let result = client
-                    .logs_query(
-                        level.as_deref(),
-                        source.as_deref(),
-                        limit,
-                        since.as_deref(),
-                    )
+                    .logs_query(level.as_deref(), source.as_deref(), limit, since.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
-            LogsAction::Tail { level, source, follow, lines } => {
+            LogsAction::Tail {
+                level,
+                source,
+                follow,
+                lines,
+            } => {
                 let http = reqwest::Client::new();
-                let result = logs::tail(&cli.gateway_url, &http, level.as_deref(), source.as_deref(), follow, lines).await?;
+                let result = logs::tail(
+                    &cli.gateway_url,
+                    &http,
+                    level.as_deref(),
+                    source.as_deref(),
+                    follow,
+                    lines,
+                )
+                .await?;
                 println!("{}", render(&result, format));
             }
-            LogsAction::Search { query, level, source, limit } => {
+            LogsAction::Search {
+                query,
+                level,
+                source,
+                limit,
+            } => {
                 let http = reqwest::Client::new();
-                let result = logs::search(&cli.gateway_url, &http, &query, level.as_deref(), source.as_deref(), limit).await?;
+                let result = logs::search(
+                    &cli.gateway_url,
+                    &http,
+                    &query,
+                    level.as_deref(),
+                    source.as_deref(),
+                    limit,
+                )
+                .await?;
                 println!("{}", render(&result, format));
             }
-            LogsAction::Export { format: fmt, level, source, since, until, limit, output } => {
+            LogsAction::Export {
+                format: fmt,
+                level,
+                source,
+                since,
+                until,
+                limit,
+                output,
+            } => {
                 let http = reqwest::Client::new();
-                let result = logs::export(&cli.gateway_url, &http, &fmt, level.as_deref(), source.as_deref(), since.as_deref(), until.as_deref(), limit, output.as_deref()).await?;
+                let result = logs::export(
+                    &cli.gateway_url,
+                    &http,
+                    &fmt,
+                    level.as_deref(),
+                    source.as_deref(),
+                    since.as_deref(),
+                    until.as_deref(),
+                    limit,
+                    output.as_deref(),
+                )
+                .await?;
                 println!("{}", render(&result, format));
             }
         },
@@ -1108,7 +1143,11 @@ pub async fn run(cli: Cli) -> Result<()> {
             };
             println!("{}", render(&dashboard, format));
         }
-        Command::Init { path, template, non_interactive } => {
+        Command::Init {
+            path,
+            template,
+            non_interactive,
+        } => {
             let target = std::path::Path::new(&path);
             init_workspace(target, template.as_deref(), non_interactive).await?;
         }
@@ -1187,19 +1226,43 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_mail_folders().await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365MailAction::Send { to, subject, body, cc } => {
-                    let to: Vec<String> = to.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
-                    let cc: Vec<String> = cc.unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                Ms365MailAction::Send {
+                    to,
+                    subject,
+                    body,
+                    cc,
+                } => {
+                    let to: Vec<String> = to
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    let cc: Vec<String> = cc
+                        .unwrap_or_default()
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
                     let result = client.ms365_mail_send(&to, &subject, &body, &cc).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365MailAction::Reply { id, body, reply_all } => {
+                Ms365MailAction::Reply {
+                    id,
+                    body,
+                    reply_all,
+                } => {
                     let result = client.ms365_mail_reply(&id, &body, reply_all).await?;
                     println!("{}", render(&result, format));
                 }
                 Ms365MailAction::Forward { id, to, comment } => {
-                    let to: Vec<String> = to.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
-                    let result = client.ms365_mail_forward(&id, &to, comment.as_deref()).await?;
+                    let to: Vec<String> = to
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    let result = client
+                        .ms365_mail_forward(&id, &to, comment.as_deref())
+                        .await?;
                     println!("{}", render(&result, format));
                 }
                 Ms365MailAction::Attachments { id } => {
@@ -1210,10 +1273,17 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_mail_attachment_read(&message_id, &id).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365MailAction::AttachmentDownload { message_id, id, output } => {
-                    let (filename, bytes) = client.ms365_mail_attachment_download(&message_id, &id).await?;
+                Ms365MailAction::AttachmentDownload {
+                    message_id,
+                    id,
+                    output,
+                } => {
+                    let (filename, bytes) = client
+                        .ms365_mail_attachment_download(&message_id, &id)
+                        .await?;
                     let dest = output.unwrap_or_else(|| filename.clone());
-                    tokio::fs::write(&dest, &bytes).await
+                    tokio::fs::write(&dest, &bytes)
+                        .await
                         .with_context(|| format!("failed to write attachment to {dest}"))?;
                     let result = crate::output::Ms365MailAttachmentDownloadResponse {
                         attachment_id: id,
@@ -1233,17 +1303,44 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_calendar_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365CalendarAction::Create { subject, start, end, attendees, location, body } => {
-                    let attendees: Vec<String> = attendees.unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
-                    let result = client.ms365_calendar_create(&subject, &start, &end, &attendees, location.as_deref(), body.as_deref()).await?;
+                Ms365CalendarAction::Create {
+                    subject,
+                    start,
+                    end,
+                    attendees,
+                    location,
+                    body,
+                } => {
+                    let attendees: Vec<String> = attendees
+                        .unwrap_or_default()
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    let result = client
+                        .ms365_calendar_create(
+                            &subject,
+                            &start,
+                            &end,
+                            &attendees,
+                            location.as_deref(),
+                            body.as_deref(),
+                        )
+                        .await?;
                     println!("{}", render(&result, format));
                 }
                 Ms365CalendarAction::Delete { id } => {
                     let result = client.ms365_calendar_delete(&id).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365CalendarAction::Respond { id, response, comment } => {
-                    let result = client.ms365_calendar_respond(&id, &response, comment.as_deref()).await?;
+                Ms365CalendarAction::Respond {
+                    id,
+                    response,
+                    comment,
+                } => {
+                    let result = client
+                        .ms365_calendar_respond(&id, &response, comment.as_deref())
+                        .await?;
                     println!("{}", render(&result, format));
                 }
             },
@@ -1263,7 +1360,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 Ms365FilesAction::Download { id, output } => {
                     let (filename, bytes) = client.ms365_files_download(&id).await?;
                     let dest = output.unwrap_or_else(|| filename.clone());
-                    tokio::fs::write(&dest, &bytes).await
+                    tokio::fs::write(&dest, &bytes)
+                        .await
                         .with_context(|| format!("failed to write OneDrive file to {dest}"))?;
                     let result = crate::output::Ms365FileDownloadResponse {
                         item_id: id,
@@ -1301,6 +1399,48 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_planner_task_read(&id).await?;
                     println!("{}", render(&result, format));
                 }
+                Ms365PlannerAction::Create {
+                    plan_id,
+                    title,
+                    bucket_id,
+                    due_date,
+                    description,
+                } => {
+                    let result = client
+                        .ms365_planner_task_create(
+                            &plan_id,
+                            &title,
+                            bucket_id.as_deref(),
+                            due_date.as_deref(),
+                            description.as_deref(),
+                        )
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365PlannerAction::Update {
+                    id,
+                    title,
+                    bucket_id,
+                    due_date,
+                    description,
+                    percent_complete,
+                } => {
+                    let result = client
+                        .ms365_planner_task_update(
+                            &id,
+                            title.as_deref(),
+                            bucket_id.as_deref(),
+                            due_date.as_deref(),
+                            description.as_deref(),
+                            percent_complete,
+                        )
+                        .await?;
+                    println!("{}", render(&result, format));
+                }
+                Ms365PlannerAction::Complete { id } => {
+                    let result = client.ms365_planner_task_complete(&id).await?;
+                    println!("{}", render(&result, format));
+                }
             },
             Ms365Action::Todo { action } => match action {
                 Ms365TodoAction::Lists { limit } => {
@@ -1329,8 +1469,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_teams_channel_read(&team_id, &id).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365TeamsAction::Messages { team_id, channel_id, limit } => {
-                    let result = client.ms365_teams_messages(&team_id, &channel_id, limit).await?;
+                Ms365TeamsAction::Messages {
+                    team_id,
+                    channel_id,
+                    limit,
+                } => {
+                    let result = client
+                        .ms365_teams_messages(&team_id, &channel_id, limit)
+                        .await?;
                     println!("{}", render(&result, format));
                 }
             },
@@ -1347,8 +1493,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let result = client.ms365_sites_lists(&site_id, limit).await?;
                     println!("{}", render(&result, format));
                 }
-                Ms365SitesAction::ListItems { site_id, list_id, limit } => {
-                    let result = client.ms365_sites_list_items(&site_id, &list_id, limit).await?;
+                Ms365SitesAction::ListItems {
+                    site_id,
+                    list_id,
+                    limit,
+                } => {
+                    let result = client
+                        .ms365_sites_list_items(&site_id, &list_id, limit)
+                        .await?;
                     println!("{}", render(&result, format));
                 }
             },
@@ -1499,9 +1651,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 // Apply filters.
                 let mut entries: Vec<_> = all
                     .into_iter()
-                    .filter(|e| {
-                        kind.as_ref().is_none_or(|k| e.kind.eq_ignore_ascii_case(k))
-                    })
+                    .filter(|e| kind.as_ref().is_none_or(|k| e.kind.eq_ignore_ascii_case(k)))
                     .filter(|e| {
                         turn.as_ref().is_none_or(|t| {
                             e.turn_id.as_deref().is_some_and(|tid| tid == t.as_str())
@@ -1636,8 +1786,14 @@ pub async fn run(cli: Cli) -> Result<()> {
                 println!("{}", render(&result, format));
             }
             AgentsAction::Tree { limit } => {
-                let sessions = client.sessions_list(None, None, Some("subagent"), None, limit).await?;
-                let root = sessions.sessions.first().map(|s| s.id.clone()).unwrap_or_default();
+                let sessions = client
+                    .sessions_list(None, None, Some("subagent"), None, limit)
+                    .await?;
+                let root = sessions
+                    .sessions
+                    .first()
+                    .map(|s| s.id.clone())
+                    .unwrap_or_default();
                 let result = client.sessions_tree(&root).await?;
                 println!("{}", render(&result, format));
             }
@@ -1863,12 +2019,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 thread,
             } => {
                 let result = client
-                    .message_send(
-                        &channel,
-                        &text,
-                        session.as_deref(),
-                        thread.as_deref(),
-                    )
+                    .message_send(&channel, &text, session.as_deref(), thread.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1879,12 +2030,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 limit,
             } => {
                 let result = client
-                    .message_search(
-                        &query,
-                        channel.as_deref(),
-                        session.as_deref(),
-                        limit,
-                    )
+                    .message_search(&query, channel.as_deref(), session.as_deref(), limit)
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1923,12 +2069,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 session,
             } => {
                 let result = client
-                    .message_edit(
-                        &message_id,
-                        &channel,
-                        &text,
-                        session.as_deref(),
-                    )
+                    .message_edit(&message_id, &channel, &text, session.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1938,12 +2079,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 session,
             } => {
                 let result = client
-                    .message_pin(
-                        &message_id,
-                        false,
-                        channel.as_deref(),
-                        session.as_deref(),
-                    )
+                    .message_pin(&message_id, false, channel.as_deref(), session.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -1953,12 +2089,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 session,
             } => {
                 let result = client
-                    .message_pin(
-                        &message_id,
-                        true,
-                        channel.as_deref(),
-                        session.as_deref(),
-                    )
+                    .message_pin(&message_id, true, channel.as_deref(), session.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -2006,12 +2137,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     session,
                 } => {
                     let result = client
-                        .message_thread_reply(
-                            &thread_id,
-                            &channel,
-                            &text,
-                            session.as_deref(),
-                        )
+                        .message_thread_reply(&thread_id, &channel, &text, session.as_deref())
                         .await?;
                     println!("{}", render(&result, format));
                 }
@@ -2036,9 +2162,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                             let output_path = if let Some(ref path) = output {
                                 tokio::fs::write(path, &bytes)
                                     .await
-                                    .with_context(|| {
-                                        format!("failed to write audio to {path}")
-                                    })?;
+                                    .with_context(|| format!("failed to write audio to {path}"))?;
                                 Some(path.clone())
                             } else {
                                 None
@@ -2106,11 +2230,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 session,
             } => {
                 let result = client
-                    .message_list_reactions(
-                        &message_id,
-                        channel.as_deref(),
-                        session.as_deref(),
-                    )
+                    .message_list_reactions(&message_id, channel.as_deref(), session.as_deref())
                     .await?;
                 println!("{}", render(&result, format));
             }
@@ -2122,12 +2242,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     session,
                 } => {
                     let result = client
-                        .message_tag_add(
-                            &message_id,
-                            &tag,
-                            channel.as_deref(),
-                            session.as_deref(),
-                        )
+                        .message_tag_add(&message_id, &tag, channel.as_deref(), session.as_deref())
                         .await?;
                     println!("{}", render(&result, format));
                 }
@@ -2153,11 +2268,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     session,
                 } => {
                     let result = client
-                        .message_tag_list(
-                            &message_id,
-                            channel.as_deref(),
-                            session.as_deref(),
-                        )
+                        .message_tag_list(&message_id, channel.as_deref(), session.as_deref())
                         .await?;
                     println!("{}", render(&result, format));
                 }
@@ -2283,7 +2394,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 max_turns,
                 wait,
             } => {
-                let result = client.agent_run(&session, &message, max_turns, wait).await?;
+                let result = client
+                    .agent_run(&session, &message, max_turns, wait)
+                    .await?;
                 println!("{}", render(&result, format));
             }
             AgentAction::Result { session, turn } => {
@@ -2570,10 +2683,7 @@ models = ["dall-e-3"]
 
         let response = set_default_image_model("dall-e-3").unwrap();
         assert!(response.changed);
-        assert_eq!(
-            response.default_image_model,
-            "hamza-eastus2/dall-e-3"
-        );
+        assert_eq!(response.default_image_model, "hamza-eastus2/dall-e-3");
         assert!(response.previous_image_model.is_none());
 
         let updated = std::fs::read_to_string(&config_path).unwrap();
@@ -2712,21 +2822,26 @@ models = ["gpt-5.4"]
     fn generate_completion_string(shell: cli::CompletionShell) -> String {
         let mut buf = Vec::new();
         let mut command = cli::Cli::command();
-        clap_complete::generate(
-            completion_shell(shell),
-            &mut command,
-            "rune",
-            &mut buf,
-        );
+        clap_complete::generate(completion_shell(shell), &mut command, "rune", &mut buf);
         String::from_utf8(buf).expect("completion script should be valid UTF-8")
     }
 
     #[test]
     fn bash_completion_contains_subcommands() {
         let script = generate_completion_string(cli::CompletionShell::Bash);
-        assert!(!script.is_empty(), "bash completion script must not be empty");
+        assert!(
+            !script.is_empty(),
+            "bash completion script must not be empty"
+        );
         // The script should reference key top-level subcommands.
-        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
+        for cmd in [
+            "gateway",
+            "status",
+            "completion",
+            "config",
+            "doctor",
+            "skills",
+        ] {
             assert!(
                 script.contains(cmd),
                 "bash completion missing subcommand `{cmd}`",
@@ -2737,8 +2852,18 @@ models = ["gpt-5.4"]
     #[test]
     fn zsh_completion_contains_subcommands() {
         let script = generate_completion_string(cli::CompletionShell::Zsh);
-        assert!(!script.is_empty(), "zsh completion script must not be empty");
-        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
+        assert!(
+            !script.is_empty(),
+            "zsh completion script must not be empty"
+        );
+        for cmd in [
+            "gateway",
+            "status",
+            "completion",
+            "config",
+            "doctor",
+            "skills",
+        ] {
             assert!(
                 script.contains(cmd),
                 "zsh completion missing subcommand `{cmd}`",
@@ -2749,8 +2874,18 @@ models = ["gpt-5.4"]
     #[test]
     fn fish_completion_contains_subcommands() {
         let script = generate_completion_string(cli::CompletionShell::Fish);
-        assert!(!script.is_empty(), "fish completion script must not be empty");
-        for cmd in ["gateway", "status", "completion", "config", "doctor", "skills"] {
+        assert!(
+            !script.is_empty(),
+            "fish completion script must not be empty"
+        );
+        for cmd in [
+            "gateway",
+            "status",
+            "completion",
+            "config",
+            "doctor",
+            "skills",
+        ] {
             assert!(
                 script.contains(cmd),
                 "fish completion missing subcommand `{cmd}`",

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -14,11 +14,7 @@ impl OutputFormat {
     /// Create from the `--json` flag value.
     #[must_use]
     pub fn from_json_flag(json: bool) -> Self {
-        if json {
-            Self::Json
-        } else {
-            Self::Human
-        }
+        if json { Self::Json } else { Self::Human }
     }
 }
 
@@ -85,7 +81,11 @@ impl fmt::Display for DoctorCheck {
             "fail" => "✗",
             _ => "•",
         };
-        write!(f, "  {icon} {} [{}]: {}", self.name, self.status, self.message)
+        write!(
+            f,
+            "  {icon} {} [{}]: {}",
+            self.name, self.status, self.message
+        )
     }
 }
 
@@ -1283,11 +1283,7 @@ impl fmt::Display for ChannelLogoutResponse {
         if self.success {
             write!(f, "Channel `{}` logged out.", self.name)
         } else {
-            write!(
-                f,
-                "Channel `{}` logout failed: {}",
-                self.name, self.message
-            )
+            write!(f, "Channel `{}` logout failed: {}", self.name, self.message)
         }
     }
 }
@@ -1310,11 +1306,7 @@ impl fmt::Display for ChannelTestResponse {
             }
             Ok(())
         } else {
-            write!(
-                f,
-                "Channel `{}`: unreachable — {}",
-                self.name, self.message
-            )
+            write!(f, "Channel `{}`: unreachable — {}", self.name, self.message)
         }
     }
 }
@@ -1967,24 +1959,66 @@ impl fmt::Display for ConfigValidationResult {
 
 // ── Config admin responses (#30) ──────────────────────────────
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConfigReloadResponse { pub success: bool, pub detail: String }
-impl fmt::Display for ConfigReloadResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { let i = if self.success { "✓" } else { "✗" }; write!(f, "{i} {}", self.detail) } }
+pub struct ConfigReloadResponse {
+    pub success: bool,
+    pub detail: String,
+}
+impl fmt::Display for ConfigReloadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let i = if self.success { "✓" } else { "✗" };
+        write!(f, "{i} {}", self.detail)
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConfigDiffResponse { pub changed: bool, pub diff: String }
-impl fmt::Display for ConfigDiffResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.changed { write!(f, "{}", self.diff) } else { write!(f, "No differences.") } } }
+pub struct ConfigDiffResponse {
+    pub changed: bool,
+    pub diff: String,
+}
+impl fmt::Display for ConfigDiffResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.changed {
+            write!(f, "{}", self.diff)
+        } else {
+            write!(f, "No differences.")
+        }
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConfigEnvResponse { pub overrides: Vec<ConfigEnvOverride> }
+pub struct ConfigEnvResponse {
+    pub overrides: Vec<ConfigEnvOverride>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConfigEnvOverride { pub key: String, pub value: String, pub source: String }
-impl fmt::Display for ConfigEnvResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.overrides.is_empty() { return write!(f, "No environment overrides active."); } for o in &self.overrides { writeln!(f, "  {}: {} ({})", o.key, o.value, o.source)?; } Ok(()) } }
+pub struct ConfigEnvOverride {
+    pub key: String,
+    pub value: String,
+    pub source: String,
+}
+impl fmt::Display for ConfigEnvResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.overrides.is_empty() {
+            return write!(f, "No environment overrides active.");
+        }
+        for o in &self.overrides {
+            writeln!(f, "  {}: {} ({})", o.key, o.value, o.source)?;
+        }
+        Ok(())
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConfigExportResponse { pub destination: String, pub bytes_written: usize }
+pub struct ConfigExportResponse {
+    pub destination: String,
+    pub bytes_written: usize,
+}
 impl fmt::Display for ConfigExportResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.destination == "-" {
             Ok(()) // content already printed to stdout
         } else {
-            write!(f, "Exported resolved config to {} ({} bytes)", self.destination, self.bytes_written)
+            write!(
+                f,
+                "Exported resolved config to {} ({} bytes)",
+                self.destination, self.bytes_written
+            )
         }
     }
 }
@@ -2025,28 +2059,107 @@ impl fmt::Display for SetupResponse {
     }
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackupCreateResponse { pub success: bool, pub backup_id: String, pub detail: String }
-impl fmt::Display for BackupCreateResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "✓ Backup {} created: {}", self.backup_id, self.detail) } }
+pub struct BackupCreateResponse {
+    pub success: bool,
+    pub backup_id: String,
+    pub detail: String,
+}
+impl fmt::Display for BackupCreateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "✓ Backup {} created: {}", self.backup_id, self.detail)
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackupSummary { pub id: String, pub label: Option<String>, pub created_at: String, pub size_bytes: Option<u64> }
+pub struct BackupSummary {
+    pub id: String,
+    pub label: Option<String>,
+    pub created_at: String,
+    pub size_bytes: Option<u64>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackupListResponse { pub backups: Vec<BackupSummary> }
-impl fmt::Display for BackupListResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.backups.is_empty() { return write!(f, "No backups found."); } for b in &self.backups { write!(f, "  {} ({})", b.id, b.created_at)?; if let Some(ref l) = b.label { write!(f, " [{l}]")?; } writeln!(f)?; } Ok(()) } }
+pub struct BackupListResponse {
+    pub backups: Vec<BackupSummary>,
+}
+impl fmt::Display for BackupListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.backups.is_empty() {
+            return write!(f, "No backups found.");
+        }
+        for b in &self.backups {
+            write!(f, "  {} ({})", b.id, b.created_at)?;
+            if let Some(ref l) = b.label {
+                write!(f, " [{l}]")?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackupRestoreResponse { pub success: bool, pub backup_id: String, pub detail: String }
-impl fmt::Display for BackupRestoreResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { let i = if self.success { "✓" } else { "✗" }; write!(f, "{i} Restore {}: {}", self.backup_id, self.detail) } }
+pub struct BackupRestoreResponse {
+    pub success: bool,
+    pub backup_id: String,
+    pub detail: String,
+}
+impl fmt::Display for BackupRestoreResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let i = if self.success { "✓" } else { "✗" };
+        write!(f, "{i} Restore {}: {}", self.backup_id, self.detail)
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateCheckResponse { pub available: bool, pub current_version: String, pub latest_version: Option<String>, pub detail: String }
-impl fmt::Display for UpdateCheckResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { if self.available { write!(f, "Update available: {} → {}", self.current_version, self.latest_version.as_deref().unwrap_or("?")) } else { write!(f, "✓ Up to date ({})", self.current_version) } } }
+pub struct UpdateCheckResponse {
+    pub available: bool,
+    pub current_version: String,
+    pub latest_version: Option<String>,
+    pub detail: String,
+}
+impl fmt::Display for UpdateCheckResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.available {
+            write!(
+                f,
+                "Update available: {} → {}",
+                self.current_version,
+                self.latest_version.as_deref().unwrap_or("?")
+            )
+        } else {
+            write!(f, "✓ Up to date ({})", self.current_version)
+        }
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateApplyResponse { pub success: bool, pub detail: String }
-impl fmt::Display for UpdateApplyResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { let i = if self.success { "✓" } else { "✗" }; write!(f, "{i} {}", self.detail) } }
+pub struct UpdateApplyResponse {
+    pub success: bool,
+    pub detail: String,
+}
+impl fmt::Display for UpdateApplyResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let i = if self.success { "✓" } else { "✗" };
+        write!(f, "{i} {}", self.detail)
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateStatusResponse { pub current_version: String, pub detail: String }
-impl fmt::Display for UpdateStatusResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{} — {}", self.current_version, self.detail) } }
+pub struct UpdateStatusResponse {
+    pub current_version: String,
+    pub detail: String,
+}
+impl fmt::Display for UpdateStatusResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} — {}", self.current_version, self.detail)
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResetResponse { pub success: bool, pub detail: String }
-impl fmt::Display for ResetResponse { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { let i = if self.success { "✓" } else { "✗" }; write!(f, "{i} {}", self.detail) } }
+pub struct ResetResponse {
+    pub success: bool,
+    pub detail: String,
+}
+impl fmt::Display for ResetResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let i = if self.success { "✓" } else { "✗" };
+        write!(f, "{i} {}", self.detail)
+    }
+}
 
 /// Location of the local config file used for mutations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3338,7 +3451,11 @@ impl fmt::Display for SecurityAuditCheck {
             "fail" => "✗",
             _ => "•",
         };
-        write!(f, "  {icon} {} [{}]: {}", self.name, self.status, self.detail)
+        write!(
+            f,
+            "  {icon} {} [{}]: {}",
+            self.name, self.status, self.detail
+        )
     }
 }
 
@@ -3367,7 +3484,11 @@ pub struct Ms365MailMessage {
 
 impl fmt::Display for Ms365MailMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "  {} | {} | {}", self.received_at, self.from, self.subject)
+        write!(
+            f,
+            "  {} | {} | {}",
+            self.received_at, self.from, self.subject
+        )
     }
 }
 
@@ -3381,7 +3502,11 @@ pub struct Ms365MailUnreadResponse {
 
 impl fmt::Display for Ms365MailUnreadResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Unread mail in {}: {} message(s)", self.folder, self.total)?;
+        writeln!(
+            f,
+            "Unread mail in {}: {} message(s)",
+            self.folder, self.total
+        )?;
         if self.messages.is_empty() {
             writeln!(f, "  (none)")?;
         } else {
@@ -3407,7 +3532,11 @@ pub struct Ms365CalendarEvent {
 impl fmt::Display for Ms365CalendarEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let loc = self.location.as_deref().unwrap_or("-");
-        write!(f, "  {} - {} | {} | {}", self.start, self.end, self.subject, loc)
+        write!(
+            f,
+            "  {} - {} | {} | {}",
+            self.start, self.end, self.subject, loc
+        )
     }
 }
 
@@ -3421,7 +3550,11 @@ pub struct Ms365CalendarUpcomingResponse {
 
 impl fmt::Display for Ms365CalendarUpcomingResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Upcoming events (next {}h): {} event(s)", self.window_hours, self.total)?;
+        writeln!(
+            f,
+            "Upcoming events (next {}h): {} event(s)",
+            self.window_hours, self.total
+        )?;
         if self.events.is_empty() {
             writeln!(f, "  (none)")?;
         } else {
@@ -3458,8 +3591,16 @@ impl fmt::Display for Ms365MailReadResponse {
         }
         writeln!(f, "Received:    {}", self.received_at)?;
         writeln!(f, "Importance:  {}", self.importance)?;
-        writeln!(f, "Read:        {}", if self.is_read { "yes" } else { "no" })?;
-        writeln!(f, "Attachments: {}", if self.has_attachments { "yes" } else { "no" })?;
+        writeln!(
+            f,
+            "Read:        {}",
+            if self.is_read { "yes" } else { "no" }
+        )?;
+        writeln!(
+            f,
+            "Attachments: {}",
+            if self.has_attachments { "yes" } else { "no" }
+        )?;
         writeln!(f)?;
         writeln!(f, "{}", self.body_preview)?;
         Ok(())
@@ -3562,7 +3703,11 @@ pub struct Ms365AuthStatusResponse {
 impl fmt::Display for Ms365AuthStatusResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "MS365 Auth Status")?;
-        writeln!(f, "  Authenticated: {}", if self.authenticated { "yes" } else { "no" })?;
+        writeln!(
+            f,
+            "  Authenticated: {}",
+            if self.authenticated { "yes" } else { "no" }
+        )?;
         if let Some(t) = &self.tenant_id {
             writeln!(f, "  Tenant ID:     {t}")?;
         }
@@ -3575,7 +3720,11 @@ impl fmt::Display for Ms365AuthStatusResponse {
         if !self.scopes.is_empty() {
             writeln!(f, "  Scopes:        {}", self.scopes.join(", "))?;
         }
-        writeln!(f, "  Token valid:   {}", if self.token_valid { "yes" } else { "no" })?;
+        writeln!(
+            f,
+            "  Token valid:   {}",
+            if self.token_valid { "yes" } else { "no" }
+        )?;
         if let Some(exp) = &self.token_expires_at {
             writeln!(f, "  Token expires: {exp}")?;
         }
@@ -3594,7 +3743,11 @@ pub struct Ms365MailFolder {
 
 impl fmt::Display for Ms365MailFolder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "  {} ({} total, {} unread)", self.display_name, self.total_count, self.unread_count)
+        write!(
+            f,
+            "  {} ({} total, {} unread)",
+            self.display_name, self.total_count, self.unread_count
+        )
     }
 }
 
@@ -3675,7 +3828,14 @@ pub struct Ms365MailAttachmentSummary {
 impl fmt::Display for Ms365MailAttachmentSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let inline = if self.is_inline { " (inline)" } else { "" };
-        write!(f, "  {} — {} [{}]{}", self.name, format_bytes(self.size), self.content_type, inline)
+        write!(
+            f,
+            "  {} — {} [{}]{}",
+            self.name,
+            format_bytes(self.size),
+            self.content_type,
+            inline
+        )
     }
 }
 
@@ -3689,7 +3849,11 @@ pub struct Ms365MailAttachmentsResponse {
 
 impl fmt::Display for Ms365MailAttachmentsResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Message {} — {} attachment(s)", self.message_id, self.total)?;
+        writeln!(
+            f,
+            "Message {} — {} attachment(s)",
+            self.message_id, self.total
+        )?;
         for att in &self.attachments {
             writeln!(f, "{att}")?;
             writeln!(f, "    id: {}", att.id)?;
@@ -3718,7 +3882,11 @@ impl fmt::Display for Ms365MailAttachmentReadResponse {
         writeln!(f, "  Message:      {}", self.message_id)?;
         writeln!(f, "  Type:         {}", self.content_type)?;
         writeln!(f, "  Size:         {}", format_bytes(self.size))?;
-        writeln!(f, "  Inline:       {}", if self.is_inline { "yes" } else { "no" })?;
+        writeln!(
+            f,
+            "  Inline:       {}",
+            if self.is_inline { "yes" } else { "no" }
+        )?;
         if let Some(ref modified) = self.last_modified {
             writeln!(f, "  Modified:     {modified}")?;
         }
@@ -3764,7 +3932,13 @@ pub struct Ms365FileItem {
 impl fmt::Display for Ms365FileItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let kind = if self.is_folder { "DIR " } else { "FILE" };
-        write!(f, "  {kind}  {:<40} {:>10}  {}", self.name, format_bytes(self.size), self.last_modified)
+        write!(
+            f,
+            "  {kind}  {:<40} {:>10}  {}",
+            self.name,
+            format_bytes(self.size),
+            self.last_modified
+        )
     }
 }
 
@@ -3845,7 +4019,14 @@ impl fmt::Display for Ms365FileSearchItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let kind = if self.is_folder { "DIR " } else { "FILE" };
         let parent = self.parent_path.as_deref().unwrap_or("");
-        write!(f, "  {kind}  {:<40} {:>10}  {}  {}", self.name, format_bytes(self.size), self.last_modified, parent)
+        write!(
+            f,
+            "  {kind}  {:<40} {:>10}  {}  {}",
+            self.name,
+            format_bytes(self.size),
+            self.last_modified,
+            parent
+        )
     }
 }
 
@@ -3859,7 +4040,11 @@ pub struct Ms365FilesSearchResponse {
 
 impl fmt::Display for Ms365FilesSearchResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "OneDrive search: \"{}\"  ({} result(s))", self.query, self.total)?;
+        writeln!(
+            f,
+            "OneDrive search: \"{}\"  ({} result(s))",
+            self.query, self.total
+        )?;
         if self.items.is_empty() {
             writeln!(f, "  (no matches)")?;
         } else {
@@ -3941,7 +4126,11 @@ pub struct Ms365UserSummary {
 impl fmt::Display for Ms365UserSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let title = self.job_title.as_deref().unwrap_or("–");
-        write!(f, "  {} <{}> — {title}", self.display_name, self.user_principal_name)
+        write!(
+            f,
+            "  {} <{}> — {title}",
+            self.display_name, self.user_principal_name
+        )
     }
 }
 
@@ -4019,7 +4208,11 @@ impl fmt::Display for Ms365PlannerTaskSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let assignee = self.assigned_to.as_deref().unwrap_or("unassigned");
         let due = self.due_date.as_deref().unwrap_or("no due date");
-        write!(f, "  [{}%] {} — {assignee}, {due}", self.percent_complete, self.title)
+        write!(
+            f,
+            "  [{}%] {} — {assignee}, {due}",
+            self.percent_complete, self.title
+        )
     }
 }
 
@@ -4088,6 +4281,66 @@ impl fmt::Display for Ms365PlannerTaskReadResponse {
     }
 }
 
+/// Response from `rune ms365 planner create`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTaskCreateResponse {
+    pub success: bool,
+    pub message: String,
+    #[serde(default, alias = "id")]
+    pub task_id: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerTaskCreateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        writeln!(f, "{icon} {}", self.message)?;
+        if let Some(task_id) = &self.task_id {
+            writeln!(f, "  Task ID:   {task_id}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 planner update`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTaskUpdateResponse {
+    pub success: bool,
+    pub message: String,
+    #[serde(default, alias = "id")]
+    pub task_id: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerTaskUpdateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        writeln!(f, "{icon} {}", self.message)?;
+        if let Some(task_id) = &self.task_id {
+            writeln!(f, "  Task ID:   {task_id}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Response from `rune ms365 planner complete`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ms365PlannerTaskCompleteResponse {
+    pub success: bool,
+    pub message: String,
+    #[serde(default, alias = "id")]
+    pub task_id: Option<String>,
+}
+
+impl fmt::Display for Ms365PlannerTaskCompleteResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let icon = if self.success { "✓" } else { "✗" };
+        writeln!(f, "{icon} {}", self.message)?;
+        if let Some(task_id) = &self.task_id {
+            writeln!(f, "  Task ID:   {task_id}")?;
+        }
+        Ok(())
+    }
+}
+
 // ── Microsoft 365 To-Do ──────────────────────────────────────────
 
 /// A single To-Do task list summary.
@@ -4140,7 +4393,11 @@ pub struct Ms365TodoTaskSummary {
 impl fmt::Display for Ms365TodoTaskSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let due = self.due_date.as_deref().unwrap_or("no due date");
-        write!(f, "  [{}] {} — {}, {due}", self.status, self.title, self.importance)
+        write!(
+            f,
+            "  [{}] {} — {}, {due}",
+            self.status, self.title, self.importance
+        )
     }
 }
 
@@ -4188,7 +4445,11 @@ impl fmt::Display for Ms365TodoTaskReadResponse {
         writeln!(f, "  List:       {}", self.list_id)?;
         writeln!(f, "  Status:     {}", self.status)?;
         writeln!(f, "  Importance: {}", self.importance)?;
-        writeln!(f, "  Reminder:   {}", if self.is_reminder_on { "yes" } else { "no" })?;
+        writeln!(
+            f,
+            "  Reminder:   {}",
+            if self.is_reminder_on { "yes" } else { "no" }
+        )?;
         if let Some(ref due) = self.due_date {
             writeln!(f, "  Due:        {due}")?;
         }
@@ -4340,7 +4601,11 @@ pub struct Ms365SiteListItemsResponse {
 
 impl fmt::Display for Ms365SiteListItemsResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Site {} / list {} — {} item(s)", self.site_id, self.list_id, self.total)?;
+        writeln!(
+            f,
+            "Site {} / list {} — {} item(s)",
+            self.site_id, self.list_id, self.total
+        )?;
         for item in &self.items {
             writeln!(f, "{item}")?;
             writeln!(f, "    id: {}", item.id)?;
@@ -4484,7 +4749,11 @@ pub struct Ms365TeamsMessagesResponse {
 
 impl fmt::Display for Ms365TeamsMessagesResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Team {} / channel {} — {} message(s)", self.team_id, self.channel_id, self.total)?;
+        writeln!(
+            f,
+            "Team {} / channel {} — {} message(s)",
+            self.team_id, self.channel_id, self.total
+        )?;
         for msg in &self.messages {
             writeln!(f, "{msg}")?;
             writeln!(f, "    id: {}", msg.id)?;
@@ -4580,7 +4849,11 @@ pub struct SecretsReloadResponse {
 impl fmt::Display for SecretsReloadResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let icon = if self.success { "✓" } else { "✗" };
-        write!(f, "{icon} {} ({} secret(s) reloaded)", self.detail, self.reloaded)
+        write!(
+            f,
+            "{icon} {} ({} secret(s) reloaded)",
+            self.detail, self.reloaded
+        )
     }
 }
 
@@ -4645,7 +4918,11 @@ pub struct SecretsApplyResponse {
 impl fmt::Display for SecretsApplyResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let icon = if self.success { "✓" } else { "✗" };
-        write!(f, "{icon} {} ({} secret(s) applied)", self.detail, self.applied)
+        write!(
+            f,
+            "{icon} {} ({} secret(s) applied)",
+            self.detail, self.applied
+        )
     }
 }
 
@@ -4675,7 +4952,6 @@ impl fmt::Display for ConfigureResponse {
         Ok(())
     }
 }
-
 
 /// Response for `logs tail`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -5451,7 +5727,9 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Logs"));
         assert!(out.contains("Entries: 1"));
-        assert!(out.contains("2026-03-20T09:00:00Z | WARN | source=gateway | gateway restart pending"));
+        assert!(
+            out.contains("2026-03-20T09:00:00Z | WARN | source=gateway | gateway restart pending")
+        );
     }
 
     #[test]
@@ -6925,9 +7203,7 @@ mod tests {
 
     #[test]
     fn render_sandbox_list_empty() {
-        let resp = SandboxListResponse {
-            boundaries: vec![],
-        };
+        let resp = SandboxListResponse { boundaries: vec![] };
         let out = render(&resp, OutputFormat::Human);
         assert!(out.contains("No sandbox boundaries configured"));
     }
@@ -7248,7 +7524,10 @@ mod tests {
 
     #[test]
     fn render_ms365_mail_send_human() {
-        let r = Ms365MailSendResponse { success: true, message: "Message sent".into() };
+        let r = Ms365MailSendResponse {
+            success: true,
+            message: "Message sent".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Message sent"));
@@ -7256,7 +7535,10 @@ mod tests {
 
     #[test]
     fn render_ms365_mail_reply_human() {
-        let r = Ms365MailReplyResponse { success: true, message: "Reply sent".into() };
+        let r = Ms365MailReplyResponse {
+            success: true,
+            message: "Reply sent".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Reply sent"));
@@ -7264,7 +7546,10 @@ mod tests {
 
     #[test]
     fn render_ms365_mail_forward_human() {
-        let r = Ms365MailForwardResponse { success: true, message: "Message forwarded".into() };
+        let r = Ms365MailForwardResponse {
+            success: true,
+            message: "Message forwarded".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Message forwarded"));
@@ -7272,7 +7557,10 @@ mod tests {
 
     #[test]
     fn render_ms365_calendar_create_human() {
-        let r = Ms365CalendarCreateResponse { success: true, message: "Event created".into() };
+        let r = Ms365CalendarCreateResponse {
+            success: true,
+            message: "Event created".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Event created"));
@@ -7280,7 +7568,10 @@ mod tests {
 
     #[test]
     fn render_ms365_calendar_create_failure() {
-        let r = Ms365CalendarCreateResponse { success: false, message: "Failed to create event".into() };
+        let r = Ms365CalendarCreateResponse {
+            success: false,
+            message: "Failed to create event".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✗"));
         assert!(out.contains("Failed to create event"));
@@ -7288,7 +7579,10 @@ mod tests {
 
     #[test]
     fn render_ms365_calendar_delete_human() {
-        let r = Ms365CalendarDeleteResponse { success: true, message: "Event deleted".into() };
+        let r = Ms365CalendarDeleteResponse {
+            success: true,
+            message: "Event deleted".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Event deleted"));
@@ -7296,7 +7590,10 @@ mod tests {
 
     #[test]
     fn render_ms365_calendar_respond_human() {
-        let r = Ms365CalendarRespondResponse { success: true, message: "Response sent: accepted".into() };
+        let r = Ms365CalendarRespondResponse {
+            success: true,
+            message: "Response sent: accepted".into(),
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("✓"));
         assert!(out.contains("Response sent: accepted"));
@@ -7304,11 +7601,54 @@ mod tests {
 
     #[test]
     fn render_ms365_calendar_create_json() {
-        let r = Ms365CalendarCreateResponse { success: true, message: "Event created".into() };
+        let r = Ms365CalendarCreateResponse {
+            success: true,
+            message: "Event created".into(),
+        };
         let out = render(&r, OutputFormat::Json);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["success"], true);
         assert_eq!(v["message"], "Event created");
+    }
+
+    #[test]
+    fn render_ms365_planner_create_human() {
+        let r = Ms365PlannerTaskCreateResponse {
+            success: true,
+            message: "Planner task created".into(),
+            task_id: Some("task-1".into()),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Planner task created"));
+        assert!(out.contains("task-1"));
+    }
+
+    #[test]
+    fn render_ms365_planner_update_human() {
+        let r = Ms365PlannerTaskUpdateResponse {
+            success: true,
+            message: "Planner task updated".into(),
+            task_id: Some("task-1".into()),
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("✓"));
+        assert!(out.contains("Planner task updated"));
+        assert!(out.contains("task-1"));
+    }
+
+    #[test]
+    fn render_ms365_planner_complete_json() {
+        let r = Ms365PlannerTaskCompleteResponse {
+            success: true,
+            message: "Planner task completed".into(),
+            task_id: Some("task-1".into()),
+        };
+        let out = render(&r, OutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["success"], true);
+        assert_eq!(v["message"], "Planner task completed");
+        assert_eq!(v["task_id"], "task-1");
     }
 
     #[test]
@@ -7366,7 +7706,8 @@ mod tests {
             attachments: vec![Ms365MailAttachmentSummary {
                 id: "att-1".into(),
                 name: "doc.docx".into(),
-                content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document".into(),
+                content_type:
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document".into(),
                 size: 51200,
                 is_inline: false,
             }],
@@ -7528,7 +7869,10 @@ mod tests {
 
     #[test]
     fn render_ms365_users_list_empty() {
-        let r = Ms365UsersListResponse { users: vec![], total: 0 };
+        let r = Ms365UsersListResponse {
+            users: vec![],
+            total: 0,
+        };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("0 user(s)"));
         assert!(out.contains("(none)"));
@@ -7608,39 +7952,38 @@ mod tests {
     }
 }
 
+#[test]
+fn render_logs_tail() {
+    let r = LogsTailResponse {
+        entries: vec![serde_json::json!({"timestamp":"T1","level":"INFO","message":"hello"})],
+        source: "gateway".into(),
+    };
+    let h = render(&r, OutputFormat::Human);
+    assert!(h.contains("hello"));
+    assert!(h.contains("gateway"));
+}
 
-    #[test]
-    fn render_logs_tail() {
-        let r = LogsTailResponse {
-            entries: vec![serde_json::json!({"timestamp":"T1","level":"INFO","message":"hello"})],
-            source: "gateway".into(),
-        };
-        let h = render(&r, OutputFormat::Human);
-        assert!(h.contains("hello"));
-        assert!(h.contains("gateway"));
-    }
+#[test]
+fn render_logs_search() {
+    let r = LogsSearchResponse {
+        query: "err".into(),
+        entries: vec![serde_json::json!({"timestamp":"T1","level":"ERROR","message":"err found"})],
+        total: 1,
+    };
+    let h = render(&r, OutputFormat::Human);
+    assert!(h.contains("err"));
+}
 
-    #[test]
-    fn render_logs_search() {
-        let r = LogsSearchResponse {
-            query: "err".into(),
-            entries: vec![serde_json::json!({"timestamp":"T1","level":"ERROR","message":"err found"})],
-            total: 1,
-        };
-        let h = render(&r, OutputFormat::Human);
-        assert!(h.contains("err"));
-    }
-
-    #[test]
-    fn render_logs_export() {
-        let r = LogsExportResponse {
-            success: true,
-            path: "/tmp/out.json".into(),
-            message: "Exported 10 entries".into(),
-        };
-        let h = render(&r, OutputFormat::Human);
-        assert!(h.contains("Exported"));
-    }
+#[test]
+fn render_logs_export() {
+    let r = LogsExportResponse {
+        success: true,
+        path: "/tmp/out.json".into(),
+        message: "Exported 10 entries".into(),
+    };
+    let h = render(&r, OutputFormat::Human);
+    assert!(h.contains("Exported"));
+}
 
 #[cfg(test)]
 mod subagent_output_tests {
@@ -7648,80 +7991,144 @@ mod subagent_output_tests {
 
     #[test]
     fn render_agent_spawn_human() {
-        let r = AgentSpawnResponse { session_id:"c1".into(), parent_session_id:"p1".into(), mode:"coding".into(), policy:"inherit".into(), status:"spawned".into() };
+        let r = AgentSpawnResponse {
+            session_id: "c1".into(),
+            parent_session_id: "p1".into(),
+            mode: "coding".into(),
+            policy: "inherit".into(),
+            status: "spawned".into(),
+        };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("Subagent spawned.")); assert!(out.contains("c1")); assert!(out.contains("p1"));
+        assert!(out.contains("Subagent spawned."));
+        assert!(out.contains("c1"));
+        assert!(out.contains("p1"));
     }
 
     #[test]
     fn render_agent_spawn_json() {
-        let r = AgentSpawnResponse { session_id:"c1".into(), parent_session_id:"p1".into(), mode:"coding".into(), policy:"inherit".into(), status:"spawned".into() };
+        let r = AgentSpawnResponse {
+            session_id: "c1".into(),
+            parent_session_id: "p1".into(),
+            mode: "coding".into(),
+            policy: "inherit".into(),
+            status: "spawned".into(),
+        };
         let out = render(&r, OutputFormat::Json);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["session_id"], "c1"); assert_eq!(v["parent_session_id"], "p1");
+        assert_eq!(v["session_id"], "c1");
+        assert_eq!(v["parent_session_id"], "p1");
     }
 
     #[test]
     fn render_agent_steer_accepted() {
-        let r = AgentSteerResponse { session_id:"c1".into(), accepted:true, detail:"ok".into() };
+        let r = AgentSteerResponse {
+            session_id: "c1".into(),
+            accepted: true,
+            detail: "ok".into(),
+        };
         assert!(render(&r, OutputFormat::Human).contains("Instruction delivered to c1."));
     }
 
     #[test]
     fn render_agent_steer_rejected() {
-        let r = AgentSteerResponse { session_id:"c1".into(), accepted:false, detail:"no".into() };
+        let r = AgentSteerResponse {
+            session_id: "c1".into(),
+            accepted: false,
+            detail: "no".into(),
+        };
         assert!(render(&r, OutputFormat::Human).contains("Steer rejected"));
     }
 
     #[test]
     fn render_agent_kill_ok() {
-        let r = AgentKillResponse { session_id:"c1".into(), killed:true, detail:"done".into() };
+        let r = AgentKillResponse {
+            session_id: "c1".into(),
+            killed: true,
+            detail: "done".into(),
+        };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("terminated")); assert!(out.contains("c1"));
+        assert!(out.contains("terminated"));
+        assert!(out.contains("c1"));
     }
 
     #[test]
     fn render_agent_kill_fail() {
-        let r = AgentKillResponse { session_id:"c1".into(), killed:false, detail:"nope".into() };
+        let r = AgentKillResponse {
+            session_id: "c1".into(),
+            killed: false,
+            detail: "nope".into(),
+        };
         assert!(render(&r, OutputFormat::Human).contains("Kill failed"));
     }
 
     #[test]
     fn render_agent_run_output() {
-        let r = AgentRunResponse { session_id:"s1".into(), turn_id:"t1".into(), status:"completed".into(), output:Some("Done.".into()) };
+        let r = AgentRunResponse {
+            session_id: "s1".into(),
+            turn_id: "t1".into(),
+            status: "completed".into(),
+            output: Some("Done.".into()),
+        };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("Agent turn completed.")); assert!(out.contains("t1")); assert!(out.contains("Done."));
+        assert!(out.contains("Agent turn completed."));
+        assert!(out.contains("t1"));
+        assert!(out.contains("Done."));
     }
 
     #[test]
     fn render_agent_run_no_output() {
-        let r = AgentRunResponse { session_id:"s1".into(), turn_id:"t1".into(), status:"running".into(), output:None };
+        let r = AgentRunResponse {
+            session_id: "s1".into(),
+            turn_id: "t1".into(),
+            status: "running".into(),
+            output: None,
+        };
         assert!(!render(&r, OutputFormat::Human).contains("Output:"));
     }
 
     #[test]
     fn render_agent_result_output() {
-        let r = AgentResultResponse { session_id:"s1".into(), turn_id:"t1".into(), status:"completed".into(), output:Some("Res".into()) };
+        let r = AgentResultResponse {
+            session_id: "s1".into(),
+            turn_id: "t1".into(),
+            status: "completed".into(),
+            output: Some("Res".into()),
+        };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("Turn result:")); assert!(out.contains("Res"));
+        assert!(out.contains("Turn result:"));
+        assert!(out.contains("Res"));
     }
 
     #[test]
     fn render_acp_send_delivered() {
-        let r = AcpSendResponse { message_id:"m1".into(), from:"a".into(), to:"b".into(), delivered:true };
+        let r = AcpSendResponse {
+            message_id: "m1".into(),
+            from: "a".into(),
+            to: "b".into(),
+            delivered: true,
+        };
         let out = render(&r, OutputFormat::Human);
-        assert!(out.contains("ACP message sent.")); assert!(out.contains("delivered"));
+        assert!(out.contains("ACP message sent."));
+        assert!(out.contains("delivered"));
     }
 
     #[test]
     fn render_acp_send_queued() {
-        let r = AcpSendResponse { message_id:"m1".into(), from:"a".into(), to:"b".into(), delivered:false };
+        let r = AcpSendResponse {
+            message_id: "m1".into(),
+            from: "a".into(),
+            to: "b".into(),
+            delivered: false,
+        };
         assert!(render(&r, OutputFormat::Human).contains("queued"));
     }
 
     #[test]
     fn render_acp_ack_ok() {
-        let r = AcpAckResponse { message_id:"m1".into(), acknowledged:true };
+        let r = AcpAckResponse {
+            message_id: "m1".into(),
+            acknowledged: true,
+        };
         assert!(render(&r, OutputFormat::Human).contains("m1"));
     }
 }
@@ -7744,15 +8151,23 @@ pub struct PluginSummary {
 impl fmt::Display for PluginSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let status = if self.enabled { "enabled" } else { "disabled" };
-        write!(f, "  {} v{} [{}] — {}", self.name, self.version, status, self.description)
+        write!(
+            f,
+            "  {} v{} [{}] — {}",
+            self.name, self.version, status, self.description
+        )
     }
 }
 
 impl fmt::Display for PluginListResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.plugins.is_empty() { return write!(f, "No plugins installed."); }
+        if self.plugins.is_empty() {
+            return write!(f, "No plugins installed.");
+        }
         writeln!(f, "Installed plugins ({}):", self.plugins.len())?;
-        for p in &self.plugins { writeln!(f, "{p}")?; }
+        for p in &self.plugins {
+            writeln!(f, "{p}")?;
+        }
         Ok(())
     }
 }
@@ -7774,7 +8189,15 @@ impl fmt::Display for PluginInfoResponse {
         writeln!(f, "  Version:  {}", self.version)?;
         writeln!(f, "  Enabled:  {}", self.enabled)?;
         writeln!(f, "  Source:   {}", self.source)?;
-        writeln!(f, "  Manifest: {}", if self.manifest_valid { "valid" } else { "invalid" })?;
+        writeln!(
+            f,
+            "  Manifest: {}",
+            if self.manifest_valid {
+                "valid"
+            } else {
+                "invalid"
+            }
+        )?;
         write!(f, "  {}", self.description)
     }
 }
@@ -7814,15 +8237,23 @@ pub struct HookSummary {
 impl fmt::Display for HookSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let status = if self.enabled { "enabled" } else { "disabled" };
-        write!(f, "  {} [{}] on {} — {}", self.name, status, self.event, self.description)
+        write!(
+            f,
+            "  {} [{}] on {} — {}",
+            self.name, status, self.event, self.description
+        )
     }
 }
 
 impl fmt::Display for HookListResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.hooks.is_empty() { return write!(f, "No hooks configured."); }
+        if self.hooks.is_empty() {
+            return write!(f, "No hooks configured.");
+        }
         writeln!(f, "Configured hooks ({}):", self.hooks.len())?;
-        for h in &self.hooks { writeln!(f, "{h}")?; }
+        for h in &self.hooks {
+            writeln!(f, "{h}")?;
+        }
         Ok(())
     }
 }
@@ -7858,7 +8289,11 @@ pub struct HookCheckResponse {
 
 impl fmt::Display for HookCheckResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Hook check: {} total, {} valid, {} invalid", self.total, self.valid, self.invalid)?;
+        writeln!(
+            f,
+            "Hook check: {} total, {} valid, {} invalid",
+            self.total, self.valid, self.invalid
+        )?;
         write!(f, "  {}", self.detail)
     }
 }

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -676,7 +676,7 @@ Important distinction:
 
 ### Microsoft 365 (`ms365`)
 
-First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download. Eleventh and twelfth slices: mail send/reply/forward and calendar create/delete/respond mutations. Thirteenth slice: OneDrive file search. Fourteenth slice: OneDrive file download.
+First through tenth parity slices: read-only mail and calendar surfaces (list + read-detail), auth/config inspection, mail folder listing, OneDrive file list/read, users/org directory inspection, Planner plans/tasks, To-Do lists/tasks, SharePoint sites inspection, Teams inspection, and mail attachment listing/read/download. Eleventh and twelfth slices: mail send/reply/forward and calendar create/delete/respond mutations. Thirteenth slice: OneDrive file search. Fourteenth slice: OneDrive file download. Fifteenth slice: Planner task create/update/complete mutations.
 
 Observed subcommands:
 
@@ -696,6 +696,9 @@ Observed subcommands:
 - `ms365 planner plans` — list Planner plans accessible to the authenticated user
 - `ms365 planner tasks --plan-id <id>` — list tasks in a Planner plan
 - `ms365 planner task-read --id <id>` — read a single Planner task by ID
+- `ms365 planner create --plan-id <id> --title <text> [--bucket-id <id>] [--due-date <iso8601>] [--description <text>]` — create a Planner task
+- `ms365 planner update --id <id> [--title <text>] [--bucket-id <id>] [--due-date <iso8601>] [--description <text>] [--percent-complete <0-100>]` — update Planner task details or progress
+- `ms365 planner complete --id <id>` — mark a Planner task complete
 - `ms365 todo lists` — list Microsoft To-Do task lists
 - `ms365 todo tasks --list-id <id>` — list tasks in a To-Do list
 - `ms365 todo task-read --list-id <id> --id <id>` — read a single To-Do task by ID
@@ -723,6 +726,7 @@ Required concepts:
 - single-item read-detail by ID (`--id`)
 - users/org directory inspection (me, list, read by ID/UPN)
 - Planner plan discovery and task enumeration by plan ID
+- Planner task creation, detail/progress update, and explicit completion
 - To-Do list discovery and task enumeration by list ID
 - SharePoint site discovery, detail read, list/library enumeration, and list item browsing
 - Teams discovery, channel enumeration, channel detail, and channel message listing
@@ -736,7 +740,11 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
+<<<<<<< HEAD
 Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–13). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. Backend foundation now includes `/ms365/auth/status` plus Planner mutation routes for task create/update/complete to unblock #232; the rest of the gateway `/ms365` family remains deferred.
+=======
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–15). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. OneDrive file download added in slice 14. Planner task mutation surface (create/update/complete) added in slice 15. Backend foundation begins with `/ms365/auth/status` only; the rest of the gateway `/ms365` family and Graph integration remain deferred.
+>>>>>>> 44a7fbc (feat(cli): salvage ms365 planner mutation surface (#232))
 
 ---
 


### PR DESCRIPTION
## Summary
- add Microsoft 365 Planner task mutation surfaces to the CLI/client/operator output:
  - `ms365 planner create`
  - `ms365 planner update`
  - `ms365 planner complete`
- wire the new commands through the existing backend planner mutation routes from #236
- add focused parser/client/output tests for the mutation surface
- update parity inventory to mark Planner task mutations shipped as slice 15

## Validation
- `CARGO_NET_OFFLINE=true cargo test -p rune-cli ms365_planner`
- `CARGO_NET_OFFLINE=true cargo clippy -p rune-cli --all-targets -- -D warnings`

## Parent / follow-on truth
- unblocks the operator-facing Planner mutation slice under #206 now that backend prerequisite #235 is shipped
