### PR TITLE
feat(streaming): response streaming with progressive Telegram edits

### DIFF
--- a/crates/rune-gateway/src/supervisor.rs
+++ b/crates/rune-gateway/src/supervisor.rs
@@ -382,7 +382,7 @@ async fn run_heartbeat(
 
     let (_turn, _usage) = deps
         .turn_executor
-        .execute_triggered(session.id, prompt, None, TriggerKind::Heartbeat)
+        .execute_triggered(session.id, prompt, None, TriggerKind::Heartbeat, None)
         .await?;
 
     // Read the last assistant message from transcript
@@ -527,7 +527,7 @@ async fn execute_in_session(
 
     let (_turn, _usage) = deps
         .turn_executor
-        .execute_triggered(session.id, message, model, trigger_kind)
+        .execute_triggered(session.id, message, model, trigger_kind, None)
         .await?;
 
     let items = deps

--- a/crates/rune-models/Cargo.toml
+++ b/crates/rune-models/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 url = "2"
 

--- a/crates/rune-models/src/lib.rs
+++ b/crates/rune-models/src/lib.rs
@@ -18,7 +18,7 @@ pub use provider::ollama::OllamaProvider;
 pub use provider::openai::OpenAiProvider;
 pub use types::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, FunctionCall,
-    FunctionDefinition, Role, ToolCallRequest, ToolDefinition, Usage,
+    FunctionDefinition, Role, StreamEvent, ToolCallRequest, ToolDefinition, Usage,
 };
 
 use rune_config::ModelProviderConfig;
@@ -351,6 +351,41 @@ impl ModelProvider for RoutedModelProvider {
         }
 
         Err(last_err)
+    }
+
+    async fn complete_stream(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<tokio::sync::mpsc::Receiver<StreamEvent>, ModelError> {
+        let Some(model_ref) = request.model.as_deref() else {
+            if self.providers.len() == 1 {
+                let provider = self
+                    .providers
+                    .values()
+                    .next()
+                    .expect("single provider should exist");
+                return provider.complete_stream(request).await;
+            }
+            return Err(ModelError::Configuration(
+                "model routing requires a selected model".into(),
+            ));
+        };
+
+        // For streaming, dispatch to primary only (no fallback chain).
+        let resolved = self
+            .models
+            .resolve_model(model_ref)
+            .map_err(map_resolution_error)?;
+        let provider = self.providers.get(&resolved.provider.name).ok_or_else(|| {
+            ModelError::Configuration(format!(
+                "provider '{}' is configured in the model inventory but not available",
+                resolved.provider.name
+            ))
+        })?;
+
+        let mut routed_request = request.clone();
+        routed_request.model = Some(resolved.raw_model.to_string());
+        provider.complete_stream(&routed_request).await
     }
 }
 

--- a/crates/rune-models/src/provider/mod.rs
+++ b/crates/rune-models/src/provider/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod response;
 use async_trait::async_trait;
 
 use crate::error::ModelError;
-use crate::types::{CompletionRequest, CompletionResponse};
+use crate::types::{CompletionRequest, CompletionResponse, StreamEvent};
 
 /// Trait for model providers (Azure OpenAI, OpenAI, etc.).
 #[async_trait]
@@ -21,4 +21,22 @@ pub trait ModelProvider: Send + Sync + std::fmt::Debug {
     /// Send a completion request and return the response.
     async fn complete(&self, request: &CompletionRequest)
     -> Result<CompletionResponse, ModelError>;
+
+    /// Stream a completion request, yielding text deltas as they arrive.
+    ///
+    /// The default implementation falls back to non-streaming [`complete`](Self::complete),
+    /// emitting the full content as a single [`StreamEvent::TextDelta`] followed by
+    /// [`StreamEvent::Done`].
+    async fn complete_stream(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<tokio::sync::mpsc::Receiver<StreamEvent>, ModelError> {
+        let response = self.complete(request).await?;
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        if let Some(ref content) = response.content {
+            let _ = tx.send(StreamEvent::TextDelta(content.clone())).await;
+        }
+        let _ = tx.send(StreamEvent::Done(response)).await;
+        Ok(rx)
+    }
 }

--- a/crates/rune-models/src/provider/openai.rs
+++ b/crates/rune-models/src/provider/openai.rs
@@ -2,12 +2,16 @@
 
 use async_trait::async_trait;
 use reqwest::Client;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::ModelProvider;
 use super::response::{ApiResponse, map_error_response, parse_response};
+use super::response::{StreamChunkResponse, StreamDelta};
 use crate::error::ModelError;
-use crate::types::{CompletionRequest, CompletionResponse};
+use crate::types::{
+    CompletionRequest, CompletionResponse, FinishReason, FunctionCall, StreamEvent,
+    ToolCallRequest, Usage,
+};
 
 /// OpenAI-compatible provider.
 #[derive(Debug)]
@@ -54,6 +58,22 @@ impl OpenAiProvider {
     pub fn url(&self) -> &str {
         &self.url
     }
+
+    /// Build an authenticated request builder for the completions endpoint.
+    fn build_request(&self) -> reqwest::RequestBuilder {
+        let mut req = self
+            .client
+            .post(&self.url)
+            .header("Content-Type", "application/json");
+
+        req = if self.use_azure_auth {
+            req.header("api-key", &self.api_key)
+        } else {
+            req.header("Authorization", format!("Bearer {}", self.api_key))
+        };
+
+        req
+    }
 }
 
 /// Azure/newer OpenAI models use `max_completion_tokens` instead of `max_tokens`.
@@ -68,6 +88,19 @@ struct OpenAiRequest<'a> {
     max_completion_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: &'a Option<Vec<crate::types::ToolDefinition>>,
+    #[serde(skip_serializing_if = "is_false")]
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_options: Option<StreamOptions>,
+}
+
+fn is_false(v: &bool) -> bool {
+    !v
+}
+
+#[derive(Debug, serde::Serialize)]
+struct StreamOptions {
+    include_usage: bool,
 }
 
 #[async_trait]
@@ -82,6 +115,8 @@ impl ModelProvider for OpenAiProvider {
             temperature: &request.temperature,
             max_completion_tokens: request.max_tokens,
             tools: &request.tools,
+            stream: false,
+            stream_options: None,
         };
 
         let body_json = serde_json::to_string(&body).unwrap_or_default();
@@ -94,18 +129,7 @@ impl ModelProvider for OpenAiProvider {
             "OpenAI completion request"
         );
 
-        let mut req = self
-            .client
-            .post(&self.url)
-            .header("Content-Type", "application/json");
-
-        req = if self.use_azure_auth {
-            req.header("api-key", &self.api_key)
-        } else {
-            req.header("Authorization", format!("Bearer {}", self.api_key))
-        };
-
-        let resp = req.json(&body).send().await?;
+        let resp = self.build_request().json(&body).send().await?;
 
         if !resp.status().is_success() {
             return Err(map_error_response(resp).await);
@@ -113,5 +137,241 @@ impl ModelProvider for OpenAiProvider {
 
         let api_resp: ApiResponse = resp.json().await?;
         parse_response(api_resp)
+    }
+
+    async fn complete_stream(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<tokio::sync::mpsc::Receiver<StreamEvent>, ModelError> {
+        let body = OpenAiRequest {
+            messages: &request.messages,
+            model: &request.model,
+            temperature: &request.temperature,
+            max_completion_tokens: request.max_tokens,
+            tools: &request.tools,
+            stream: true,
+            stream_options: Some(StreamOptions {
+                include_usage: true,
+            }),
+        };
+
+        debug!(
+            url = %self.url,
+            azure = self.use_azure_auth,
+            model = ?body.model,
+            msg_count = body.messages.len(),
+            "OpenAI streaming completion request"
+        );
+
+        let resp = self
+            .build_request()
+            .json(&body)
+            // Override timeout for streaming — responses may take several minutes.
+            .timeout(std::time::Duration::from_secs(600))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(map_error_response(resp).await);
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+
+        tokio::spawn(async move {
+            if let Err(e) = parse_sse_stream(resp, &tx).await {
+                warn!(error = %e, "SSE stream parsing failed, sending partial response");
+            }
+            // Sender is dropped here, signalling the receiver that streaming is done.
+        });
+
+        Ok(rx)
+    }
+}
+
+/// Parse an SSE stream from an OpenAI-compatible API, forwarding events to `tx`.
+async fn parse_sse_stream(
+    mut resp: reqwest::Response,
+    tx: &tokio::sync::mpsc::Sender<StreamEvent>,
+) -> Result<(), ModelError> {
+    let mut buffer = String::new();
+    let mut content = String::new();
+    let mut finish_reason: Option<FinishReason> = None;
+    let mut usage = Usage::default();
+
+    // Tool-call accumulators (indexed by `index` from delta).
+    let mut tc_ids: Vec<String> = Vec::new();
+    let mut tc_types: Vec<String> = Vec::new();
+    let mut tc_names: Vec<String> = Vec::new();
+    let mut tc_args: Vec<String> = Vec::new();
+
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| ModelError::Provider(format!("stream read error: {e}")))?
+    {
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        // Process all complete lines in the buffer.
+        while let Some(newline_pos) = buffer.find('\n') {
+            let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
+            buffer = buffer[newline_pos + 1..].to_string();
+
+            if line.is_empty() || !line.starts_with("data: ") {
+                continue;
+            }
+
+            let data = &line[6..];
+
+            if data == "[DONE]" {
+                // Assemble final response and send Done event.
+                let tool_calls = assemble_tool_calls(&tc_ids, &tc_types, &tc_names, &tc_args);
+                let _ = tx
+                    .send(StreamEvent::Done(CompletionResponse {
+                        content: if content.is_empty() {
+                            None
+                        } else {
+                            Some(content)
+                        },
+                        usage,
+                        finish_reason,
+                        tool_calls,
+                    }))
+                    .await;
+                return Ok(());
+            }
+
+            // Parse the JSON chunk.
+            let chunk_resp: StreamChunkResponse = match serde_json::from_str(data) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            // Extract usage from the final chunk (when stream_options.include_usage is set).
+            if let Some(ref u) = chunk_resp.usage {
+                usage = Usage {
+                    prompt_tokens: u.prompt_tokens.unwrap_or(0),
+                    completion_tokens: u.completion_tokens.unwrap_or(0),
+                    total_tokens: u.total_tokens.unwrap_or(0),
+                };
+            }
+
+            if let Some(ref choices) = chunk_resp.choices {
+                if let Some(choice) = choices.first() {
+                    // Update finish reason.
+                    if let Some(ref fr) = choice.finish_reason {
+                        finish_reason = Some(parse_finish_reason(fr));
+                    }
+
+                    // Process delta content and tool calls.
+                    if let Some(ref delta) = choice.delta {
+                        process_delta(
+                            delta,
+                            &mut content,
+                            &mut tc_ids,
+                            &mut tc_types,
+                            &mut tc_names,
+                            &mut tc_args,
+                            tx,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Stream ended without [DONE] — send what we have.
+    let tool_calls = assemble_tool_calls(&tc_ids, &tc_types, &tc_names, &tc_args);
+    let _ = tx
+        .send(StreamEvent::Done(CompletionResponse {
+            content: if content.is_empty() {
+                None
+            } else {
+                Some(content)
+            },
+            usage,
+            finish_reason,
+            tool_calls,
+        }))
+        .await;
+
+    Ok(())
+}
+
+/// Process a single streaming delta, updating accumulators and forwarding text.
+async fn process_delta(
+    delta: &StreamDelta,
+    content: &mut String,
+    tc_ids: &mut Vec<String>,
+    tc_types: &mut Vec<String>,
+    tc_names: &mut Vec<String>,
+    tc_args: &mut Vec<String>,
+    tx: &tokio::sync::mpsc::Sender<StreamEvent>,
+) {
+    // Forward text content.
+    if let Some(ref text) = delta.content {
+        content.push_str(text);
+        let _ = tx.send(StreamEvent::TextDelta(text.clone())).await;
+    }
+
+    // Accumulate tool call deltas.
+    if let Some(ref tool_call_deltas) = delta.tool_calls {
+        for tc_delta in tool_call_deltas {
+            let idx = tc_delta.index.unwrap_or(0);
+
+            // Extend vectors if needed.
+            while tc_ids.len() <= idx {
+                tc_ids.push(String::new());
+                tc_types.push("function".to_string());
+                tc_names.push(String::new());
+                tc_args.push(String::new());
+            }
+
+            if let Some(ref id) = tc_delta.id {
+                tc_ids[idx] = id.clone();
+            }
+            if let Some(ref ct) = tc_delta.call_type {
+                tc_types[idx] = ct.clone();
+            }
+            if let Some(ref func) = tc_delta.function {
+                if let Some(ref name) = func.name {
+                    tc_names[idx] = name.clone();
+                }
+                if let Some(ref args) = func.arguments {
+                    tc_args[idx].push_str(args);
+                }
+            }
+        }
+    }
+}
+
+/// Assemble accumulated tool call deltas into final [`ToolCallRequest`] items.
+fn assemble_tool_calls(
+    ids: &[String],
+    types: &[String],
+    names: &[String],
+    args: &[String],
+) -> Vec<ToolCallRequest> {
+    ids.iter()
+        .enumerate()
+        .filter(|(_, id)| !id.is_empty())
+        .map(|(i, id)| ToolCallRequest {
+            id: id.clone(),
+            call_type: types.get(i).cloned().unwrap_or_else(|| "function".into()),
+            function: FunctionCall {
+                name: names.get(i).cloned().unwrap_or_default(),
+                arguments: args.get(i).cloned().unwrap_or_default(),
+            },
+        })
+        .collect()
+}
+
+fn parse_finish_reason(s: &str) -> FinishReason {
+    match s {
+        "stop" => FinishReason::Stop,
+        "length" => FinishReason::Length,
+        "tool_calls" => FinishReason::ToolCalls,
+        "content_filter" => FinishReason::ContentFilter,
+        _ => FinishReason::Stop,
     }
 }

--- a/crates/rune-models/src/provider/response.rs
+++ b/crates/rune-models/src/provider/response.rs
@@ -134,6 +134,42 @@ pub(crate) fn parse_response(api: ApiResponse) -> Result<CompletionResponse, Mod
     })
 }
 
+// ── SSE streaming types (OpenAI-compatible) ─────────────────────────
+
+/// A single chunk from the OpenAI streaming API (SSE `data:` payload).
+#[derive(Deserialize)]
+pub(crate) struct StreamChunkResponse {
+    pub choices: Option<Vec<StreamChunkChoice>>,
+    pub usage: Option<ApiUsage>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamChunkChoice {
+    pub delta: Option<StreamDelta>,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamDelta {
+    pub content: Option<String>,
+    pub tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamToolCallDelta {
+    pub index: Option<usize>,
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub call_type: Option<String>,
+    pub function: Option<StreamFunctionDelta>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamFunctionDelta {
+    pub name: Option<String>,
+    pub arguments: Option<String>,
+}
+
 // ── Anthropic error format ──────────────────────────────────────────
 
 /// Anthropic API error envelope: `{ "type": "error", "error": { "type": "...", "message": "..." } }`.

--- a/crates/rune-models/src/types.rs
+++ b/crates/rune-models/src/types.rs
@@ -96,3 +96,12 @@ pub struct CompletionResponse {
     pub finish_reason: Option<FinishReason>,
     pub tool_calls: Vec<ToolCallRequest>,
 }
+
+/// Events emitted during streaming completion.
+#[derive(Clone, Debug)]
+pub enum StreamEvent {
+    /// A chunk of text content from the model.
+    TextDelta(String),
+    /// Streaming is complete; carries the assembled final response.
+    Done(CompletionResponse),
+}

--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -9,7 +9,7 @@ use rune_core::{
     ApprovalDecision, ApprovalId, NormalizedMessage, SessionKind, ToolCallId, TranscriptItem,
     TriggerKind, TurnId, TurnStatus,
 };
-use rune_models::{CompletionRequest, ModelProvider};
+use rune_models::{CompletionRequest, ModelProvider, StreamEvent};
 use rune_store::models::{NewApproval, NewTranscriptItem, NewTurn, TranscriptItemRow, TurnRow};
 use rune_store::repos::{ApprovalRepo, SessionRepo, ToolApprovalPolicyRepo, TranscriptRepo, TurnRepo};
 use rune_tools::{ToolCall, ToolExecutor, ToolRegistry, ToolResult};
@@ -161,6 +161,30 @@ impl TurnExecutor {
             user_message,
             model_ref,
             TriggerKind::UserMessage,
+            None,
+        )
+        .await
+    }
+
+    /// Execute a turn with streaming — text deltas are forwarded to `chunk_tx`
+    /// as they arrive from the model provider. The caller can progressively
+    /// update a UI (e.g. edit a Telegram message) while the model generates.
+    ///
+    /// Falls back to non-streaming transparently if the provider does not
+    /// support streaming or if the response contains tool calls.
+    pub async fn execute_streaming(
+        &self,
+        session_id: Uuid,
+        user_message: &str,
+        model_ref: Option<&str>,
+        chunk_tx: tokio::sync::mpsc::Sender<String>,
+    ) -> Result<(TurnRow, UsageAccumulator), RuntimeError> {
+        self.execute_triggered(
+            session_id,
+            user_message,
+            model_ref,
+            TriggerKind::UserMessage,
+            Some(chunk_tx),
         )
         .await
     }
@@ -172,6 +196,7 @@ impl TurnExecutor {
         user_message: &str,
         model_ref: Option<&str>,
         trigger_kind: TriggerKind,
+        chunk_tx: Option<tokio::sync::mpsc::Sender<String>>,
     ) -> Result<(TurnRow, UsageAccumulator), RuntimeError> {
         let turn_id = TurnId::new();
         let now = Utc::now();
@@ -228,7 +253,7 @@ impl TurnExecutor {
         // 4. Run the model/tool loop
         let mut usage = UsageAccumulator::new();
         let result = self
-            .run_turn_loop(session_id, turn_id, effective_model.as_deref(), &mut usage)
+            .run_turn_loop(session_id, turn_id, effective_model.as_deref(), &mut usage, chunk_tx.as_ref())
             .await;
 
         // Persist usage totals even on failed turns so operator surfaces remain durable.
@@ -468,6 +493,7 @@ impl TurnExecutor {
                 TurnId::from(turn_uuid),
                 effective_model.as_deref(),
                 &mut usage,
+                None,
             )
             .await;
 
@@ -523,6 +549,7 @@ impl TurnExecutor {
         turn_id: TurnId,
         model_ref: Option<&str>,
         usage: &mut UsageAccumulator,
+        chunk_tx: Option<&tokio::sync::mpsc::Sender<String>>,
     ) -> Result<TurnLoopOutcome, RuntimeError> {
         let session = self.session_repo.find_by_id(session_id).await?;
         let session_kind = parse_session_kind(&session.kind)?;
@@ -597,42 +624,38 @@ impl TurnExecutor {
                 },
             };
 
-            // Call model with retry on transient errors
-            let response = {
-                const MAX_RETRIES: u32 = 3;
-                const BACKOFF_SECS: [u64; 3] = [1, 3, 10];
-                let mut last_err = None;
-                let mut resp = None;
-
-                for attempt in 0..=MAX_RETRIES {
-                    match self.model_provider.complete(&request).await {
-                        Ok(r) => {
-                            resp = Some(r);
-                            break;
+            // Call model — try streaming when a chunk sender is available,
+            // otherwise use the non-streaming path with retries.
+            let response = if let Some(tx) = chunk_tx {
+                match self.model_provider.complete_stream(&request).await {
+                    Ok(mut rx) => {
+                        let mut final_response = None;
+                        while let Some(event) = rx.recv().await {
+                            match event {
+                                StreamEvent::TextDelta(delta) => {
+                                    let _ = tx.send(delta).await;
+                                }
+                                StreamEvent::Done(resp) => {
+                                    final_response = Some(resp);
+                                    break;
+                                }
+                            }
                         }
-                        Err(e) => {
-                            if attempt < MAX_RETRIES && e.is_retriable() {
-                                let delay = BACKOFF_SECS[attempt as usize];
-                                warn!(
-                                    error = %e,
-                                    attempt = attempt + 1,
-                                    max_retries = MAX_RETRIES,
-                                    backoff_secs = delay,
-                                    "transient model error, retrying"
-                                );
-                                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-                                last_err = Some(e);
-                            } else {
-                                error!(error = %e, "model call failed");
-                                return Err(RuntimeError::Model(e));
+                        match final_response {
+                            Some(resp) => resp,
+                            None => {
+                                warn!("stream ended without Done event, falling back to non-streaming");
+                                self.complete_with_retries(&request).await?
                             }
                         }
                     }
+                    Err(e) => {
+                        warn!(error = %e, "streaming request failed, falling back to non-streaming");
+                        self.complete_with_retries(&request).await?
+                    }
                 }
-
-                resp.ok_or_else(|| {
-                    RuntimeError::Model(last_err.unwrap())
-                })?
+            } else {
+                self.complete_with_retries(&request).await?
             };
 
             usage.add(&response.usage);
@@ -882,6 +905,41 @@ impl TurnExecutor {
 
             return Ok(TurnLoopOutcome::Completed);
         }
+    }
+
+    /// Non-streaming model call with transient-error retries and exponential backoff.
+    async fn complete_with_retries(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<rune_models::CompletionResponse, RuntimeError> {
+        const MAX_RETRIES: u32 = 3;
+        const BACKOFF_SECS: [u64; 3] = [1, 3, 10];
+        let mut last_err = None;
+
+        for attempt in 0..=MAX_RETRIES {
+            match self.model_provider.complete(request).await {
+                Ok(r) => return Ok(r),
+                Err(e) => {
+                    if attempt < MAX_RETRIES && e.is_retriable() {
+                        let delay = BACKOFF_SECS[attempt as usize];
+                        warn!(
+                            error = %e,
+                            attempt = attempt + 1,
+                            max_retries = MAX_RETRIES,
+                            backoff_secs = delay,
+                            "transient model error, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+                        last_err = Some(e);
+                    } else {
+                        error!(error = %e, "model call failed");
+                        return Err(RuntimeError::Model(e));
+                    }
+                }
+            }
+        }
+
+        Err(RuntimeError::Model(last_err.unwrap()))
     }
 
     /// Append a transcript item, auto-incrementing the sequence number.

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -163,11 +163,40 @@ impl SessionLoop {
                     }
                 };
 
-                match self
+                // Set up a streaming channel so we can progressively edit
+                // the placeholder message as the model generates text.
+                let (chunk_tx, chunk_rx) = tokio::sync::mpsc::channel::<String>(64);
+
+                // Spawn a background task that edits the placeholder with
+                // accumulated text, throttled to at most one edit per 500ms
+                // to stay within Telegram rate limits.
+                let edit_handle = if let Some(ref ph_id) = placeholder_id {
+                    let channel = self.channel.clone();
+                    let channel_id = msg.channel_id;
+                    let chat_id = msg.raw_chat_id.clone();
+                    let ph_id = ph_id.clone();
+
+                    Some(tokio::spawn(progressive_edit_loop(
+                        channel, channel_id, chat_id, ph_id, chunk_rx,
+                    )))
+                } else {
+                    // No placeholder — drain chunks so the sender never blocks.
+                    Some(tokio::spawn(drain_chunks(chunk_rx)))
+                };
+
+                let result = self
                     .turn_executor
-                    .execute(session.id, &enriched_content, None)
-                    .await
-                {
+                    .execute_streaming(session.id, &enriched_content, None, chunk_tx)
+                    .await;
+
+                // Wait for the progressive edit task to finish (it exits when
+                // the chunk_tx sender is dropped, i.e. when execute_streaming
+                // returns above).
+                if let Some(handle) = edit_handle {
+                    let _ = handle.await;
+                }
+
+                match result {
                     Ok((turn, usage)) => {
                         debug!(
                             turn_id = %turn.id,
@@ -178,7 +207,9 @@ impl SessionLoop {
 
                         if let Some(reply) = self.get_last_assistant_message(session.id).await {
                             let ch = self.channel.lock().await;
-                            // If we sent a placeholder, edit it; otherwise send a new reply.
+                            // Final edit with the authoritative response from
+                            // the transcript (ensures consistency after tool
+                            // calls or partial streaming).
                             let result = if let Some(ref ph_id) = placeholder_id {
                                 ch.send(OutboundAction::Edit {
                                     channel_id: msg.channel_id,
@@ -627,4 +658,71 @@ impl SessionLoop {
         }
         None
     }
+}
+
+// ── Streaming helpers ───────────────────────────────────────────────
+
+/// Progressively edit a Telegram placeholder message as text chunks arrive.
+///
+/// Throttles edits to at most one every 500 ms to stay within Telegram Bot API
+/// rate limits (~30 messages per second per chat). The very first chunk always
+/// triggers an immediate edit so the user sees output as fast as possible.
+async fn progressive_edit_loop(
+    channel: Arc<Mutex<Box<dyn rune_channels::ChannelAdapter>>>,
+    channel_id: rune_core::ChannelId,
+    chat_id: String,
+    message_id: String,
+    mut chunk_rx: tokio::sync::mpsc::Receiver<String>,
+) {
+    use std::time::Duration;
+    use tokio::time::Instant;
+
+    let throttle = Duration::from_millis(500);
+    // Set last_edit far enough in the past so the first chunk triggers an edit.
+    let mut last_edit = Instant::now() - throttle;
+    let mut accumulated = String::new();
+
+    loop {
+        match chunk_rx.recv().await {
+            Some(chunk) => {
+                accumulated.push_str(&chunk);
+
+                if last_edit.elapsed() >= throttle {
+                    let ch = channel.lock().await;
+                    let _ = ch
+                        .send(OutboundAction::Edit {
+                            channel_id,
+                            chat_id: chat_id.clone(),
+                            message_id: message_id.clone(),
+                            new_content: accumulated.clone(),
+                        })
+                        .await;
+                    last_edit = Instant::now();
+                }
+            }
+            None => {
+                // Sender dropped — streaming finished. One final edit to
+                // flush any remaining text that was accumulated after the
+                // last throttled edit.
+                if !accumulated.is_empty() {
+                    let ch = channel.lock().await;
+                    let _ = ch
+                        .send(OutboundAction::Edit {
+                            channel_id,
+                            chat_id: chat_id.clone(),
+                            message_id: message_id.clone(),
+                            new_content: accumulated,
+                        })
+                        .await;
+                }
+                break;
+            }
+        }
+    }
+}
+
+/// Drain a chunk receiver without doing anything. Used when there is no
+/// placeholder message to edit (so the sender never blocks).
+async fn drain_chunks(mut rx: tokio::sync::mpsc::Receiver<String>) {
+    while rx.recv().await.is_some() {}
 }


### PR DESCRIPTION
## Summary
- **Streaming model provider**: `ModelProvider` trait gains `complete_stream()` with a default fallback to non-streaming. `OpenAiProvider` implements native SSE streaming with chunked line buffering, tool-call delta accumulation, and usage extraction.
- **Streaming executor**: New `execute_streaming()` method forwards text deltas via an `mpsc` channel while the model generates. Falls back gracefully to non-streaming on failure. Tool calls still work normally.
- **Progressive Telegram editing**: Session loop spawns a `progressive_edit_loop` that edits the placeholder message as chunks arrive, throttled to 1 edit per 500ms to respect Telegram rate limits. Final edit uses the authoritative transcript text.

Closes #242

## Changed files
| File | Change |
|------|--------|
| `rune-models/types.rs` | Add `StreamEvent` enum |
| `rune-models/provider/mod.rs` | Add `complete_stream()` to trait with default fallback |
| `rune-models/provider/openai.rs` | Implement SSE streaming, add `stream`/`stream_options` to request |
| `rune-models/provider/response.rs` | Add SSE delta types |
| `rune-models/lib.rs` | Export `StreamEvent`, add `complete_stream` to `RoutedModelProvider` |
| `rune-runtime/executor.rs` | Add `execute_streaming()`, plumb `chunk_tx` through turn loop |
| `rune-runtime/session_loop.rs` | Progressive edit loop, streaming integration |
| `rune-gateway/supervisor.rs` | Pass `None` chunk_tx to updated `execute_triggered` signature |

## Test plan
- [x] Full workspace compiles clean (`cargo check`)
- [x] All 1,290+ existing tests pass (`cargo test` — 0 failures)
- [ ] Manual test: send a message on Telegram, verify progressive text appears instead of "Thinking..." followed by wall of text
- [ ] Verify tool-call responses still work (model calls tools, loops, responds)
- [ ] Verify non-streaming providers (Anthropic, Bedrock, etc.) fall back gracefully via default `complete_stream` impl