### PR TITLE
fix(chat): resolve scroll overflow and virtualize message list

### DIFF
--- a/ui/src/components/chat/ChatThread.tsx
+++ b/ui/src/components/chat/ChatThread.tsx
@@ -1,4 +1,5 @@
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useState, useCallback, useMemo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -194,8 +195,120 @@ function getLaneMeta(entry: TranscriptEntry) {
 }
 
 const SCROLL_THRESHOLD = 80;
-const INITIAL_VISIBLE_GROUPS = 30;
-const LOAD_MORE_GROUPS = 20;
+
+function estimateGroupHeight(group: EntryGroup): number {
+  if (group.type === "date_divider") return 40;
+  if (group.type === "tool_pair") return 80;
+  return 120;
+}
+
+function GroupRenderer({
+  group,
+  onInspectTool,
+  selectedToolEntryId,
+  showThinking,
+}: {
+  group: EntryGroup;
+  onInspectTool?: (entry: TranscriptEntry, pairedEntry?: TranscriptEntry) => void;
+  selectedToolEntryId?: string | null;
+  showThinking: boolean;
+}) {
+  if (group.type === "date_divider") {
+    return (
+      <div className="flex items-center gap-2 px-0.5 py-1 sm:gap-3 sm:px-1">
+        <Separator className="flex-1 bg-border/60" />
+        <span className="rounded-full border border-border/70 bg-background/85 px-2.5 py-1 text-[9px] font-medium uppercase tracking-[0.16em] text-muted-foreground sm:px-3 sm:text-[10px]">
+          {group.dateLabel}
+        </span>
+        <Separator className="flex-1 bg-border/60" />
+      </div>
+    );
+  }
+
+  const leadEntry = group.entries[0];
+  const lane = getLaneMeta(leadEntry);
+
+  if (group.type === "message") {
+    const entry = group.entries[0];
+    return (
+      <div className="space-y-1.5 sm:space-y-2">
+        <div
+          className={cn(
+            "hidden px-1 sm:flex",
+            normalizeTranscriptKind(entry.kind) === "user" ? "justify-end" : "justify-start",
+          )}
+        >
+          <Badge
+            variant="outline"
+            className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
+          >
+            {lane.icon}
+            {lane.label}
+          </Badge>
+        </div>
+        <ChatMessage
+          entry={entry}
+          isLive={isLiveEntry(entry)}
+          showThinking={showThinking}
+        />
+      </div>
+    );
+  }
+
+  if (group.type === "tool_pair") {
+    return (
+      <div className="space-y-1.5 px-0.5 sm:space-y-2 sm:px-2">
+        <Badge
+          variant="outline"
+          className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
+        >
+          {lane.icon}
+          {lane.label}
+        </Badge>
+        <div className="flex flex-col gap-1">
+          {group.entries.map((entry, ei) => {
+            const pairedEntry =
+              ei === 0 && group.entries.length > 1
+                ? group.entries[1]
+                : ei > 0
+                  ? group.entries[0]
+                  : undefined;
+
+            return (
+              <ToolCard
+                key={entry.id}
+                entry={entry}
+                pairedEntry={pairedEntry}
+                onInspect={onInspectTool}
+                isSelected={selectedToolEntryId === entry.id}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5 sm:space-y-2">
+      <Badge
+        variant="outline"
+        className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
+      >
+        {lane.icon}
+        {lane.label}
+      </Badge>
+      {group.entries.map((entry) => (
+        <ChatMessage
+          key={entry.id}
+          entry={entry}
+          isLive={isLiveEntry(entry)}
+          showThinking={showThinking}
+        />
+      ))}
+    </div>
+  );
+}
 
 export function ChatThread({
   entries,
@@ -207,11 +320,18 @@ export function ChatThread({
   focusMode = false,
 }: ChatThreadProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const endRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [hasNewMessages, setHasNewMessages] = useState(false);
-  const [visibleGroupCount, setVisibleGroupCount] = useState(INITIAL_VISIBLE_GROUPS);
   const prevLengthRef = useRef(entries.length);
+
+  const allGroups = useMemo(() => groupEntries(entries), [entries]);
+
+  const virtualizer = useVirtualizer({
+    count: allGroups.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: (index) => estimateGroupHeight(allGroups[index]),
+    overscan: 10,
+  });
 
   const checkScrollPosition = useCallback(() => {
     const el = containerRef.current;
@@ -225,47 +345,19 @@ export function ChatThread({
     if (entries.length > prevLengthRef.current) {
       if (isAtBottom) {
         requestAnimationFrame(() => {
-          endRef.current?.scrollIntoView({ behavior: "smooth" });
+          virtualizer.scrollToIndex(allGroups.length - 1, { align: "end", behavior: "smooth" });
         });
       } else {
-        requestAnimationFrame(() => {
-          setHasNewMessages(true);
-        });
+        setHasNewMessages(true);
       }
     }
     prevLengthRef.current = entries.length;
-  }, [entries.length, isAtBottom]);
+  }, [entries.length, isAtBottom, allGroups.length, virtualizer]);
 
   const scrollToBottom = useCallback(() => {
-    endRef.current?.scrollIntoView({ behavior: "smooth" });
+    virtualizer.scrollToIndex(allGroups.length - 1, { align: "end", behavior: "smooth" });
     setHasNewMessages(false);
-  }, []);
-
-  const allGroups = groupEntries(entries);
-
-  // Only render the last N groups; load more when user scrolls to top
-  const startIndex = Math.max(0, allGroups.length - visibleGroupCount);
-  const groups = allGroups.slice(startIndex);
-  const hasMoreAbove = startIndex > 0;
-
-  // Reset visible count when switching sessions (entries change drastically)
-  useEffect(() => {
-    setVisibleGroupCount(INITIAL_VISIBLE_GROUPS);
-  }, [entries.length === 0]);
-
-  const handleLoadMore = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const prevScrollHeight = el.scrollHeight;
-    setVisibleGroupCount((prev) => prev + LOAD_MORE_GROUPS);
-    // Preserve scroll position after loading more above
-    requestAnimationFrame(() => {
-      if (el) {
-        const newScrollHeight = el.scrollHeight;
-        el.scrollTop += newScrollHeight - prevScrollHeight;
-      }
-    });
-  }, []);
+  }, [virtualizer, allGroups.length]);
 
   if (isLoading) {
     return (
@@ -295,126 +387,51 @@ export function ChatThread({
     );
   }
 
+  const virtualItems = virtualizer.getVirtualItems();
+
   return (
     <div className={cn("relative min-h-0 flex-1 overflow-hidden bg-gradient-to-b from-background/40 to-background", className)}>
       <div
         ref={containerRef}
         onScroll={checkScrollPosition}
         className={cn(
-          "flex h-full flex-col gap-3 overflow-y-auto py-3 scroll-pb-28 sm:gap-4 sm:py-4 sm:scroll-pb-6",
+          "h-full overflow-y-auto",
           focusMode ? "px-3 sm:px-8 lg:px-12" : "px-2.5 sm:px-4",
         )}
       >
-        {hasMoreAbove && (
-          <div className="flex justify-center py-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleLoadMore}
-              className="gap-1.5 rounded-full text-xs text-muted-foreground"
-            >
-              Load earlier messages ({startIndex} more)
-            </Button>
-          </div>
-        )}
-        {groups.map((group, gi) => {
-          if (group.type === "date_divider") {
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const group = allGroups[virtualRow.index];
             return (
-              <div key={`date-${gi}`} className="flex items-center gap-2 px-0.5 py-1 sm:gap-3 sm:px-1">
-                <Separator className="flex-1 bg-border/60" />
-                <span className="rounded-full border border-border/70 bg-background/85 px-2.5 py-1 text-[9px] font-medium uppercase tracking-[0.16em] text-muted-foreground sm:px-3 sm:text-[10px]">
-                  {group.dateLabel}
-                </span>
-                <Separator className="flex-1 bg-border/60" />
-              </div>
-            );
-          }
-
-          const leadEntry = group.entries[0];
-          const lane = getLaneMeta(leadEntry);
-
-          if (group.type === "message") {
-            const entry = group.entries[0];
-            return (
-              <div key={entry.id} className="space-y-1.5 sm:space-y-2">
-                <div
-                  className={cn(
-                    "hidden px-1 sm:flex",
-                    normalizeTranscriptKind(entry.kind) === "user" ? "justify-end" : "justify-start",
-                  )}
-                >
-                  <Badge
-                    variant="outline"
-                    className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
-                  >
-                    {lane.icon}
-                    {lane.label}
-                  </Badge>
-                </div>
-                <ChatMessage
-                  entry={entry}
-                  isLive={isLiveEntry(entry)}
-                  showThinking={showThinking}
-                />
-              </div>
-            );
-          }
-
-          if (group.type === "tool_pair") {
-            return (
-              <div key={`tool-group-${gi}`} className="space-y-1.5 px-0.5 sm:space-y-2 sm:px-2">
-                <Badge
-                  variant="outline"
-                  className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
-                >
-                  {lane.icon}
-                  {lane.label}
-                </Badge>
-                <div className="flex flex-col gap-1">
-                  {group.entries.map((entry, ei) => {
-                    const pairedEntry =
-                      ei === 0 && group.entries.length > 1
-                        ? group.entries[1]
-                        : ei > 0
-                          ? group.entries[0]
-                          : undefined;
-
-                    return (
-                      <ToolCard
-                        key={entry.id}
-                        entry={entry}
-                        pairedEntry={pairedEntry}
-                        onInspect={onInspectTool}
-                        isSelected={selectedToolEntryId === entry.id}
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          }
-
-          return (
-            <div key={`other-${gi}`} className="space-y-1.5 sm:space-y-2">
-              <Badge
-                variant="outline"
-                className={cn("gap-1 rounded-full px-2.5 py-1 text-[10px]", lane.badgeClass)}
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+                className="py-1.5 sm:py-2"
               >
-                {lane.icon}
-                {lane.label}
-              </Badge>
-              {group.entries.map((entry) => (
-                <ChatMessage
-                  key={entry.id}
-                  entry={entry}
-                  isLive={isLiveEntry(entry)}
+                <GroupRenderer
+                  group={group}
+                  onInspectTool={onInspectTool}
+                  selectedToolEntryId={selectedToolEntryId}
                   showThinking={showThinking}
                 />
-              ))}
-            </div>
-          );
-        })}
-        <div ref={endRef} />
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       {hasNewMessages && (

--- a/ui/src/routes/_admin.tsx
+++ b/ui/src/routes/_admin.tsx
@@ -10,7 +10,7 @@ function AdminLayout() {
   return (
     <div className="flex h-[100dvh] flex-col overflow-hidden bg-gradient-to-br from-background to-muted/20">
       <AdminNavbar />
-      <main className="mx-auto min-h-0 w-full max-w-7xl flex-1 overflow-y-auto px-4 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pt-6 lg:px-8 lg:pb-8">
+      <main className="mx-auto min-h-0 w-full max-w-7xl flex-1 overflow-hidden px-4 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pt-6 lg:px-8 lg:pb-8">
         <Outlet />
       </main>
       <AdminBottomNav />

--- a/ui/src/routes/_admin/chat.tsx
+++ b/ui/src/routes/_admin/chat.tsx
@@ -293,9 +293,9 @@ function ChatPage() {
   }, []);
 
   return (
-    <div className="flex h-full flex-col gap-4 overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       <section className="shrink-0 overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-background via-background to-primary/5 shadow-[0_24px_80px_rgba(249,115,22,0.10)]">
-        <div className="grid gap-4 px-4 py-4 sm:px-6 sm:py-5 lg:grid-cols-[minmax(0,1fr)_360px] lg:px-8 lg:py-6">
+        <div className="grid gap-3 px-4 py-3 sm:px-6 sm:py-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:px-8 lg:py-5">
           <div className="space-y-3 sm:space-y-4">
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline" className="border-primary/25 bg-primary/10 text-primary">
@@ -403,7 +403,7 @@ function ChatPage() {
         </div>
       </section>
 
-      <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <div className="grid min-h-0 flex-1 gap-3 overflow-hidden lg:grid-cols-[320px_minmax(0,1fr)]">
         <div className="space-y-3 lg:hidden">
           <div className="grid grid-cols-1 gap-2 rounded-3xl border border-border/70 bg-card/80 p-3 shadow-[0_18px_50px_rgba(15,23,42,0.08)] backdrop-blur sm:grid-cols-2">
             <div className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/70 px-3 py-2">


### PR DESCRIPTION
## Summary
- **CSS flex chain fix**: `_admin.tsx` main changed from `overflow-y-auto` to `overflow-hidden` so child pages control their own scroll context
- **Chat layout tightening**: removed `gap-4` from root flex, reduced hero section padding, added `overflow-hidden` to chat grid container
- **True virtualization**: replaced "render last 30 groups" pagination in `ChatThread.tsx` with `@tanstack/react-virtual` `useVirtualizer` — estimated row heights (40px date dividers, 80px tool cards, 120px messages) with dynamic measurement via `measureElement`

Closes #244

## Test plan
- [ ] Open http://localhost:18790/chat — page should NOT extend beyond viewport
- [ ] Scroll through 100+ messages smoothly without jank
- [ ] "New messages" button appears when scrolled up and new messages arrive
- [ ] Auto-scroll to bottom works when already at bottom
- [ ] Mobile drawer, inspector panel, and focus mode still work correctly
- [ ] Verify no layout shift on window resize