### PR TITLE
fix(gateway): tighten session status unresolved wording (#42)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -1921,7 +1921,7 @@ fn render_session_status_card(
         vec!["cost posture is estimate-only; provider pricing is not wired yet".to_string()];
     if approval_mode == "on-miss" {
         unresolved.push(
-            "approval requests and operator-triggered resume are durable, but restart-safe continuation for mid-resume approval flows is not parity-complete yet".to_string(),
+            "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
         );
     }
     if security_mode == "allowlist" {

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -437,7 +437,7 @@ impl RpcDispatcher {
             vec!["cost posture is estimate-only; provider pricing is not wired yet".to_string()];
         if approval_mode == "on-miss" {
             unresolved.push(
-                "approval requests and operator-triggered resume are durable, but restart-safe continuation for mid-resume approval flows is not parity-complete yet".to_string(),
+                "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
             );
         }
         if security_mode == "allowlist" {

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1977,7 +1977,7 @@ async fn ws_rpc_session_status_surfaces_defaults_and_usage() {
     let unresolved = payload["unresolved"].as_array().unwrap();
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("cost posture is estimate-only; provider pricing is not wired yet")));
-    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests and operator-triggered resume are durable, but restart-safe continuation for mid-resume approval flows is not parity-complete yet")));
+    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable")));
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("host/node/sandbox parity and PTY fidelity are not yet parity-complete")));
 }
@@ -4640,7 +4640,7 @@ async fn get_session_status_returns_parity_card_fields() {
     assert_eq!(json["security_mode"], "allowlist");
     assert!(json["unresolved"].is_array());
     let unresolved = json["unresolved"].as_array().unwrap();
-    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests and operator-triggered resume are durable, but restart-safe continuation for mid-resume approval flows is not parity-complete yet")));
+    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable")));
 }
 
 #[tokio::test]
@@ -4772,7 +4772,7 @@ async fn get_session_status_surfaces_subagent_metadata() {
     let unresolved = json["unresolved"].as_array().unwrap();
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("cost posture is estimate-only; provider pricing is not wired yet")));
-    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests and operator-triggered resume are durable, but restart-safe continuation for mid-resume approval flows is not parity-complete yet")));
+    assert!(unresolved.iter().any(|item| item.as_str() == Some("approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable")));
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("host/node/sandbox parity and PTY fidelity are not yet parity-complete")));
     assert!(unresolved.iter().any(|item| item.as_str() == Some("subagent runtime execution remains conservative; durable lifecycle inspection is available but full remote/runtime attachment parity is not complete")));


### PR DESCRIPTION
## Summary
- tighten gateway/session status wording so unresolved approval/session-resume parity notes match current shipped behavior
- update the matching HTTP and ws_rpc route-test expectations
- remove the last dirty-main blocker that was preventing a clean relaunch of the next MS365 lane

## Validation
- `cargo test -p rune-gateway --test route_tests ws_rpc_session_status_surfaces_defaults_and_usage -- --nocapture`
- `cargo test -p rune-gateway --test route_tests get_session_status_returns_parity_card_fields -- --nocapture`
- `cargo test -p rune-gateway --test route_tests get_session_status_surfaces_subagent_metadata -- --nocapture`
- `cargo check -p rune-gateway`

## Tracker truth
- backend/queue blocker cleanup for #42
- once merged, issue #268 can be relaunched from a clean main baseline
