### PR TITLE
fix(update): harden zero-config update guidance (#61)

### DIFF
--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -31,9 +31,12 @@ if [ ! -f "$REPO_DIR/target/release/rune" ]; then
 fi
 
 # Quick smoke tests — avoid commands that require a running gateway
-if ! "$REPO_DIR/target/release/rune-gateway" --version >/dev/null 2>&1; then
-    echo "[self-update] Gateway binary version check failed — aborting"
-    exit 1
+if ! timeout 10 "$REPO_DIR/target/release/rune-gateway" --config /nonexistent-rune-config.toml >/dev/null 2>&1; then
+    status=$?
+    if [ "$status" -ne 1 ]; then
+        echo "[self-update] Gateway binary startup sanity check failed with status $status — aborting"
+        exit 1
+    fi
 fi
 if ! "$REPO_DIR/target/release/rune" --version >/dev/null 2>&1; then
     echo "[self-update] CLI binary version check failed — aborting"


### PR DESCRIPTION
## Summary
- make the self-update gateway smoke check tolerate the expected config-missing exit path
- keep the update wizard aligned with the shipped zero-config service/docker setup flow
- convert the local-only #61 residue into a real GitHub artifact

## Validation
- cargo clippy -p rune-cli --all-targets -- -D warnings
- cargo test -q -p rune-cli
- bash -n scripts/self-update.sh
