### PR TITLE
feat: wire MS365 calendar mutation routes in gateway

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -27,7 +27,10 @@ use rune_config::{
     AppConfig, MemoryLevel, ModelBootstrap, PathsProfile, RuntimeMode, StorageBackend,
 };
 use rune_core::ToolCategory;
-use rune_gateway::ms365::{GraphMs365MailService, GraphMs365PlannerService, GraphMs365TodoService};
+use rune_gateway::ms365::{
+    GraphMs365CalendarService, GraphMs365MailService, GraphMs365PlannerService,
+    GraphMs365TodoService,
+};
 use rune_gateway::{Services, init_logging, start};
 use rune_mcp::discovery::McpServerConfig as RuntimeMcpServerConfig;
 use rune_mcp::{McpManager, McpToolExecutor};
@@ -727,6 +730,7 @@ async fn build_services(
         process_manager,
         capabilities,
         device_repo,
+        ms365_calendar_service: Arc::new(GraphMs365CalendarService::new()),
         ms365_planner_service: Arc::new(GraphMs365PlannerService::new()),
         ms365_todo_service: Arc::new(GraphMs365TodoService::new()),
         ms365_mail_service: Arc::new(GraphMs365MailService::new()),

--- a/crates/rune-gateway/src/ms365.rs
+++ b/crates/rune-gateway/src/ms365.rs
@@ -201,6 +201,69 @@ pub struct TodoTask {
     pub body_preview: Option<String>,
 }
 
+/// Gateway request for creating a Microsoft 365 calendar event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateCalendarEventRequest {
+    pub subject: String,
+    pub start: String,
+    pub end: String,
+    #[serde(default)]
+    pub attendees: Vec<String>,
+    #[serde(default)]
+    pub location: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+impl CreateCalendarEventRequest {
+    pub fn validate(&self) -> Result<(), Ms365CalendarServiceError> {
+        if self.subject.trim().is_empty() {
+            return Err(Ms365CalendarServiceError::Validation(
+                "calendar event subject is required".to_string(),
+            ));
+        }
+
+        validate_optional_mail_recipients(&self.attendees, "calendar attendees")?;
+        validate_calendar_datetime(&self.start, "calendar event start")?;
+        validate_calendar_datetime(&self.end, "calendar event end")?;
+
+        let start = DateTime::parse_from_rfc3339(self.start.trim()).map_err(|error| {
+            Ms365CalendarServiceError::Validation(format!(
+                "calendar event start must be valid RFC3339: {error}"
+            ))
+        })?;
+        let end = DateTime::parse_from_rfc3339(self.end.trim()).map_err(|error| {
+            Ms365CalendarServiceError::Validation(format!(
+                "calendar event end must be valid RFC3339: {error}"
+            ))
+        })?;
+
+        if end <= start {
+            return Err(Ms365CalendarServiceError::Validation(
+                "calendar event end must be after start".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Gateway request for responding to a Microsoft 365 calendar invitation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RespondCalendarEventRequest {
+    pub response: String,
+    #[serde(default)]
+    pub comment: Option<String>,
+}
+
+impl RespondCalendarEventRequest {
+    pub fn validate(&self, id: &str) -> Result<(), Ms365CalendarServiceError> {
+        validate_calendar_event_id(id)?;
+        validate_calendar_response(self.response.as_str())?;
+        Ok(())
+    }
+}
+
 /// Gateway request for sending a Microsoft 365 mail message.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendMailRequest {
@@ -292,6 +355,7 @@ pub enum Ms365ServiceError {
 pub type Ms365PlannerServiceError = Ms365ServiceError;
 pub type Ms365TodoServiceError = Ms365ServiceError;
 pub type Ms365MailServiceError = Ms365ServiceError;
+pub type Ms365CalendarServiceError = Ms365ServiceError;
 
 #[async_trait]
 pub trait Ms365PlannerService: Send + Sync {
@@ -346,6 +410,22 @@ pub trait Ms365MailService: Send + Sync {
         id: &str,
         request: ForwardMailRequest,
     ) -> Result<(), Ms365MailServiceError>;
+}
+
+#[async_trait]
+pub trait Ms365CalendarService: Send + Sync {
+    async fn create_event(
+        &self,
+        request: CreateCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError>;
+
+    async fn delete_event(&self, id: &str) -> Result<(), Ms365CalendarServiceError>;
+
+    async fn respond_to_event(
+        &self,
+        id: &str,
+        request: RespondCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError>;
 }
 
 /// Planner mutation service backed by Microsoft Graph.
@@ -770,6 +850,123 @@ impl Ms365TodoService for GraphMs365TodoService {
         .await?;
 
         self.read_task(list_id, task_id).await
+    }
+}
+
+/// Calendar mutation service backed by Microsoft Graph.
+pub struct GraphMs365CalendarService {
+    client: Client,
+}
+
+impl Default for GraphMs365CalendarService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphMs365CalendarService {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Ms365CalendarService for GraphMs365CalendarService {
+    async fn create_event(
+        &self,
+        request: CreateCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError> {
+        request.validate()?;
+
+        let mut body = Map::new();
+        body.insert("subject".to_string(), json!(request.subject.trim()));
+        body.insert("start".to_string(), graph_datetime_value(&request.start)?);
+        body.insert("end".to_string(), graph_datetime_value(&request.end)?);
+
+        if !request.attendees.is_empty() {
+            body.insert(
+                "attendees".to_string(),
+                graph_calendar_attendees_value(&request.attendees)?,
+            );
+        }
+
+        if let Some(location) = request
+            .location
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            body.insert(
+                "location".to_string(),
+                json!({
+                    "displayName": location.trim(),
+                }),
+            );
+        }
+
+        if let Some(content) = request
+            .body
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            body.insert("body".to_string(), graph_item_body_value(content.trim()));
+        }
+
+        send_graph_empty(
+            graph_request(&self.client, reqwest::Method::POST, "/me/events")?
+                .json(&Value::Object(body)),
+            "calendar",
+        )
+        .await
+    }
+
+    async fn delete_event(&self, id: &str) -> Result<(), Ms365CalendarServiceError> {
+        validate_calendar_event_id(id)?;
+
+        send_graph_empty(
+            graph_request(
+                &self.client,
+                reqwest::Method::DELETE,
+                &format!("/me/events/{}", id.trim()),
+            )?,
+            "calendar",
+        )
+        .await
+    }
+
+    async fn respond_to_event(
+        &self,
+        id: &str,
+        request: RespondCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError> {
+        request.validate(id)?;
+
+        let event_id = id.trim();
+        let action = match request.response.trim() {
+            "accept" => "accept",
+            "decline" => "decline",
+            "tentative" => "tentativelyAccept",
+            _ => unreachable!("calendar response validated before dispatch"),
+        };
+
+        send_graph_empty(
+            graph_request(
+                &self.client,
+                reqwest::Method::POST,
+                &format!("/me/events/{event_id}/{action}"),
+            )?
+            .json(&json!({
+                "comment": request
+                    .comment
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or_default(),
+                "sendResponse": true,
+            })),
+            "calendar",
+        )
+        .await
     }
 }
 
@@ -1214,6 +1411,71 @@ fn graph_mail_recipient_value(recipient: &str) -> Value {
             "address": recipient.trim(),
         }
     })
+}
+
+fn graph_calendar_attendees_value(
+    attendees: &[String],
+) -> Result<Value, Ms365CalendarServiceError> {
+    validate_optional_mail_recipients(attendees, "calendar attendees")?;
+
+    Ok(Value::Array(
+        attendees
+            .iter()
+            .map(|attendee| {
+                json!({
+                    "emailAddress": {
+                        "address": attendee.trim(),
+                    },
+                    "type": "required",
+                })
+            })
+            .collect(),
+    ))
+}
+
+fn validate_calendar_event_id(id: &str) -> Result<(), Ms365CalendarServiceError> {
+    if id.trim().is_empty() {
+        return Err(Ms365CalendarServiceError::Validation(
+            "calendar event id is required".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_calendar_response(value: &str) -> Result<(), Ms365CalendarServiceError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Ms365CalendarServiceError::Validation(
+            "calendar response is required".to_string(),
+        ));
+    }
+
+    if !matches!(trimmed, "accept" | "decline" | "tentative") {
+        return Err(Ms365CalendarServiceError::Validation(
+            "calendar response must be one of accept, decline, or tentative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_calendar_datetime(
+    value: &str,
+    field_name: &str,
+) -> Result<(), Ms365CalendarServiceError> {
+    if value.trim().is_empty() {
+        return Err(Ms365CalendarServiceError::Validation(format!(
+            "{field_name} is required"
+        )));
+    }
+
+    DateTime::parse_from_rfc3339(value.trim()).map_err(|error| {
+        Ms365CalendarServiceError::Validation(format!(
+            "{field_name} must be valid RFC3339: {error}"
+        ))
+    })?;
+
+    Ok(())
 }
 
 fn validate_todo_list_id(list_id: &str) -> Result<(), Ms365TodoServiceError> {

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -26,8 +26,9 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::ms365::{
-    CreatePlannerTaskRequest, CreateTodoTaskRequest, ForwardMailRequest, Ms365MailServiceError,
-    Ms365PlannerServiceError, Ms365TodoServiceError, PlannerTask, ReplyMailRequest,
+    CreateCalendarEventRequest, CreatePlannerTaskRequest, CreateTodoTaskRequest,
+    ForwardMailRequest, Ms365CalendarServiceError, Ms365MailServiceError, Ms365PlannerServiceError,
+    Ms365TodoServiceError, PlannerTask, ReplyMailRequest, RespondCalendarEventRequest,
     SendMailRequest, TodoTask, UpdatePlannerTaskRequest, UpdateTodoTaskRequest,
 };
 use crate::pairing::{DeviceRole, PairingError, PairingRequest, StoredPairedDevice};
@@ -3598,6 +3599,75 @@ pub struct Ms365MailMutationResponse {
     pub message: String,
 }
 
+#[derive(Serialize)]
+pub struct Ms365CalendarMutationResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+/// `POST /ms365/calendar/events` — create a Microsoft 365 calendar event.
+pub async fn ms365_calendar_create_event(
+    State(state): State<AppState>,
+    Json(request): Json<CreateCalendarEventRequest>,
+) -> Result<(StatusCode, Json<Ms365CalendarMutationResponse>), GatewayError> {
+    state
+        .ms365_calendar_service
+        .create_event(request)
+        .await
+        .map_err(map_ms365_calendar_service_error)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(Ms365CalendarMutationResponse {
+            success: true,
+            message: "Calendar event created".to_string(),
+        }),
+    ))
+}
+
+/// `DELETE /ms365/calendar/events/{id}` — delete a Microsoft 365 calendar event.
+pub async fn ms365_calendar_delete_event(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Ms365CalendarMutationResponse>, GatewayError> {
+    state
+        .ms365_calendar_service
+        .delete_event(&id)
+        .await
+        .map_err(map_ms365_calendar_service_error)?;
+
+    Ok(Json(Ms365CalendarMutationResponse {
+        success: true,
+        message: "Calendar event deleted".to_string(),
+    }))
+}
+
+/// `POST /ms365/calendar/events/{id}/delete` — compatibility alias for existing clients.
+pub async fn ms365_calendar_delete_event_compat(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Ms365CalendarMutationResponse>, GatewayError> {
+    ms365_calendar_delete_event(State(state), Path(id)).await
+}
+
+/// `POST /ms365/calendar/events/{id}/respond` — respond to a Microsoft 365 calendar invitation.
+pub async fn ms365_calendar_respond_event(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(request): Json<RespondCalendarEventRequest>,
+) -> Result<Json<Ms365CalendarMutationResponse>, GatewayError> {
+    state
+        .ms365_calendar_service
+        .respond_to_event(&id, request)
+        .await
+        .map_err(map_ms365_calendar_service_error)?;
+
+    Ok(Json(Ms365CalendarMutationResponse {
+        success: true,
+        message: "Calendar response sent".to_string(),
+    }))
+}
+
 /// `POST /ms365/mail/send` — send a Microsoft 365 mail message.
 pub async fn ms365_mail_send(
     State(state): State<AppState>,
@@ -3752,6 +3822,17 @@ pub async fn ms365_todo_complete_task(
         .map_err(map_ms365_todo_service_error)?;
 
     Ok(Json(Ms365TodoTaskMutationResponse { task }))
+}
+
+fn map_ms365_calendar_service_error(error: Ms365CalendarServiceError) -> GatewayError {
+    match error {
+        Ms365CalendarServiceError::Validation(message)
+        | Ms365CalendarServiceError::NotFound(message) => GatewayError::BadRequest(message),
+        Ms365CalendarServiceError::NotConfigured(message)
+        | Ms365CalendarServiceError::Upstream(message) => GatewayError::Internal(message),
+        Ms365CalendarServiceError::Unauthorized => GatewayError::Unauthorized,
+        Ms365CalendarServiceError::Forbidden(message) => GatewayError::Forbidden(message),
+    }
 }
 
 fn map_ms365_planner_service_error(error: Ms365PlannerServiceError) -> GatewayError {
@@ -4270,7 +4351,9 @@ fn build_configure_items(
             config
                 .models
                 .zero_config_ollama_base_url(std::env::var("OLLAMA_HOST").ok().as_deref())
-                .map(|base| format!("no explicit model providers; zero-config Ollama available at {base}"))
+                .map(|base| {
+                    format!("no explicit model providers; zero-config Ollama available at {base}")
+                })
                 .unwrap_or_else(|| "no model providers; using demo echo backend".into())
         },
     });

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -32,7 +32,7 @@ use tokio::sync::RwLock;
 
 use crate::auth::bearer_auth;
 use crate::error::GatewayError;
-use crate::ms365::{Ms365MailService, Ms365PlannerService, Ms365TodoService};
+use crate::ms365::{Ms365CalendarService, Ms365MailService, Ms365PlannerService, Ms365TodoService};
 use crate::pairing::DeviceRegistry;
 use crate::routes;
 use crate::state::{AppState, SessionEvent};
@@ -81,6 +81,7 @@ pub struct Services {
     pub process_manager: ProcessManager,
     pub capabilities: Capabilities,
     pub device_repo: Arc<dyn DeviceRepo>,
+    pub ms365_calendar_service: Arc<dyn Ms365CalendarService>,
     pub ms365_planner_service: Arc<dyn Ms365PlannerService>,
     pub ms365_todo_service: Arc<dyn Ms365TodoService>,
     pub ms365_mail_service: Arc<dyn Ms365MailService>,
@@ -202,6 +203,7 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         event_tx,
         tts_engine,
         stt_engine,
+        ms365_calendar_service: services.ms365_calendar_service,
         ms365_planner_service: services.ms365_planner_service,
         ms365_todo_service: services.ms365_todo_service,
         ms365_mail_service: services.ms365_mail_service,
@@ -422,6 +424,22 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/stt/disable", post(routes::stt_disable))
         // Microsoft 365 routes
         .route("/ms365/auth/status", get(routes::ms365_auth_status))
+        .route(
+            "/ms365/calendar/events",
+            post(routes::ms365_calendar_create_event),
+        )
+        .route(
+            "/ms365/calendar/events/{id}",
+            delete(routes::ms365_calendar_delete_event),
+        )
+        .route(
+            "/ms365/calendar/events/{id}/delete",
+            post(routes::ms365_calendar_delete_event_compat),
+        )
+        .route(
+            "/ms365/calendar/events/{id}/respond",
+            post(routes::ms365_calendar_respond_event),
+        )
         .route("/ms365/mail/send", post(routes::ms365_mail_send))
         .route(
             "/ms365/mail/messages/{id}/reply",

--- a/crates/rune-gateway/src/state.rs
+++ b/crates/rune-gateway/src/state.rs
@@ -19,7 +19,7 @@ use rune_tools::process_tool::ProcessManager;
 use rune_tts::TtsEngine;
 use tokio::sync::{RwLock, broadcast};
 
-use crate::ms365::{Ms365MailService, Ms365PlannerService, Ms365TodoService};
+use crate::ms365::{Ms365CalendarService, Ms365MailService, Ms365PlannerService, Ms365TodoService};
 use crate::pairing::DeviceRegistry;
 
 /// Events emitted for WebSocket subscribers.
@@ -88,6 +88,8 @@ pub struct AppState {
     pub tts_engine: Option<Arc<RwLock<TtsEngine>>>,
     /// Speech-to-text engine (constructed when STT API key is configured).
     pub stt_engine: Option<Arc<RwLock<SttEngine>>>,
+    /// Microsoft 365 Calendar mutation backend.
+    pub ms365_calendar_service: Arc<dyn Ms365CalendarService>,
     /// Microsoft 365 Planner mutation backend.
     pub ms365_planner_service: Arc<dyn Ms365PlannerService>,
     /// Microsoft 365 To-Do mutation backend.

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -35,10 +35,11 @@ use rune_tools::{ToolCall, ToolError, ToolExecutor, ToolRegistry, ToolResult};
 use std::collections::HashMap;
 
 use rune_gateway::ms365::{
-    CreatePlannerTaskRequest, CreateTodoTaskRequest, ForwardMailRequest, Ms365MailService,
+    CreateCalendarEventRequest, CreatePlannerTaskRequest, CreateTodoTaskRequest,
+    ForwardMailRequest, Ms365CalendarService, Ms365CalendarServiceError, Ms365MailService,
     Ms365MailServiceError, Ms365PlannerService, Ms365PlannerServiceError, Ms365TodoService,
-    Ms365TodoServiceError, PlannerTask, ReplyMailRequest, SendMailRequest, TodoTask,
-    UpdatePlannerTaskRequest, UpdateTodoTaskRequest,
+    Ms365TodoServiceError, PlannerTask, ReplyMailRequest, RespondCalendarEventRequest,
+    SendMailRequest, TodoTask, UpdatePlannerTaskRequest, UpdateTodoTaskRequest,
 };
 use rune_gateway::{AppState, SessionEvent, build_router, pairing::DeviceRegistry};
 
@@ -778,6 +779,26 @@ enum TodoMutationCall {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CalendarMutationCall {
+    Create(CreateCalendarEventRequest),
+    Delete {
+        id: String,
+    },
+    Respond {
+        id: String,
+        request: RespondCalendarEventRequest,
+    },
+}
+
+#[derive(Debug)]
+struct FakeMs365CalendarService {
+    create_response: Result<(), Ms365CalendarServiceError>,
+    delete_response: Result<(), Ms365CalendarServiceError>,
+    respond_response: Result<(), Ms365CalendarServiceError>,
+    calls: Mutex<Vec<CalendarMutationCall>>,
+}
+
 #[derive(Debug)]
 struct FakeMs365PlannerService {
     create_response: Result<PlannerTask, Ms365PlannerServiceError>,
@@ -813,6 +834,23 @@ struct FakeMs365MailService {
     reply_response: Result<(), Ms365MailServiceError>,
     forward_response: Result<(), Ms365MailServiceError>,
     calls: Mutex<Vec<MailMutationCall>>,
+}
+
+impl Default for FakeMs365CalendarService {
+    fn default() -> Self {
+        Self {
+            create_response: Err(Ms365CalendarServiceError::NotConfigured(
+                "test calendar service not configured".to_string(),
+            )),
+            delete_response: Err(Ms365CalendarServiceError::NotConfigured(
+                "test calendar service not configured".to_string(),
+            )),
+            respond_response: Err(Ms365CalendarServiceError::NotConfigured(
+                "test calendar service not configured".to_string(),
+            )),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
 }
 
 impl Default for FakeMs365PlannerService {
@@ -857,6 +895,33 @@ impl Default for FakeMs365MailService {
             forward_response: Ok(()),
             calls: Mutex::new(Vec::new()),
         }
+    }
+}
+
+impl FakeMs365CalendarService {
+    fn with_create_response(response: Result<(), Ms365CalendarServiceError>) -> Self {
+        Self {
+            create_response: response,
+            ..Self::default()
+        }
+    }
+
+    fn with_delete_response(response: Result<(), Ms365CalendarServiceError>) -> Self {
+        Self {
+            delete_response: response,
+            ..Self::default()
+        }
+    }
+
+    fn with_respond_response(response: Result<(), Ms365CalendarServiceError>) -> Self {
+        Self {
+            respond_response: response,
+            ..Self::default()
+        }
+    }
+
+    async fn calls(&self) -> Vec<CalendarMutationCall> {
+        self.calls.lock().await.clone()
     }
 }
 
@@ -911,6 +976,40 @@ impl FakeMs365TodoService {
 
     async fn calls(&self) -> Vec<TodoMutationCall> {
         self.calls.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl Ms365CalendarService for FakeMs365CalendarService {
+    async fn create_event(
+        &self,
+        request: CreateCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError> {
+        self.calls
+            .lock()
+            .await
+            .push(CalendarMutationCall::Create(request));
+        self.create_response.clone()
+    }
+
+    async fn delete_event(&self, id: &str) -> Result<(), Ms365CalendarServiceError> {
+        self.calls
+            .lock()
+            .await
+            .push(CalendarMutationCall::Delete { id: id.to_string() });
+        self.delete_response.clone()
+    }
+
+    async fn respond_to_event(
+        &self,
+        id: &str,
+        request: RespondCalendarEventRequest,
+    ) -> Result<(), Ms365CalendarServiceError> {
+        self.calls.lock().await.push(CalendarMutationCall::Respond {
+            id: id.to_string(),
+            request,
+        });
+        self.respond_response.clone()
     }
 }
 
@@ -1036,6 +1135,10 @@ fn build_test_app_with_config(config: AppConfig, auth_token: Option<String>) -> 
     build_test_app_parts(config, auth_token).0
 }
 
+fn test_ms365_calendar_service() -> Arc<dyn Ms365CalendarService> {
+    Arc::new(FakeMs365CalendarService::default())
+}
+
 fn test_ms365_planner_service() -> Arc<dyn Ms365PlannerService> {
     Arc::new(FakeMs365PlannerService::default())
 }
@@ -1055,6 +1158,21 @@ fn build_test_app_parts(
     build_test_app_parts_with_ms365_services(
         config,
         auth_token,
+        test_ms365_calendar_service(),
+        test_ms365_planner_service(),
+        test_ms365_todo_service(),
+    )
+}
+
+fn build_test_app_parts_with_calendar_service(
+    config: AppConfig,
+    auth_token: Option<String>,
+    ms365_calendar_service: Arc<dyn Ms365CalendarService>,
+) -> (axum::Router, Arc<MemDeviceRepo>) {
+    build_test_app_parts_with_ms365_services(
+        config,
+        auth_token,
+        ms365_calendar_service,
         test_ms365_planner_service(),
         test_ms365_todo_service(),
     )
@@ -1068,6 +1186,7 @@ fn build_test_app_parts_with_planner_service(
     build_test_app_parts_with_ms365_services(
         config,
         auth_token,
+        test_ms365_calendar_service(),
         ms365_planner_service,
         test_ms365_todo_service(),
     )
@@ -1081,6 +1200,7 @@ fn build_test_app_parts_with_todo_service(
     build_test_app_parts_with_ms365_services(
         config,
         auth_token,
+        test_ms365_calendar_service(),
         test_ms365_planner_service(),
         ms365_todo_service,
     )
@@ -1089,6 +1209,7 @@ fn build_test_app_parts_with_todo_service(
 fn build_test_app_parts_with_ms365_services(
     mut config: AppConfig,
     auth_token: Option<String>,
+    ms365_calendar_service: Arc<dyn Ms365CalendarService>,
     ms365_planner_service: Arc<dyn Ms365PlannerService>,
     ms365_todo_service: Arc<dyn Ms365TodoService>,
 ) -> (axum::Router, Arc<MemDeviceRepo>) {
@@ -1165,6 +1286,7 @@ fn build_test_app_parts_with_ms365_services(
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service,
         ms365_planner_service,
         ms365_todo_service,
         ms365_mail_service: test_ms365_mail_service(),
@@ -1195,6 +1317,20 @@ fn sample_planner_task(id: &str) -> PlannerTask {
         created_at: Some("2026-03-22T10:15:00Z".to_string()),
         priority: Some(5),
         description: Some("Collect user-facing changes.".to_string()),
+    }
+}
+
+fn sample_calendar_create_request() -> CreateCalendarEventRequest {
+    CreateCalendarEventRequest {
+        subject: "Sprint review".to_string(),
+        start: "2026-03-30T09:00:00Z".to_string(),
+        end: "2026-03-30T10:00:00Z".to_string(),
+        attendees: vec![
+            "alice@example.com".to_string(),
+            "bob@example.com".to_string(),
+        ],
+        location: Some("Conference Room A".to_string()),
+        body: Some("Walk through the shipped backend slice.".to_string()),
     }
 }
 
@@ -1286,6 +1422,7 @@ async fn ws_rpc_status_matches_http_status_basics() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1391,6 +1528,7 @@ enabled: true
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1508,6 +1646,7 @@ async fn status_reports_configured_lane_capacities() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1602,6 +1741,7 @@ async fn ws_rpc_runtime_lanes_reports_lane_queue_stats() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1734,6 +1874,7 @@ async fn ws_rpc_health_reports_session_count() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1841,6 +1982,7 @@ async fn ws_rpc_cron_list_and_get_surface_delivery_mode() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -1969,6 +2111,7 @@ async fn ws_rpc_session_status_surfaces_defaults_and_usage() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2114,6 +2257,7 @@ async fn ws_rpc_session_get_includes_last_turn_timestamps() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2204,6 +2348,7 @@ async fn ws_rpc_session_status_rejects_invalid_uuid() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2290,6 +2435,7 @@ async fn ws_rpc_turns_list_and_get_return_turn_rows() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2455,6 +2601,7 @@ async fn ws_rpc_tools_and_approvals_list_surface_state() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2555,6 +2702,7 @@ async fn ws_handle_text_message_subscribe_unsubscribe_and_errors() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2702,6 +2850,7 @@ async fn ws_handle_text_message_supports_event_and_global_subscriptions() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2845,6 +2994,7 @@ async fn ws_subscribe_bumps_state_version_once_and_non_subscription_rpc_does_not
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -2953,6 +3103,7 @@ async fn ws_handle_text_message_dispatches_rpc_errors() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -3413,6 +3564,152 @@ async fn ms365_auth_status_requires_auth_when_gateway_token_enabled() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ms365_calendar_create_event_forwards_request_and_returns_created_response() {
+    let calendar_service = Arc::new(FakeMs365CalendarService::with_create_response(Ok(())));
+    let (app, _device_repo) = build_test_app_parts_with_calendar_service(
+        AppConfig::default(),
+        None,
+        calendar_service.clone(),
+    );
+
+    let request = sample_calendar_create_request();
+    let response = app
+        .oneshot(
+            Request::post("/ms365/calendar/events")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let json = body_json(response).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["message"], "Calendar event created");
+
+    let calls = calendar_service.calls().await;
+    assert_eq!(calls, vec![CalendarMutationCall::Create(request)]);
+}
+
+#[tokio::test]
+async fn ms365_calendar_delete_routes_forward_id_and_preserve_compat_alias() {
+    let calendar_service = Arc::new(FakeMs365CalendarService::with_delete_response(Ok(())));
+    let (app, _device_repo) = build_test_app_parts_with_calendar_service(
+        AppConfig::default(),
+        None,
+        calendar_service.clone(),
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::delete("/ms365/calendar/events/event-123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["message"], "Calendar event deleted");
+
+    let response = app
+        .oneshot(
+            Request::post("/ms365/calendar/events/event-456/delete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let calls = calendar_service.calls().await;
+    assert_eq!(
+        calls,
+        vec![
+            CalendarMutationCall::Delete {
+                id: "event-123".to_string(),
+            },
+            CalendarMutationCall::Delete {
+                id: "event-456".to_string(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn ms365_calendar_respond_event_forwards_request_and_returns_success() {
+    let calendar_service = Arc::new(FakeMs365CalendarService::with_respond_response(Ok(())));
+    let (app, _device_repo) = build_test_app_parts_with_calendar_service(
+        AppConfig::default(),
+        None,
+        calendar_service.clone(),
+    );
+
+    let request = RespondCalendarEventRequest {
+        response: "tentative".to_string(),
+        comment: Some("Need to confirm timing with the team.".to_string()),
+    };
+    let response = app
+        .oneshot(
+            Request::post("/ms365/calendar/events/event-789/respond")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["message"], "Calendar response sent");
+
+    let calls = calendar_service.calls().await;
+    assert_eq!(
+        calls,
+        vec![CalendarMutationCall::Respond {
+            id: "event-789".to_string(),
+            request,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn ms365_calendar_mutation_routes_require_auth_when_gateway_token_enabled() {
+    let app = build_test_app(Some(TEST_AUTH_TOKEN.to_string()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ms365/calendar/events")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&sample_calendar_create_request()).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::delete("/ms365/calendar/events/event-123")
+                .header(header::AUTHORIZATION, format!("Bearer {TEST_AUTH_TOKEN}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 #[tokio::test]
@@ -4803,6 +5100,7 @@ async fn send_message_and_transcript_with_shared_state() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -5032,6 +5330,7 @@ async fn get_session_status_surfaces_subagent_metadata() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6038,6 +6337,7 @@ async fn list_sessions_filters_by_channel_and_activity() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6289,6 +6589,7 @@ async fn reminders_list_includes_outcome_fields() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6391,6 +6692,7 @@ async fn reminders_cancel_returns_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6510,6 +6812,7 @@ async fn agent_steer_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6662,6 +6965,7 @@ async fn agent_kill_success() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),
@@ -6812,6 +7116,7 @@ async fn ws_rpc_agent_steer_and_kill() {
         event_tx,
         tts_engine: None,
         stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
         ms365_planner_service: test_ms365_planner_service(),
         ms365_todo_service: test_ms365_todo_service(),
         ms365_mail_service: test_ms365_mail_service(),

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -746,7 +746,7 @@ Required concepts:
 
 Parity level: **close** — operator workflow and practical outcomes match; naming/format may differ from upstream.
 
-Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–16). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. OneDrive file download added in slice 14. Planner task mutation surface (create/update/complete) added in slice 15. To-Do task mutation surface (create/update/complete) added in slice 16. Backend foundation now includes `/ms365/auth/status`, Planner mutation routes for task create/update/complete, and To-Do mutation routes for list-scoped task create/update/complete; the rest of the gateway `/ms365` family remains deferred.
+Status: CLI/API shape implemented (issue #206, slices 1–8, 10, 12–16). Calendar mutation surface (create/delete/respond) added in slice 12. OneDrive file search added in slice 13. OneDrive file download added in slice 14. Planner task mutation surface (create/update/complete) added in slice 15. To-Do task mutation surface (create/update/complete) added in slice 16. Backend foundation now includes `/ms365/auth/status`, Calendar mutation routes for event create/delete/respond (plus the legacy POST delete compatibility alias), Planner mutation routes for task create/update/complete, and To-Do mutation routes for list-scoped task create/update/complete; the rest of the gateway `/ms365` family remains deferred.
 
 ---
 


### PR DESCRIPTION
## Summary
- add MS365 calendar mutation request/service types and Graph-backed create, delete, and respond operations
- wire gateway/runtime state for POST /ms365/calendar/events, DELETE /ms365/calendar/events/:id, and POST /ms365/calendar/events/:id/respond
- preserve the existing POST /ms365/calendar/events/:id/delete compatibility alias and update parity notes for the backend coverage now shipped
- add focused route tests proving the calendar mutation routes are real and gateway-auth protected

## Validation
- cargo test -p rune-gateway --test route_tests ms365_calendar_
- cargo test -p rune-gateway --test route_tests ms365_
- cargo test -p rune-gateway --test route_tests
- cargo test -p rune-gateway

Closes #268