### PR TITLE
feat(update): surface release-backed update notices (#253)

### DIFF
--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -27,6 +27,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 serde_json.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -28,7 +28,6 @@ use rune_config::{
     AppConfig, MemoryLevel, ModelBootstrap, PathsProfile, RuntimeMode, StorageBackend,
 };
 use rune_core::ToolCategory;
-use rune_spells_security_audit::security_audit_tool_definition;
 use rune_gateway::ms365::{
     GraphMs365CalendarService, GraphMs365FilesService, GraphMs365MailService,
     GraphMs365PlannerService, GraphMs365TodoService, GraphMs365UsersService,
@@ -48,6 +47,7 @@ use rune_runtime::{
     scheduler::{ReminderStore, Scheduler},
     session_loop::SessionLoop,
 };
+use rune_spells_security_audit::security_audit_tool_definition;
 use rune_store::models::{NewToolExecution, SessionRow, TurnRow};
 use rune_store::repos::{
     ApprovalRepo, MemoryEmbeddingRepo, SessionRepo, ToolApprovalPolicyRepo, ToolExecutionRepo,
@@ -328,6 +328,8 @@ fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: 
         "starting rune gateway"
     );
 
+    emit_update_hint();
+
     if config.models.bootstrap() == ModelBootstrap::ZeroConfigOllama {
         if let Some(model) = config.models.default_model.as_deref() {
             info!(
@@ -360,6 +362,70 @@ fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: 
             warn!(warning = %warning, "trusted-environment bypass active — NOT YET ACKNOWLEDGED");
         }
     }
+}
+
+fn emit_update_hint() {
+    let current_version = env!("CARGO_PKG_VERSION");
+    if let Some((current, latest)) = git_update_versions() {
+        if current != latest {
+            info!(current = %current, latest = %latest, "update available for running checkout");
+        }
+        return;
+    }
+
+    if let Ok(Some(latest)) = latest_github_release_version() {
+        if latest != current_version {
+            info!(current_version, latest = %latest, "update available for packaged build");
+        }
+    }
+}
+
+fn git_update_versions() -> Option<(String, String)> {
+    use std::process::Command;
+
+    let current = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())?;
+
+    let latest = Command::new("git")
+        .args(["rev-parse", "--short=12", "@{upstream}"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| current.clone());
+
+    Some((current, latest))
+}
+
+fn latest_github_release_version() -> Result<Option<String>, String> {
+    let response = reqwest::blocking::Client::builder()
+        .user_agent("rune-gateway")
+        .build()
+        .map_err(|error| error.to_string())?
+        .get("https://api.github.com/repos/ghostrider0470/rune/releases/latest")
+        .send()
+        .map_err(|error| error.to_string())?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "HTTP {} from GitHub releases API",
+            response.status()
+        ));
+    }
+
+    let payload: serde_json::Value = response.json().map_err(|error| error.to_string())?;
+    Ok(payload
+        .get("tag_name")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned))
 }
 
 fn trimmed_env_var(name: &str) -> Option<String> {
@@ -3113,7 +3179,11 @@ mod tests {
             Ok(before.saturating_sub(existing.len()))
         }
 
-        async fn delete_chunk(&self, file_path: &str, _chunk_index: i32) -> Result<bool, StoreError> {
+        async fn delete_chunk(
+            &self,
+            file_path: &str,
+            _chunk_index: i32,
+        ) -> Result<bool, StoreError> {
             self.deleted_files.lock().await.push(file_path.to_string());
             Ok(true)
         }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -2113,18 +2113,24 @@ pub struct UpdateCheckResponse {
     pub current_version: String,
     pub latest_version: Option<String>,
     pub detail: String,
+    pub source: String,
 }
 impl fmt::Display for UpdateCheckResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.available {
             write!(
                 f,
-                "Update available: {} → {}",
+                "Update available [{}]: {} → {}",
+                self.source,
                 self.current_version,
                 self.latest_version.as_deref().unwrap_or("?")
             )
         } else {
-            write!(f, "✓ Up to date ({})", self.current_version)
+            write!(
+                f,
+                "✓ Up to date [{}] ({})",
+                self.source, self.current_version
+            )
         }
     }
 }

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -140,6 +140,7 @@ pub struct UpdateCheckResponse {
     pub current_version: String,
     pub latest_version: Option<String>,
     pub detail: String,
+    pub source: String,
 }
 
 #[derive(Serialize)]
@@ -4737,10 +4738,13 @@ pub async fn memory_delete(
 pub struct RecallRequest {
     pub query: String,
     #[serde(default = "default_top_k")]
+    #[allow(dead_code)]
     pub top_k: usize,
 }
 
-fn default_top_k() -> usize { 10 }
+fn default_top_k() -> usize {
+    10
+}
 
 /// Request body for `POST /api/v1/memory/capture`.
 #[derive(Deserialize)]
@@ -4761,7 +4765,9 @@ pub struct StoreFactRequest {
     pub session_id: Option<String>,
 }
 
-fn default_category() -> String { "general".to_string() }
+fn default_category() -> String {
+    "general".to_string()
+}
 
 /// `POST /api/v1/memory/recall` — semantic recall from shared memory.
 ///
@@ -4912,7 +4918,7 @@ pub async fn v1_memory_delete(
     Ok(Json(json!({"deleted": true, "id": id})))
 }
 
-// ── Logs ──────────────────────────────────────────────────────────────────── 
+// ── Logs ────────────────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]
 pub struct LogsQuery {
@@ -5489,7 +5495,7 @@ pub async fn setup(
 /// `GET /update/check` - report the currently running version and whether a newer Git HEAD exists.
 pub async fn update_check() -> Result<Json<UpdateCheckResponse>, GatewayError> {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
-    let detail = if let Some((current, latest)) = git_update_versions() {
+    if let Some((current, latest)) = git_update_versions() {
         let available = current != latest;
         let detail = if available {
             format!("local checkout is behind Git HEAD ({current} -> {latest})")
@@ -5501,18 +5507,68 @@ pub async fn update_check() -> Result<Json<UpdateCheckResponse>, GatewayError> {
             current_version: current,
             latest_version: Some(latest),
             detail,
+            source: "git".to_string(),
         }));
-    } else {
-        "gateway build is not running from a Git checkout; remote update availability unknown"
-            .to_string()
-    };
+    }
 
-    Ok(Json(UpdateCheckResponse {
-        available: false,
-        current_version,
-        latest_version: None,
-        detail,
-    }))
+    match latest_github_release_version("ghostrider0470/rune").await {
+        Ok(Some(latest)) => {
+            let available = latest != current_version;
+            let detail = if available {
+                format!("GitHub release {latest} is newer than running build {current_version}")
+            } else {
+                format!("running build matches latest GitHub release ({current_version})")
+            };
+            Ok(Json(UpdateCheckResponse {
+                available,
+                current_version,
+                latest_version: Some(latest),
+                detail,
+                source: "github-release".to_string(),
+            }))
+        }
+        Ok(None) => Ok(Json(UpdateCheckResponse {
+            available: false,
+            current_version,
+            latest_version: None,
+            detail: "GitHub release metadata did not include a tag name".to_string(),
+            source: "github-release".to_string(),
+        })),
+        Err(error) => Ok(Json(UpdateCheckResponse {
+            available: false,
+            current_version,
+            latest_version: None,
+            detail: format!(
+                "gateway build is not running from a Git checkout and GitHub release lookup failed: {error}"
+            ),
+            source: "unknown".to_string(),
+        })),
+    }
+}
+
+#[derive(Deserialize)]
+struct GitHubLatestRelease {
+    tag_name: Option<String>,
+}
+
+async fn latest_github_release_version(repo: &str) -> Result<Option<String>, String> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/latest");
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header(reqwest::header::USER_AGENT, "rune-gateway")
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+
+    if !response.status().is_success() {
+        return Err(format!("HTTP {} from {url}", response.status()));
+    }
+
+    response
+        .json::<GitHubLatestRelease>()
+        .await
+        .map(|payload| payload.tag_name.filter(|value| !value.trim().is_empty()))
+        .map_err(|error| error.to_string())
 }
 
 /// `POST /update/apply` - guide operators to the supported source/self-update flows.
@@ -5698,8 +5754,20 @@ mod tests {
         let base = tmp.path().to_path_buf();
         // Create all 9 subdirs
         for sub in &[
-            "db", "sessions", "memory", "media", "spells", "skills", "plugins", "logs", "backups",
-            "config", "secrets", "workspace", "cache", "data",
+            "db",
+            "sessions",
+            "memory",
+            "media",
+            "spells",
+            "skills",
+            "plugins",
+            "logs",
+            "backups",
+            "config",
+            "secrets",
+            "workspace",
+            "cache",
+            "data",
         ] {
             std::fs::create_dir(base.join(sub)).unwrap();
         }


### PR DESCRIPTION
## Summary
- extend `/update/check` to fall back to GitHub releases when not running from a git checkout
- expose the update source in CLI output so packaged builds can report release-backed availability
- log a startup hint in the gateway when the running checkout or packaged build is behind

## Validation
- cargo check
- cargo clippy -- -D warnings *(currently fails on pre-existing unrelated warnings in rune-runtime and rune-cli)*