### PR TITLE
feat(spells): enforce versioned spell metadata (#302)

### DIFF
--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -716,6 +716,14 @@ pub struct SkillSummary {
     pub enabled: bool,
     pub source_dir: String,
     pub binary_path: Option<String>,
+    pub namespace: Option<String>,
+    pub version: Option<String>,
+    pub author: Option<String>,
+    pub kind: String,
+    pub requires: Vec<String>,
+    pub tags: Vec<String>,
+    pub match_rules: Option<serde_json::Value>,
+    pub triggers: Vec<String>,
 }
 
 impl fmt::Display for SkillSummary {
@@ -727,6 +735,28 @@ impl fmt::Display for SkillSummary {
             if self.enabled { "enabled" } else { "disabled" }
         )?;
         writeln!(f, "  Description: {}", self.description)?;
+        if let Some(version) = &self.version {
+            writeln!(f, "  Version: {}", version)?;
+        }
+        if let Some(namespace) = &self.namespace {
+            writeln!(f, "  Namespace: {}", namespace)?;
+        }
+        if let Some(author) = &self.author {
+            writeln!(f, "  Author: {}", author)?;
+        }
+        writeln!(f, "  Kind: {}", self.kind)?;
+        if !self.requires.is_empty() {
+            writeln!(f, "  Requires: {}", self.requires.join(", "))?;
+        }
+        if !self.tags.is_empty() {
+            writeln!(f, "  Tags: {}", self.tags.join(", "))?;
+        }
+        if let Some(match_rules) = &self.match_rules {
+            writeln!(f, "  Match: {}", match_rules)?;
+        }
+        if !self.triggers.is_empty() {
+            writeln!(f, "  Triggers: {}", self.triggers.join(", "))?;
+        }
         writeln!(f, "  Source: {}", self.source_dir)?;
         write!(
             f,
@@ -772,6 +802,28 @@ impl fmt::Display for SkillInfoResponse {
         writeln!(f, "Skill: {}", self.skill.name)?;
         writeln!(f, "  Enabled: {}", self.skill.enabled)?;
         writeln!(f, "  Description: {}", self.skill.description)?;
+        if let Some(version) = &self.skill.version {
+            writeln!(f, "  Version: {}", version)?;
+        }
+        if let Some(namespace) = &self.skill.namespace {
+            writeln!(f, "  Namespace: {}", namespace)?;
+        }
+        if let Some(author) = &self.skill.author {
+            writeln!(f, "  Author: {}", author)?;
+        }
+        writeln!(f, "  Kind: {}", self.skill.kind)?;
+        if !self.skill.requires.is_empty() {
+            writeln!(f, "  Requires: {}", self.skill.requires.join(", "))?;
+        }
+        if !self.skill.tags.is_empty() {
+            writeln!(f, "  Tags: {}", self.skill.tags.join(", "))?;
+        }
+        if let Some(match_rules) = &self.skill.match_rules {
+            writeln!(f, "  Match: {}", match_rules)?;
+        }
+        if !self.skill.triggers.is_empty() {
+            writeln!(f, "  Triggers: {}", self.skill.triggers.join(", "))?;
+        }
         writeln!(f, "  Source: {}", self.skill.source_dir)?;
         write!(
             f,

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -404,8 +404,6 @@ pub async fn comms_ack(
     }))
 }
 
-
-
 pub async fn acp_send(
     State(state): State<AppState>,
     Json(body): Json<AcpSendRequest>,
@@ -494,9 +492,14 @@ pub async fn acp_ack(
     let (path, _original) = inbox
         .into_iter()
         .find(|(_, msg)| msg.id == body.message_id)
-        .ok_or_else(|| GatewayError::BadRequest(format!("ACP message {} not found", body.message_id)))?;
+        .ok_or_else(|| {
+            GatewayError::BadRequest(format!("ACP message {} not found", body.message_id))
+        })?;
 
-    client.archive(&path).await.map_err(GatewayError::BadRequest)?;
+    client
+        .archive(&path)
+        .await
+        .map_err(GatewayError::BadRequest)?;
 
     Ok(Json(AcpAckResponse { acknowledged: true }))
 }
@@ -2186,6 +2189,14 @@ fn skill_to_response(skill: Skill) -> SkillResponse {
         enabled: skill.enabled,
         source_dir: skill.source_dir.display().to_string(),
         binary_path: skill.binary_path.map(|path| path.display().to_string()),
+        namespace: skill.namespace,
+        version: skill.version,
+        author: skill.author,
+        kind: format!("{:?}", skill.kind).to_lowercase(),
+        requires: skill.requires,
+        tags: skill.tags,
+        match_rules: skill.match_rules,
+        triggers: skill.triggers,
     }
 }
 
@@ -2746,6 +2757,18 @@ pub struct SkillResponse {
     pub source_dir: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binary_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    pub kind: String,
+    pub requires: Vec<String>,
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_rules: Option<serde_json::Value>,
+    pub triggers: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -7058,8 +7058,16 @@ async fn skills_routes_list_reload_and_toggle() {
         skills_dir.join("alpha/SKILL.md"),
         r#"---
 name: alpha
+version: 1.2.3
+namespace: horizon
+author: Horizon Tech d.o.o.
+kind: tool
 description: Alpha skill
 binary: ./run-alpha.sh
+requires: ["network"]
+tags: ["alpha", "tool"]
+match: {"channel":"telegram"}
+triggers: ["on:demand"]
 enabled: true
 ---
 
@@ -7085,6 +7093,7 @@ enabled: true
         skills_dir.join("beta/SKILL.md"),
         r#"---
 name: beta
+version: 0.1.0
 description: Beta skill
 enabled: false
 ---
@@ -7124,6 +7133,17 @@ enabled: false
             .unwrap()
             .contains("run-alpha.sh")
     );
+    assert_eq!(alpha["version"], "1.2.3");
+    assert_eq!(alpha["namespace"], "horizon");
+    assert_eq!(alpha["author"], "Horizon Tech d.o.o.");
+    assert_eq!(alpha["kind"], "tool");
+    assert_eq!(alpha["requires"], serde_json::json!(["network"]));
+    assert_eq!(alpha["tags"], serde_json::json!(["alpha", "tool"]));
+    assert_eq!(
+        alpha["match_rules"],
+        serde_json::json!({"channel":"telegram"})
+    );
+    assert_eq!(alpha["triggers"], serde_json::json!(["on:demand"]));
 
     let response = app
         .clone()
@@ -7208,8 +7228,16 @@ async fn skills_detail_route_returns_skill_and_missing_error() {
         skills_dir.join("alpha/SKILL.md"),
         r#"---
 name: alpha
+version: 1.2.3
+namespace: horizon
+author: Horizon Tech d.o.o.
+kind: tool
 description: Alpha skill
 binary: ./run-alpha.sh
+requires: ["network"]
+tags: ["alpha", "tool"]
+match: {"channel":"telegram"}
+triggers: ["on:demand"]
 enabled: true
 ---
 
@@ -7248,6 +7276,17 @@ enabled: true
             .unwrap()
             .contains("run-alpha.sh")
     );
+    assert_eq!(json["version"], "1.2.3");
+    assert_eq!(json["namespace"], "horizon");
+    assert_eq!(json["author"], "Horizon Tech d.o.o.");
+    assert_eq!(json["kind"], "tool");
+    assert_eq!(json["requires"], serde_json::json!(["network"]));
+    assert_eq!(json["tags"], serde_json::json!(["alpha", "tool"]));
+    assert_eq!(
+        json["match_rules"],
+        serde_json::json!({"channel":"telegram"})
+    );
+    assert_eq!(json["triggers"], serde_json::json!(["on:demand"]));
 
     let response = app
         .oneshot(Request::get("/skills/missing").body(Body::empty()).unwrap())

--- a/crates/rune-runtime/src/plugin_scanner.rs
+++ b/crates/rune-runtime/src/plugin_scanner.rs
@@ -309,9 +309,11 @@ impl PluginScanner {
                 user_invocable: cs.user_invocable,
                 namespace: None,
                 version: None,
+                author: None,
                 kind: Default::default(),
                 requires: vec![],
                 tags: vec![],
+                match_rules: None,
                 triggers: vec![],
             };
             self.skill_registry.register(skill).await;

--- a/crates/rune-runtime/src/spell.rs
+++ b/crates/rune-runtime/src/spell.rs
@@ -67,6 +67,9 @@ pub struct Spell {
     /// Semantic version string, e.g. `"0.1.0"`.
     #[serde(default)]
     pub version: Option<String>,
+    /// Optional spell author / org.
+    #[serde(default)]
+    pub author: Option<String>,
     /// Spell kind (assistant / tool / workflow / sensor).
     #[serde(default)]
     pub kind: SpellKind,
@@ -76,6 +79,9 @@ pub struct Spell {
     /// Free-form tags for search/filtering.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Optional context-matching rules for auto-activation.
+    #[serde(default)]
+    pub match_rules: Option<serde_json::Value>,
     /// Trigger patterns that activate this spell.
     #[serde(default)]
     pub triggers: Vec<String>,
@@ -102,10 +108,12 @@ pub struct SpellFrontmatter {
     pub namespace: Option<String>,
     pub version: Option<String>,
     pub kind: Option<SpellKind>,
+    pub author: Option<String>,
     #[serde(default)]
     pub requires: Vec<String>,
     #[serde(default)]
     pub tags: Vec<String>,
+    pub match_rules: Option<serde_json::Value>,
     #[serde(default)]
     pub triggers: Vec<String>,
 }

--- a/crates/rune-runtime/src/spell_loader.rs
+++ b/crates/rune-runtime/src/spell_loader.rs
@@ -271,6 +271,10 @@ async fn load_spell_from_path(path: &Path, dir_namespace: Option<&str>) -> Resul
         .description
         .unwrap_or_else(|| format!("Spell: {name}"));
 
+    if frontmatter.version.as_deref().is_none_or(str::is_empty) {
+        return Err("missing required field: version".to_string());
+    }
+
     let binary_path = frontmatter.binary.map(|b| {
         let bp = PathBuf::from(&b);
         if bp.is_relative() {
@@ -300,9 +304,11 @@ async fn load_spell_from_path(path: &Path, dir_namespace: Option<&str>) -> Resul
         user_invocable: false,
         namespace,
         version: frontmatter.version,
+        author: frontmatter.author,
         kind: frontmatter.kind.unwrap_or_default(),
         requires: frontmatter.requires,
         tags: frontmatter.tags,
+        match_rules: frontmatter.match_rules,
         triggers: frontmatter.triggers,
     })
 }
@@ -324,6 +330,7 @@ mod tests {
             spell_dir.join("SPELL.md"),
             r#"---
 name: my-spell
+version: 0.1.0
 description: A test spell
 ---
 
@@ -358,6 +365,7 @@ description: A test spell
             spell_dir.join("SKILL.md"),
             r#"---
 name: legacy-skill
+version: 0.1.0
 description: Uses old SKILL.md filename
 ---
 "#,
@@ -420,6 +428,7 @@ version: 0.1.0
             alpha_dir.join("SPELL.md"),
             r#"---
 name: alpha
+version: 0.1.0
 description: Alpha spell
 ---
 "#,
@@ -454,6 +463,7 @@ description: Alpha spell
             valid_dir.join("SPELL.md"),
             r#"---
 name: valid
+version: 0.1.0
 description: Valid spell
 binary: ./run.sh
 parameters: {"type":"object","properties":{"path":{"type":"string"}}}
@@ -496,6 +506,7 @@ enabled: true
             spell_dir.join("SPELL.md"),
             r#"---
 name: sticky-spell
+version: 0.1.0
 description: Sticky spell
 enabled: true
 ---
@@ -514,6 +525,34 @@ enabled: true
         let second = loader.scan_summary().await;
         assert_eq!(second.loaded, 1);
         assert!(!registry.get("sticky-spell").await.unwrap().enabled);
+    }
+
+
+    #[tokio::test]
+    async fn scan_rejects_spell_missing_required_version() {
+        let tmp = TempDir::new().unwrap();
+
+        let spell_dir = tmp.path().join("missing-version");
+        fs::create_dir_all(&spell_dir).await.unwrap();
+        fs::write(
+            spell_dir.join("SPELL.md"),
+            r#"---
+name: missing-version
+description: Missing version should fail
+---
+"#,
+        )
+        .await
+        .unwrap();
+
+        let registry = Arc::new(SpellRegistry::new());
+        let loader = SpellLoader::new(tmp.path(), registry.clone());
+
+        let summary = loader.scan_summary().await;
+        assert_eq!(summary.discovered, 1);
+        assert_eq!(summary.loaded, 0);
+        assert_eq!(summary.removed, 0);
+        assert!(registry.get("missing-version").await.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #302

Changes:
- enforce required `version` in SPELL.md loading with test coverage
- expose spell manifest metadata via gateway skills responses
- render version/namespace/author/kind/requires/tags/match/triggers in CLI skill output