### PR TITLE
feat(runtime): document restart continuity semantics (#284)

### DIFF
--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -35,7 +35,7 @@ As of 2026-03-14 early-morning execution:
 - background `exec` launches now persist restart-visible metadata into durable tool-execution audit rows, with honest degraded `process` inspection after restart
 
 Highest-leverage remaining parity gaps:
-1. restart-safe continuation guarantees remain explicitly incomplete: current Rune preserves durable approval-decision resume metadata and startup restoration of active session indexing, but it still does not prove broader restart-safe continuation for approval-resumed turns, live process handles, resumed-session notifications, or all in-flight work across gateway restarts.
+1. restart-safe continuation guarantees remain explicitly incomplete: current Rune preserves durable approval-decision resume metadata, startup restoration of active session indexing, and a one-time resumed-session notice on the next inbound message for restored channel sessions. The supported continuity contract is intentionally narrower than full in-place resurrection: transcript history plus durable approval/session state are restored, while in-flight turns, live process handles, and typing/progress UI do not resume in place across gateway restarts.
 2. broader persistence/inspectability for subagent lifecycle beyond scheduled descendants
    - Note: baseline durable parent/requester linkage for direct/channel/scheduled/subagent sessions already exists in runtime tests, and live `sessions_spawn` now also preserves requester linkage when the caller provides `sessionKey`/`requesterSessionId`; remaining gap is richer lifecycle/runtime inspectability rather than the linkage primitive itself.
 3. deeper session-status parity quality (cost fidelity, unresolved-note reduction, broader runtime linkage)


### PR DESCRIPTION
Closes #284

Changes:
- document the shipped restart continuity contract in agent orchestration docs
- align docs with existing resumed-session notice behavior and runtime coverage
- keep scope narrow: explicit semantics, not broader resurrection claims