### PR TITLE
feat(spells): add rust patterns library (#303)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/rune-browser",
   "crates/rune-testkit",
   "crates/rune-spells/security-audit",
+  "crates/rune-spells/rust-patterns",
   "apps/gateway",
   "apps/cli",
 ]

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -22,6 +22,7 @@ rune-stt = { path = "../../crates/rune-stt" }
 rune-store = { path = "../../crates/rune-store" }
 rune-tools = { path = "../../crates/rune-tools" }
 rune-spells-security-audit = { path = "../../crates/rune-spells/security-audit" }
+rune-spells-rust-patterns = { path = "../../crates/rune-spells/rust-patterns" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -47,6 +47,7 @@ use rune_runtime::{
     scheduler::{ReminderStore, Scheduler},
     session_loop::SessionLoop,
 };
+use rune_spells_rust_patterns::rust_patterns_tool_definition;
 use rune_spells_security_audit::security_audit_tool_definition;
 use rune_store::models::{NewToolExecution, SessionRow, TurnRow};
 use rune_store::repos::{
@@ -2014,6 +2015,7 @@ fn register_real_tool_definitions(registry: &mut ToolRegistry, browse_enabled: b
     }
 
     registry.register(security_audit_tool_definition());
+    registry.register(rust_patterns_tool_definition());
 }
 
 /// Build the model provider from config, falling back to echo if none configured.

--- a/crates/rune-spells/rust-patterns/Cargo.toml
+++ b/crates/rune-spells/rust-patterns/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rune-spells-rust-patterns"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+rune-core = { path = "../../rune-core" }
+rune-tools = { path = "../../rune-tools" }
+serde.workspace = true
+serde_json.workspace = true
+toml.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/rune-spells/rust-patterns/SPELL.md
+++ b/crates/rune-spells/rust-patterns/SPELL.md
@@ -1,0 +1,21 @@
+---
+name: rust-patterns
+namespace: rune.rust-patterns
+version: 0.1.0
+kind: tool
+description: Rust-native pattern library spell for querying production Rust patterns by topic, tags, and file imports.
+requires:
+  - filesystem
+tags:
+  - rust
+  - patterns
+  - codegen
+triggers:
+  - rust pattern
+  - rust best practice
+  - rust example
+---
+
+# Rust Patterns
+
+Native Rust spell that loads pattern references from TOML files and returns the most relevant matches for agent code generation.

--- a/crates/rune-spells/rust-patterns/patterns/anti_patterns.toml
+++ b/crates/rune-spells/rust-patterns/patterns/anti_patterns.toml
@@ -1,0 +1,16 @@
+[meta]
+topic = "anti_patterns"
+tags = ["anti-pattern", "unwrap", "blocking", "clone"]
+relevance_signals = ["mutex", "sync-io", "unwrap", "clone"]
+
+[[patterns]]
+name = "common rust anti-patterns"
+when = "Reviewing code for maintainability and runtime safety"
+code = """
+// avoid: value.clone() just to satisfy the borrow checker
+// avoid: Arc<Mutex<T>> as the default architecture
+// avoid: .unwrap() in library code
+// avoid: std::fs inside async fn
+"""
+rationale = "Surfacing recurring mistakes early keeps code idiomatic and production-safe"
+anti_pattern = "Treating the borrow checker as an obstacle instead of a design signal"

--- a/crates/rune-spells/rust-patterns/patterns/async_tokio.toml
+++ b/crates/rune-spells/rust-patterns/patterns/async_tokio.toml
@@ -1,0 +1,27 @@
+[meta]
+topic = "async_tokio"
+tags = ["tokio", "async", "select", "spawn-blocking"]
+relevance_signals = ["timeout", "tokio", "await", "blocking"]
+
+[[patterns]]
+name = "tokio select with timeout"
+when = "Racing a task against shutdown or timeout conditions"
+code = """
+tokio::select! {
+    result = worker() => result?,
+    _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+        anyhow::bail!("worker timed out");
+    }
+}
+"""
+rationale = "tokio::select! expresses cancellation and timeout behavior without manual polling"
+anti_pattern = "Busy waiting or manual timeout bookkeeping around futures"
+
+[[patterns]]
+name = "spawn blocking for sync work"
+when = "Calling blocking CPU-heavy or synchronous APIs from async code"
+code = """
+let value = tokio::task::spawn_blocking(move || expensive_sync_call()).await?;
+"""
+rationale = "spawn_blocking prevents sync work from starving async executors"
+anti_pattern = "Using std::fs or long blocking calls directly inside async fn"

--- a/crates/rune-spells/rust-patterns/patterns/axum_web.toml
+++ b/crates/rune-spells/rust-patterns/patterns/axum_web.toml
@@ -1,0 +1,15 @@
+[meta]
+topic = "axum_web"
+tags = ["axum", "router", "json", "state"]
+relevance_signals = ["route", "handler", "statuscode", "json"]
+
+[[patterns]]
+name = "axum router with state"
+when = "Building HTTP endpoints with shared application state"
+code = """
+let app = axum::Router::new()
+    .route("/users", axum::routing::post(create_user))
+    .with_state(std::sync::Arc::new(AppState { repo }));
+"""
+rationale = "Axum state injection keeps handlers lean and testable"
+anti_pattern = "Global mutable state instead of explicit shared state injection"

--- a/crates/rune-spells/rust-patterns/patterns/cli_clap.toml
+++ b/crates/rune-spells/rust-patterns/patterns/cli_clap.toml
@@ -1,0 +1,19 @@
+[meta]
+topic = "cli_clap"
+tags = ["clap", "cli", "parser", "subcommand"]
+relevance_signals = ["arg", "derive", "subcommand"]
+
+[[patterns]]
+name = "clap derive api"
+when = "Building a typed CLI with subcommands and env-backed args"
+code = """
+#[derive(clap::Parser)]
+struct Cli {
+    #[arg(short, long)]
+    verbose: bool,
+    #[command(subcommand)]
+    command: Command,
+}
+"""
+rationale = "Clap derive keeps CLI definitions declarative and discoverable"
+anti_pattern = "Manual argv parsing with ad-hoc validation"

--- a/crates/rune-spells/rust-patterns/patterns/concurrency.toml
+++ b/crates/rune-spells/rust-patterns/patterns/concurrency.toml
@@ -1,0 +1,26 @@
+[meta]
+topic = "concurrency"
+tags = ["arc", "mutex", "rwlock", "rayon", "channel"]
+relevance_signals = ["parallel", "shared-state", "message-passing"]
+
+[[patterns]]
+name = "prefer channels over shared mutexes"
+when = "Coordinating ownership transfer between tasks"
+code = """
+let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+tx.send(job).await?;
+while let Some(job) = rx.recv().await {
+    handle(job).await;
+}
+"""
+rationale = "Message passing often removes lock contention and clarifies ownership"
+anti_pattern = "Defaulting to Arc<Mutex<T>> everywhere"
+
+[[patterns]]
+name = "rwlock for read-heavy state"
+when = "Shared state has frequent reads and rare writes"
+code = """
+let shared = std::sync::Arc::new(tokio::sync::RwLock::new(Config::default()));
+"""
+rationale = "RwLock allows concurrent readers while preserving exclusive writes"
+anti_pattern = "Using a Mutex when reads vastly outnumber writes"

--- a/crates/rune-spells/rust-patterns/patterns/database.toml
+++ b/crates/rune-spells/rust-patterns/patterns/database.toml
@@ -1,0 +1,25 @@
+[meta]
+topic = "database"
+tags = ["sqlx", "diesel", "seaorm", "database"]
+relevance_signals = ["query", "orm", "postgres", "fetch-all"]
+
+[[patterns]]
+name = "sqlx for checked raw SQL"
+when = "You want explicit SQL with async execution and strong checking"
+code = """
+let users = sqlx::query_as::<_, User>("SELECT id, email FROM users WHERE active = $1")
+    .bind(true)
+    .fetch_all(&pool)
+    .await?;
+"""
+rationale = "SQLx keeps SQL visible while providing compile-time verification in supported setups"
+anti_pattern = "String-concatenated SQL with unbound parameters"
+
+[[patterns]]
+name = "diesel for type-safe query builder"
+when = "You prefer schema-driven query composition in synchronous codebases"
+code = """
+let rows = users.filter(active.eq(true)).load::<User>(&mut conn)?;
+"""
+rationale = "Diesel gives strong compile-time query guarantees through the type system"
+anti_pattern = "Hand-written SQL spread everywhere without shared query patterns"

--- a/crates/rune-spells/rust-patterns/patterns/error_handling.toml
+++ b/crates/rune-spells/rust-patterns/patterns/error_handling.toml
@@ -1,0 +1,36 @@
+[meta]
+topic = "error_handling"
+tags = ["thiserror", "anyhow", "result", "error"]
+relevance_signals = ["unwrap", "expect", "context", "thiserror", "anyhow"]
+
+[[patterns]]
+name = "thiserror for libraries"
+when = "Building a library crate where callers need matchable error variants"
+code = """
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MyError {
+    #[error("file not found: {0}")]
+    FileNotFound(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+"""
+rationale = "thiserror keeps library errors structured and matchable while generating Display and Error implementations"
+anti_pattern = ".unwrap() in library code — return Result<T, E> instead"
+
+[[patterns]]
+name = "anyhow for applications"
+when = "Building a binary or service where rich context matters more than typed variants"
+code = """
+use anyhow::{Context, Result};
+
+fn run() -> Result<()> {
+    let config = std::fs::read_to_string("config.toml")
+        .context("failed to read config.toml")?;
+    Ok(())
+}
+"""
+rationale = "anyhow is ideal at the application edge where error context chains matter most"
+anti_pattern = "Dropping source context and returning generic string errors"

--- a/crates/rune-spells/rust-patterns/patterns/ownership.toml
+++ b/crates/rune-spells/rust-patterns/patterns/ownership.toml
@@ -1,0 +1,16 @@
+[meta]
+topic = "ownership"
+tags = ["ownership", "borrow", "move", "reference"]
+relevance_signals = ["borrow", "borrow-checker", "move", "clone"]
+
+[[patterns]]
+name = "ownership mental model"
+when = "Reasoning about moves and borrows in core Rust code"
+code = """
+let y = x;      // move
+let r1 = &data; // immutable borrow
+let r2 = &data; // another immutable borrow
+let m = &mut data; // exclusive mutable borrow
+"""
+rationale = "Treat ownership like title transfer: moves invalidate the source, immutable borrows allow many readers, mutable borrow allows one exclusive writer"
+anti_pattern = "Over-cloning to bypass the borrow checker instead of restructuring code around references"

--- a/crates/rune-spells/rust-patterns/patterns/pyo3.toml
+++ b/crates/rune-spells/rust-patterns/patterns/pyo3.toml
@@ -1,0 +1,20 @@
+[meta]
+topic = "pyo3"
+tags = ["pyo3", "python", "maturin"]
+relevance_signals = ["pymodule", "pyfunction", "python"]
+
+[[patterns]]
+name = "pyo3 module export"
+when = "Creating Python bindings for Rust functions"
+code = """
+#[pyo3::pyfunction]
+fn add(a: usize, b: usize) -> usize { a + b }
+
+#[pyo3::pymodule]
+fn my_module(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    m.add_function(pyo3::wrap_pyfunction!(add, m)?)?;
+    Ok(())
+}
+"""
+rationale = "PyO3 macros provide a direct bridge from Rust functions into Python modules"
+anti_pattern = "Hand-writing unsafe Python FFI when PyO3 already covers the use case"

--- a/crates/rune-spells/rust-patterns/patterns/wasm.toml
+++ b/crates/rune-spells/rust-patterns/patterns/wasm.toml
@@ -1,0 +1,14 @@
+[meta]
+topic = "wasm"
+tags = ["wasm", "wasm-bindgen", "webassembly"]
+relevance_signals = ["browser", "wasm32", "bindgen"]
+
+[[patterns]]
+name = "guard platform-specific wasm code"
+when = "Exposing Rust functions to browser runtimes"
+code = """
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+"""
+rationale = "cfg-gating keeps host builds clean while enabling wasm-specific exports"
+anti_pattern = "Mixing wasm-only APIs into native builds without conditional compilation"

--- a/crates/rune-spells/rust-patterns/src/lib.rs
+++ b/crates/rune-spells/rust-patterns/src/lib.rs
@@ -1,0 +1,418 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RustPatternsError {
+    #[error("pattern directory not found: {0}")]
+    PatternDirMissing(PathBuf),
+    #[error("failed to read {path}: {source}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse TOML {path}: {source}")]
+    ParseToml {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Pattern {
+    pub topic: String,
+    pub name: String,
+    pub when: String,
+    pub code: String,
+    pub rationale: String,
+    pub anti_pattern: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternQuery {
+    pub topic: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub context_file: Option<PathBuf>,
+    pub task_description: Option<String>,
+    pub error_message: Option<String>,
+    pub max_results: usize,
+}
+
+impl Default for PatternQuery {
+    fn default() -> Self {
+        Self {
+            topic: None,
+            tags: None,
+            context_file: None,
+            task_description: None,
+            error_message: None,
+            max_results: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    pub patterns: Vec<Pattern>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationFinding {
+    pub file: String,
+    pub line: usize,
+    pub issue: String,
+    pub recommendation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ValidationReport {
+    pub findings: Vec<ValidationFinding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PatternFile {
+    meta: PatternMeta,
+    patterns: Vec<PatternEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PatternMeta {
+    topic: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    relevance_signals: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PatternEntry {
+    name: String,
+    when: String,
+    code: String,
+    rationale: String,
+    anti_pattern: String,
+}
+
+#[derive(Debug, Clone)]
+struct LoadedTopic {
+    topic: String,
+    tags: Vec<String>,
+    relevance_signals: Vec<String>,
+    patterns: Vec<Pattern>,
+}
+
+pub fn rust_patterns_tool_definition() -> rune_tools::ToolDefinition {
+    rune_tools::ToolDefinition {
+        name: "rust_pattern".into(),
+        description: "Query the Rust patterns spell by topic, tags, task description, error text, or a Rust source file's imports.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "topic": { "type": "string", "description": "Pattern topic, e.g. error_handling" },
+                "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags to match, e.g. [\"tokio\", \"select\"]" },
+                "context_file": { "type": "string", "description": "Rust file path used for import-based pattern detection" },
+                "task_description": { "type": "string", "description": "Free-form task text used for relevance matching" },
+                "error_message": { "type": "string", "description": "Error text used for debugging-oriented relevance matching" },
+                "max_results": { "type": "integer", "description": "Maximum number of patterns to return (default: 3)" }
+            }
+        }),
+        category: rune_core::ToolCategory::FileRead,
+        requires_approval: false,
+    }
+}
+
+pub fn rust_pattern(query: PatternQuery) -> Result<QueryResult, RustPatternsError> {
+    let topics = load_pattern_library(default_patterns_dir())?;
+    let mut scored = Vec::new();
+
+    let requested_topic = query.topic.as_ref().map(|t| normalize(t));
+    let requested_tags: Vec<String> = query
+        .tags
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tag| normalize(&tag))
+        .collect();
+    let import_signals = query
+        .context_file
+        .as_ref()
+        .map(|path| collect_import_signals(path).unwrap_or_default())
+        .unwrap_or_default();
+    let task_terms = tokenize(query.task_description.as_deref().unwrap_or_default());
+    let error_terms = tokenize(query.error_message.as_deref().unwrap_or_default());
+
+    for topic in topics {
+        let topic_norm = normalize(&topic.topic);
+        let topic_tags: Vec<String> = topic.tags.iter().map(|tag| normalize(tag)).collect();
+        let topic_signals: Vec<String> = topic
+            .relevance_signals
+            .iter()
+            .map(|signal| normalize(signal))
+            .collect();
+
+        let mut score = 0usize;
+        if requested_topic.as_ref().is_some_and(|wanted| wanted == &topic_norm) {
+            score += 100;
+        }
+        for tag in &requested_tags {
+            if topic_tags.iter().any(|candidate| candidate == tag)
+                || topic_signals.iter().any(|candidate| candidate.contains(tag) || tag.contains(candidate))
+            {
+                score += 20;
+            }
+        }
+        for signal in &import_signals {
+            if topic_tags.iter().any(|candidate| candidate == signal)
+                || topic_signals.iter().any(|candidate| candidate.contains(signal) || signal.contains(candidate))
+            {
+                score += 15;
+            }
+        }
+        for term in task_terms.iter().chain(error_terms.iter()) {
+            if topic_tags.iter().any(|candidate| candidate == term)
+                || topic_signals.iter().any(|candidate| candidate.contains(term) || term.contains(candidate))
+                || topic_norm.contains(term)
+            {
+                score += 5;
+            }
+        }
+
+        if score == 0
+            && requested_topic.is_none()
+            && requested_tags.is_empty()
+            && import_signals.is_empty()
+            && task_terms.is_empty()
+            && error_terms.is_empty()
+        {
+            score = 1;
+        }
+
+        for pattern in topic.patterns {
+            if score > 0 {
+                scored.push((score, pattern));
+            }
+        }
+    }
+
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| a.1.topic.cmp(&b.1.topic))
+            .then_with(|| a.1.name.cmp(&b.1.name))
+    });
+    scored.dedup_by(|a, b| a.1.topic == b.1.topic && a.1.name == b.1.name);
+
+    Ok(QueryResult {
+        patterns: scored
+            .into_iter()
+            .take(query.max_results.max(1))
+            .map(|(_, pattern)| pattern)
+            .collect(),
+    })
+}
+
+pub fn validate_rune_codebase(root: &Path) -> ValidationReport {
+    let mut findings = Vec::new();
+    collect_validation_findings(root, &mut findings);
+    ValidationReport { findings }
+}
+
+fn collect_validation_findings(root: &Path, findings: &mut Vec<ValidationFinding>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let skip = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| matches!(name, "target" | ".git" | "node_modules"));
+            if !skip {
+                collect_validation_findings(&path, findings);
+            }
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+
+        if path.components().any(|component| component.as_os_str() == "tests") {
+            continue;
+        }
+
+        if let Ok(content) = fs::read_to_string(&path) {
+            let async_and_blocking = content.contains("async fn") && content.contains("std::thread::sleep");
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.contains(".unwrap()") {
+                    findings.push(ValidationFinding {
+                        file: path.display().to_string(),
+                        line: idx + 1,
+                        issue: "unwrap() in non-test Rust code".into(),
+                        recommendation: "Prefer ? or a typed error path from the rust-patterns anti-pattern library.".into(),
+                    });
+                }
+                if async_and_blocking && trimmed.starts_with("async fn") {
+                    findings.push(ValidationFinding {
+                        file: path.display().to_string(),
+                        line: idx + 1,
+                        issue: "blocking std::thread::sleep inside async context".into(),
+                        recommendation: "Use tokio::time::sleep or spawn_blocking depending on the workload.".into(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn load_pattern_library(dir: PathBuf) -> Result<Vec<LoadedTopic>, RustPatternsError> {
+    if !dir.exists() {
+        return Err(RustPatternsError::PatternDirMissing(dir));
+    }
+
+    let mut topics = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|source| RustPatternsError::ReadFile {
+        path: dir.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| RustPatternsError::ReadFile {
+            path: dir.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+            continue;
+        }
+
+        let raw = fs::read_to_string(&path).map_err(|source| RustPatternsError::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        let parsed: PatternFile = toml::from_str(&raw).map_err(|source| RustPatternsError::ParseToml {
+            path: path.clone(),
+            source,
+        })?;
+
+        let patterns = parsed
+            .patterns
+            .into_iter()
+            .map(|pattern| Pattern {
+                topic: parsed.meta.topic.clone(),
+                name: pattern.name,
+                when: pattern.when,
+                code: pattern.code,
+                rationale: pattern.rationale,
+                anti_pattern: pattern.anti_pattern,
+                tags: parsed.meta.tags.clone(),
+            })
+            .collect();
+
+        topics.push(LoadedTopic {
+            topic: parsed.meta.topic,
+            tags: parsed.meta.tags,
+            relevance_signals: parsed.meta.relevance_signals,
+            patterns,
+        });
+    }
+
+    Ok(topics)
+}
+
+fn default_patterns_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("patterns")
+}
+
+fn collect_import_signals(path: &Path) -> Result<Vec<String>, RustPatternsError> {
+    let raw = fs::read_to_string(path).map_err(|source| RustPatternsError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut signals = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("use ") {
+            let crate_name = rest
+                .split([':', ';', ' '])
+                .next()
+                .unwrap_or_default()
+                .trim();
+            if !crate_name.is_empty() {
+                signals.push(normalize(crate_name));
+            }
+        }
+    }
+    Ok(signals)
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|part| !part.is_empty())
+        .map(normalize)
+        .collect()
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_definition_name_is_stable() {
+        let def = rust_patterns_tool_definition();
+        assert_eq!(def.name, "rust_pattern");
+    }
+
+    #[test]
+    fn loads_all_seed_topics() {
+        let topics = load_pattern_library(default_patterns_dir()).expect("seed patterns should load");
+        assert!(topics.iter().any(|topic| topic.topic == "error_handling"));
+        assert!(topics.iter().any(|topic| topic.topic == "async_tokio"));
+        assert!(topics.iter().any(|topic| topic.topic == "anti_patterns"));
+    }
+
+    #[test]
+    fn query_by_topic_returns_matching_patterns() {
+        let result = rust_pattern(PatternQuery {
+            topic: Some("error_handling".into()),
+            ..Default::default()
+        })
+        .expect("query should work");
+
+        assert!(!result.patterns.is_empty());
+        assert!(result.patterns.iter().all(|pattern| pattern.topic == "error_handling"));
+    }
+
+    #[test]
+    fn query_by_tags_and_task_description_prefers_tokio() {
+        let result = rust_pattern(PatternQuery {
+            tags: Some(vec!["tokio".into(), "select".into()]),
+            task_description: Some("Need an async timeout with tokio select".into()),
+            ..Default::default()
+        })
+        .expect("query should work");
+
+        assert!(!result.patterns.is_empty());
+        assert_eq!(result.patterns[0].topic, "async_tokio");
+    }
+
+    #[test]
+    fn validation_flags_unwrap_in_non_test_code() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("sample.rs");
+        fs::write(&file, "fn demo() { let _ = Some(1).unwrap(); }\n").unwrap();
+
+        let report = validate_rune_codebase(tmp.path());
+        assert_eq!(report.findings.len(), 1);
+        assert!(report.findings[0].issue.contains("unwrap"));
+    }
+}


### PR DESCRIPTION
Closes #303

Changes:
- add native rune-spells-rust-patterns crate and SPELL manifest
- load Rust patterns from structured TOML files across required topics
- add query, context inference, and repo validation support with tests