### PR TITLE
feat(cli): add self-update alias (#253)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -448,6 +448,7 @@ pub enum Command {
         action: BackupAction,
     },
     /// Manage gateway updates.
+    #[command(alias = "self-update")]
     Update {
         #[command(subcommand)]
         action: UpdateAction,
@@ -6308,4 +6309,15 @@ fn parse_service_install_no_bootstrap() {
         } => assert!(no_bootstrap),
         other => panic!("unexpected command: {other:?}"),
     }
+}
+
+#[test]
+fn parse_update_self_update_alias() {
+    let cli = Cli::try_parse_from(["rune", "self-update", "check"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Command::Update {
+            action: UpdateAction::Check
+        }
+    ));
 }


### PR DESCRIPTION
Closes #253

Changes:
- add `self-update` as a CLI alias for `rune update`
- cover alias parsing with a CLI test

Notes:
- `cargo check` passes
- targeted `cargo test -p rune-cli parse_update_self_update_alias` is currently blocked by pre-existing test compile errors in `crates/rune-cli/src/output.rs` unrelated to this change