### PR TITLE
feat(rust-patterns): complete seed pattern coverage (#303)

### DIFF
--- a/crates/rune-spells/rust-patterns/patterns/axum_web.toml
+++ b/crates/rune-spells/rust-patterns/patterns/axum_web.toml
@@ -13,3 +13,18 @@ let app = axum::Router::new()
 """
 rationale = "Axum state injection keeps handlers lean and testable"
 anti_pattern = "Global mutable state instead of explicit shared state injection"
+
+[[patterns]]
+name = "json extractor with status code"
+when = "Receiving and validating JSON payloads in an Axum handler"
+code = """
+async fn create_user(
+    axum::extract::State(state): axum::extract::State<std::sync::Arc<AppState>>,
+    axum::Json(input): axum::Json<CreateUserRequest>,
+) -> Result<(axum::http::StatusCode, axum::Json<User>), AppError> {
+    let user = state.repo.create(input).await?;
+    Ok((axum::http::StatusCode::CREATED, axum::Json(user)))
+}
+"""
+rationale = "Typed extractors and explicit status codes keep request handling precise and ergonomic"
+anti_pattern = "Manual body parsing and ad-hoc JSON decoding inside handlers"

--- a/crates/rune-spells/rust-patterns/patterns/cli_clap.toml
+++ b/crates/rune-spells/rust-patterns/patterns/cli_clap.toml
@@ -17,3 +17,19 @@ struct Cli {
 """
 rationale = "Clap derive keeps CLI definitions declarative and discoverable"
 anti_pattern = "Manual argv parsing with ad-hoc validation"
+
+[[patterns]]
+name = "clap subcommand enum"
+when = "Modeling multiple command entrypoints with strongly typed arguments"
+code = """
+#[derive(clap::Subcommand)]
+enum Command {
+    Serve {
+        #[arg(long, default_value_t = 8080)]
+        port: u16,
+    },
+    Check,
+}
+"""
+rationale = "Subcommand enums keep command routing explicit and self-documenting"
+anti_pattern = "Using stringly-typed command switches scattered through main()"

--- a/crates/rune-spells/rust-patterns/patterns/ownership.toml
+++ b/crates/rune-spells/rust-patterns/patterns/ownership.toml
@@ -14,3 +14,14 @@ let m = &mut data; // exclusive mutable borrow
 """
 rationale = "Treat ownership like title transfer: moves invalidate the source, immutable borrows allow many readers, mutable borrow allows one exclusive writer"
 anti_pattern = "Over-cloning to bypass the borrow checker instead of restructuring code around references"
+
+[[patterns]]
+name = "borrow instead of cloning"
+when = "A helper only needs to read data and ownership transfer would force extra cloning"
+code = """
+fn render(user: &User) -> String {
+    format!("{} <{}>", user.name, user.email)
+}
+"""
+rationale = "Borrowing preserves ownership for the caller and avoids unnecessary allocations"
+anti_pattern = "Cloning large structs just to pass them into read-only helper functions"

--- a/crates/rune-spells/rust-patterns/patterns/wasm.toml
+++ b/crates/rune-spells/rust-patterns/patterns/wasm.toml
@@ -12,3 +12,16 @@ use wasm_bindgen::prelude::*;
 """
 rationale = "cfg-gating keeps host builds clean while enabling wasm-specific exports"
 anti_pattern = "Mixing wasm-only APIs into native builds without conditional compilation"
+
+[[patterns]]
+name = "wasm bindgen export"
+when = "Publishing a Rust function for JavaScript callers in the browser"
+code = """
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn greet(name: &str) -> String {
+    format!("hello, {name}")
+}
+"""
+rationale = "wasm-bindgen provides the standard bridge for JS-facing exports from Rust"
+anti_pattern = "Expecting plain pub fn symbols to be callable from JavaScript without bindgen glue"

--- a/crates/rune-spells/rust-patterns/src/lib.rs
+++ b/crates/rune-spells/rust-patterns/src/lib.rs
@@ -161,21 +161,27 @@ pub fn rust_pattern(query: PatternQuery) -> Result<QueryResult, RustPatternsErro
         }
         for tag in &requested_tags {
             if topic_tags.iter().any(|candidate| candidate == tag)
-                || topic_signals.iter().any(|candidate| candidate.contains(tag) || tag.contains(candidate))
+                || topic_signals
+                    .iter()
+                    .any(|candidate| candidate.contains(tag) || tag.contains(candidate))
             {
                 score += 20;
             }
         }
         for signal in &import_signals {
             if topic_tags.iter().any(|candidate| candidate == signal)
-                || topic_signals.iter().any(|candidate| candidate.contains(signal) || signal.contains(candidate))
+                || topic_signals
+                    .iter()
+                    .any(|candidate| candidate.contains(signal) || signal.contains(candidate))
             {
                 score += 15;
             }
         }
         for term in task_terms.iter().chain(error_terms.iter()) {
             if topic_tags.iter().any(|candidate| candidate == term)
-                || topic_signals.iter().any(|candidate| candidate.contains(term) || term.contains(candidate))
+                || topic_signals
+                    .iter()
+                    .any(|candidate| candidate.contains(term) || term.contains(candidate))
                 || topic_norm.contains(term)
             {
                 score += 5;
@@ -322,6 +328,7 @@ fn load_pattern_library(dir: PathBuf) -> Result<Vec<LoadedTopic>, RustPatternsEr
         });
     }
 
+    topics.sort_by(|a, b| a.topic.cmp(&b.topic));
     Ok(topics)
 }
 
@@ -375,9 +382,22 @@ mod tests {
     #[test]
     fn loads_all_seed_topics() {
         let topics = load_pattern_library(default_patterns_dir()).expect("seed patterns should load");
+        assert!(topics.iter().any(|topic| topic.topic == "ownership"));
         assert!(topics.iter().any(|topic| topic.topic == "error_handling"));
         assert!(topics.iter().any(|topic| topic.topic == "async_tokio"));
+        assert!(topics.iter().any(|topic| topic.topic == "axum_web"));
+        assert!(topics.iter().any(|topic| topic.topic == "concurrency"));
+        assert!(topics.iter().any(|topic| topic.topic == "database"));
+        assert!(topics.iter().any(|topic| topic.topic == "cli_clap"));
+        assert!(topics.iter().any(|topic| topic.topic == "wasm"));
+        assert!(topics.iter().any(|topic| topic.topic == "pyo3"));
         assert!(topics.iter().any(|topic| topic.topic == "anti_patterns"));
+    }
+
+    #[test]
+    fn every_seed_topic_has_at_least_one_pattern() {
+        let topics = load_pattern_library(default_patterns_dir()).expect("seed patterns should load");
+        assert!(topics.iter().all(|topic| !topic.patterns.is_empty()));
     }
 
     #[test]
@@ -406,10 +426,30 @@ mod tests {
     }
 
     #[test]
+    fn query_by_imports_prefers_axum_patterns() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("handler.rs");
+        fs::write(
+            &file,
+            "use axum::Json;\nuse axum::extract::State;\nasync fn handler() {}\n",
+        )
+        .expect("write file");
+
+        let result = rust_pattern(PatternQuery {
+            context_file: Some(file),
+            ..Default::default()
+        })
+        .expect("query should work");
+
+        assert!(!result.patterns.is_empty());
+        assert_eq!(result.patterns[0].topic, "axum_web");
+    }
+
+    #[test]
     fn validation_flags_unwrap_in_non_test_code() {
-        let tmp = tempfile::tempdir().unwrap();
+        let tmp = tempfile::tempdir().expect("tempdir");
         let file = tmp.path().join("sample.rs");
-        fs::write(&file, "fn demo() { let _ = Some(1).unwrap(); }\n").unwrap();
+        fs::write(&file, "fn demo() { let _ = Some(1).unwrap(); }\n").expect("write file");
 
         let report = validate_rune_codebase(tmp.path());
         assert_eq!(report.findings.len(), 1);


### PR DESCRIPTION
Closes #303

Changes:
- add missing pattern examples for ownership, axum, clap, and wasm topics
- strengthen rust-patterns tests to assert all seed topics load and import-based matching works
- keep pattern loading deterministic by sorting loaded topics before scoring