### PR TITLE
feat(runtime): clarify restart resume notice semantics (#284)

### DIFF
--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -657,13 +657,13 @@ impl SessionLoop {
             notices.get(routing_key).cloned()
         };
 
-        let fingerprint = session.updated_at.to_rfc3339();
+        let fingerprint = session.last_activity_at.to_rfc3339();
         if last_notified.as_deref() == Some(fingerprint.as_str()) {
             return;
         }
 
         let text = format!(
-            "Resumed session `{}` after restart. Transcript history and durable approval/session state were restored. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.",
+            "Resumed session `{}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.",
             session.id
         );
 


### PR DESCRIPTION
Closes #284

Changes:
- key resumed-session notifications off last saved activity instead of generic updated_at timestamps
- make the notification copy explicit about what restart continuity restores vs what does not resume in place
- keep the scope narrow to the operator-visible restart continuity semantics in this follow-on issue