### PR TITLE
docs(acp): update parity docs for wired CLI routes (#266)

### DIFF
--- a/docs/FUNCTIONALITY-CHECKLIST.md
+++ b/docs/FUNCTIONALITY-CHECKLIST.md
@@ -123,6 +123,7 @@ Implementation note (2026-03-19): the operator CLI now exposes the `models` comm
 - [ ] `agent` command
 - [ ] `agents` command family
 - [x] `acp` tool dispatch — `acp_dispatch` tool registered; dispatches to Claude Code CLI and Codex CLI as subprocesses
+  - 2026-03-27 parity slice: ACP operator surface is now wired end-to-end through gateway `/acp/send`, `/acp/inbox`, and `/acp/ack` plus CLI client/execution paths, so the remaining ACP gap is narrowed to streaming/background execution and richer agent config rather than missing route/CLI plumbing.
 - [ ] `acp` CLI command family (`rune acp send/inbox/ack`)
 - [ ] `skills` command family
 - [ ] `plugins` command family

--- a/docs/parity/CLI-MATRIX.md
+++ b/docs/parity/CLI-MATRIX.md
@@ -61,7 +61,7 @@
 | `message` | `rune message` | **Partial** | `send`, `read`, `edit`, `delete`, `react`, `pin`, `search`, `broadcast`, `thread list/reply`, `voice send/status`, `tag`, `ack`, `list-reactions` shipped | #74 |
 | `agent` | `rune agent` | **Shipped** | `run`, `result` | #70 |
 | `agents` | `rune agents` | **Partial** | `list`, `show`, `status`, `tree`, `templates`, `start --template` shipped. `steer`/`kill` remain blocked because no client-facing transport surface exists yet to send those control actions, even though internal lifecycle/session logic already exists. | #63/#70 |
-| `acp` | `acp_dispatch` tool | **Partial** | Tool dispatches tasks to Claude Code / Codex CLIs as subprocesses. CLI `rune acp send/inbox/ack` surface not yet wired. | #70 |
+| `acp` | `acp_dispatch` tool + `rune acp send/inbox/ack` | **Partial** | Tool dispatches tasks to Claude Code / Codex CLIs as subprocesses. CLI ACP send/inbox/ack now routes through gateway `/acp/send`, `/acp/inbox`, and `/acp/ack`. Remaining gaps: streaming output, background dispatch, richer agent config/sandbox controls. | #70 |
 | `devices` | — | **Not started** | `list`, `remove`, `clear`, `approve`, `reject`, `rotate`, `revoke` | — |
 | `pairing` | — | **Not started** | `list`, `approve` | — |
 | `node` | — | **Not started** | `run`, `status`, `install`, `uninstall`, `stop`, `restart` | — |

--- a/docs/parity/PARITY-INVENTORY.md
+++ b/docs/parity/PARITY-INVENTORY.md
@@ -611,7 +611,7 @@ Required concepts:
 - ACP bridge/runtime distinction
 - thread-bound persistent ACP sessions where supported
 
-Status: `acp_dispatch` tool implemented — dispatches to Claude Code CLI and Codex CLI as subprocesses. CLI `rune acp send/inbox/ack` surface parsed but not yet wired to gateway routes.
+Status: `acp_dispatch` tool implemented — dispatches to Claude Code CLI and Codex CLI as subprocesses. CLI `rune acp send/inbox/ack` is now wired to gateway `/acp/send`, `/acp/inbox`, and `/acp/ack` routes. Remaining work: streaming output, background dispatch, and richer agent-specific config/sandbox controls.
 
 ### Browser / TUI / dashboard / QR
 Observed local families include:


### PR DESCRIPTION
Closes #266

Changes:
- update CLI parity matrix to reflect shipped ACP send/inbox/ack route wiring
- update parity inventory status for ACP gateway endpoints
- add functionality checklist note narrowing remaining ACP gaps to streaming/background/config work