### PR TITLE
feat(runtime): gate resumed-session notices to restored sessions (#284)

### DIFF
--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -51,6 +51,7 @@ pub struct SessionLoop {
     channel: Arc<Mutex<Box<dyn ChannelAdapter>>>,
     sessions: Mutex<SessionIndex>,
     resumed_session_notifications: Mutex<HashMap<String, String>>,
+    restored_session_routes: Mutex<HashMap<String, String>>,
     agents: AgentsConfig,
     models: ModelsConfig,
     stt_engine: Option<Arc<RwLock<SttEngine>>>,
@@ -94,6 +95,7 @@ impl SessionLoop {
             channel: Arc::new(Mutex::new(channel)),
             sessions: Mutex::new(HashMap::new()),
             resumed_session_notifications: Mutex::new(HashMap::new()),
+            restored_session_routes: Mutex::new(HashMap::new()),
             agents,
             models,
             stt_engine: None,
@@ -133,6 +135,10 @@ impl SessionLoop {
                 for session in &sessions {
                     if let Some(ref channel_ref) = session.channel_ref {
                         index.insert(channel_ref.clone(), session.id);
+                        self.restored_session_routes
+                            .lock()
+                            .await
+                            .insert(channel_ref.clone(), session.last_activity_at.to_rfc3339());
                     }
                 }
                 if !sessions.is_empty() {
@@ -652,12 +658,20 @@ impl SessionLoop {
         routing_key: &str,
         session: &SessionRow,
     ) {
+        let fingerprint = session.last_activity_at.to_rfc3339();
+        let restored = {
+            let restored = self.restored_session_routes.lock().await;
+            restored.get(routing_key).cloned()
+        };
+        if restored.as_deref() != Some(fingerprint.as_str()) {
+            return;
+        }
+
         let last_notified = {
             let notices = self.resumed_session_notifications.lock().await;
             notices.get(routing_key).cloned()
         };
 
-        let fingerprint = session.last_activity_at.to_rfc3339();
         if last_notified.as_deref() == Some(fingerprint.as_str()) {
             return;
         }

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2415,6 +2415,53 @@ impl rune_channels::ChannelAdapter for SharedSentChannelAdapter {
 }
 
 #[tokio::test]
+async fn resumed_session_notice_skips_non_restored_sessions() {
+    let h = TestHarness::new();
+    let engine = Arc::new(h.session_engine());
+    let existing = engine
+        .create_session_full(
+            SessionKind::Channel,
+            Some(h.workspace_root.to_string_lossy().to_string()),
+            None,
+            Some("chat-2:user-2".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let adapter = SharedSentChannelAdapter { sent: sent.clone() };
+    let session_loop = crate::session_loop::SessionLoop::new(
+        engine.clone(),
+        Arc::new(h.turn_executor(
+            Arc::new(FakeModelProvider::new(vec![])),
+            Arc::new(FakeToolExecutor::new(vec![])),
+            ToolRegistry::new(),
+        )),
+        h.session_repo.clone(),
+        Box::new(adapter),
+        rune_config::AgentsConfig::default(),
+        rune_config::ModelsConfig::default(),
+    );
+
+    let msg = rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "chat-2".to_string(),
+        sender: "user-2".to_string(),
+        content: "hello".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-2".to_string(),
+    };
+
+    session_loop
+        .maybe_send_resumed_session_notice(&msg, "chat-2:user-2", &existing)
+        .await;
+
+    let sent = sent.lock().await.clone();
+    assert!(sent.is_empty(), "notice should not be sent for sessions that were not restored during startup");
+}
+
+#[tokio::test]
 async fn resumed_session_notice_only_for_restored_channel_sessions() {
     let h = TestHarness::new();
     let engine = Arc::new(h.session_engine());


### PR DESCRIPTION
Closes #284

Changes:
- only send resumed-session notices for sessions restored during startup
- keep restart continuity semantics explicit in the notice text
- add a regression test proving non-restored sessions do not get restart notices