### PR TITLE
feat(memory): preserve auto-capture metadata (#297)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -4869,6 +4869,8 @@ pub async fn memory_graph(
         "nodes": graph.nodes.iter().map(|n| json!({
             "id": n.id.to_string(),
             "fact": n.fact,
+            "source_agent": n.source_agent,
+            "trigger": n.trigger,
             "category": n.category,
             "session_id": n.source_session_id.map(|s| s.to_string()),
             "created_at": n.created_at.to_rfc3339(),
@@ -4930,6 +4932,10 @@ pub struct CaptureRequest {
     pub assistant_message: String,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub source_agent: Option<String>,
+    #[serde(default)]
+    pub trigger: Option<String>,
 }
 
 /// Request body for `POST /api/v1/memory/store`.
@@ -4940,6 +4946,10 @@ pub struct StoreFactRequest {
     pub category: String,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub source_agent: Option<String>,
+    #[serde(default)]
+    pub trigger: Option<String>,
 }
 
 fn default_category() -> String {
@@ -4968,6 +4978,8 @@ pub async fn v1_memory_recall(
             "fact": m.fact,
             "category": m.category,
             "session_id": m.source_session_id.map(|s| s.to_string()),
+            "source_agent": m.source_agent,
+            "trigger": m.trigger,
             "created_at": m.created_at.to_rfc3339(),
             "access_count": m.access_count,
         })).collect::<Vec<_>>(),
@@ -4993,7 +5005,15 @@ pub async fn v1_memory_capture(
         .unwrap_or_else(uuid::Uuid::new_v4);
 
     let stored = mem0
-        .capture(&body.user_message, &body.assistant_message, session_id)
+        .capture_with_metadata(
+            &body.user_message,
+            &body.assistant_message,
+            session_id,
+            rune_runtime::mem0::MemoryCaptureMetadata {
+                source_agent: body.source_agent.clone(),
+                trigger: body.trigger.clone(),
+            },
+        )
         .await;
 
     Ok(Json(json!({
@@ -5002,6 +5022,9 @@ pub async fn v1_memory_capture(
             "id": m.id.to_string(),
             "fact": m.fact,
             "category": m.category,
+            "session_id": m.source_session_id.map(|s| s.to_string()),
+            "source_agent": m.source_agent,
+            "trigger": m.trigger,
         })).collect::<Vec<_>>(),
     })))
 }
@@ -5028,7 +5051,17 @@ pub async fn v1_memory_store(
     let assistant_msg = format!("Noted. Category: {}. Fact: {}", body.category, body.fact);
 
     let sid = session_id.unwrap_or_else(uuid::Uuid::new_v4);
-    let stored = mem0.capture(&user_msg, &assistant_msg, sid).await;
+    let stored = mem0
+        .capture_with_metadata(
+            &user_msg,
+            &assistant_msg,
+            sid,
+            rune_runtime::mem0::MemoryCaptureMetadata {
+                source_agent: body.source_agent.clone(),
+                trigger: body.trigger.clone(),
+            },
+        )
+        .await;
 
     Ok(Json(json!({
         "stored": !stored.is_empty(),
@@ -5036,6 +5069,9 @@ pub async fn v1_memory_store(
             "id": m.id.to_string(),
             "fact": m.fact,
             "category": m.category,
+            "session_id": m.source_session_id.map(|s| s.to_string()),
+            "source_agent": m.source_agent,
+            "trigger": m.trigger,
         })).collect::<Vec<_>>(),
     })))
 }

--- a/crates/rune-runtime/src/mem0.rs
+++ b/crates/rune-runtime/src/mem0.rs
@@ -25,9 +25,17 @@ pub struct Memory {
     pub fact: String,
     pub category: String,
     pub source_session_id: Option<Uuid>,
+    pub source_agent: Option<String>,
+    pub trigger: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub access_count: i32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryCaptureMetadata {
+    pub source_agent: Option<String>,
+    pub trigger: Option<String>,
 }
 
 /// A graph of memories: nodes + similarity edges for visualization.
@@ -73,6 +81,8 @@ fn ensure_table_sql(dims: usize) -> String {
     category TEXT NOT NULL DEFAULT 'general',
     embedding vector({dims}),
     source_session_id UUID,
+    source_agent TEXT,
+    trigger TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     access_count INTEGER NOT NULL DEFAULT 0
@@ -89,7 +99,7 @@ CREATE INDEX IF NOT EXISTS idx_rune_memories_embedding
 "#;
 
 const RECALL_SQL: &str = r#"
-SELECT id, fact, category, source_session_id, created_at, updated_at, access_count
+SELECT id, fact, category, source_session_id, source_agent, trigger, created_at, updated_at, access_count
 FROM rune_memories
 WHERE 1 - (embedding <=> $1::vector) > $2
 ORDER BY embedding <=> $1::vector
@@ -101,7 +111,7 @@ UPDATE rune_memories SET access_count = access_count + 1 WHERE id = ANY($1)
 "#;
 
 const DEDUP_CHECK_SQL: &str = r#"
-SELECT id, fact, 1 - (embedding <=> $1::vector) AS similarity
+SELECT id, fact, source_agent, trigger, 1 - (embedding <=> $1::vector) AS similarity
 FROM rune_memories
 WHERE 1 - (embedding <=> $1::vector) > $2
 ORDER BY embedding <=> $1::vector
@@ -109,13 +119,13 @@ LIMIT 1
 "#;
 
 const INSERT_MEMORY_SQL: &str = r#"
-INSERT INTO rune_memories (id, fact, category, embedding, source_session_id, created_at, updated_at)
-VALUES ($1, $2, $3, $4::vector, $5, $6, $7)
+INSERT INTO rune_memories (id, fact, category, embedding, source_session_id, source_agent, trigger, created_at, updated_at)
+VALUES ($1, $2, $3, $4::vector, $5, $6, $7, $8, $9)
 "#;
 
 const UPDATE_MEMORY_SQL: &str = r#"
 UPDATE rune_memories
-SET fact = $2, category = $3, embedding = $4::vector, updated_at = $5
+SET fact = $2, category = $3, embedding = $4::vector, source_agent = $5, trigger = $6, updated_at = $7
 WHERE id = $1
 "#;
 
@@ -203,6 +213,15 @@ impl Mem0Engine {
         if let Err(e) = client.batch_execute(&table_sql).await {
             error!(error = %e, "mem0: failed to create rune_memories table — disabling");
             return None;
+        }
+
+        if let Err(e) = client
+            .batch_execute(
+                "ALTER TABLE rune_memories ADD COLUMN IF NOT EXISTS source_agent TEXT;\n                 ALTER TABLE rune_memories ADD COLUMN IF NOT EXISTS trigger TEXT;",
+            )
+            .await
+        {
+            warn!(error = %e, "mem0: failed to ensure metadata columns");
         }
 
         // pgvector 0.9.0+ supports HNSW indexes up to 4000 dimensions, which
@@ -324,6 +343,8 @@ impl Mem0Engine {
                 fact: row.get("fact"),
                 category: row.get("category"),
                 source_session_id: row.get("source_session_id"),
+                source_agent: row.get("source_agent"),
+                trigger: row.get("trigger"),
                 created_at: row.get("created_at"),
                 updated_at: row.get("updated_at"),
                 access_count: row.get("access_count"),
@@ -350,6 +371,25 @@ impl Mem0Engine {
         assistant_msg: &str,
         session_id: Uuid,
     ) -> Vec<Memory> {
+        self.capture_with_metadata(
+            user_msg,
+            assistant_msg,
+            session_id,
+            MemoryCaptureMetadata {
+                source_agent: None,
+                trigger: None,
+            },
+        )
+        .await
+    }
+
+    pub async fn capture_with_metadata(
+        &self,
+        user_msg: &str,
+        assistant_msg: &str,
+        session_id: Uuid,
+        metadata: MemoryCaptureMetadata,
+    ) -> Vec<Memory> {
         if let Err(e) = self.ensure_connected().await {
             warn!(error = %e, "mem0 capture: connection check failed");
             return Vec::new();
@@ -370,7 +410,7 @@ impl Mem0Engine {
         let mut stored = Vec::new();
 
         for fact in facts {
-            match self.store_fact(&fact, session_id).await {
+            match self.store_fact(&fact, session_id, &metadata).await {
                 Ok(Some(mem)) => stored.push(mem),
                 Ok(None) => {
                     debug!(fact = %fact.fact, "mem0: deduplicated (already exists)");
@@ -422,6 +462,8 @@ impl Mem0Engine {
                 fact: row.get("fact"),
                 category: row.get("category"),
                 source_session_id: row.get("source_session_id"),
+                source_agent: row.get("source_agent"),
+                trigger: row.get("trigger"),
                 created_at: row.get("created_at"),
                 updated_at: row.get("updated_at"),
                 access_count: row.get("access_count"),
@@ -465,6 +507,8 @@ impl Mem0Engine {
                 fact: row.get("fact"),
                 category: row.get("category"),
                 source_session_id: row.get("source_session_id"),
+                source_agent: row.get("source_agent"),
+                trigger: row.get("trigger"),
                 created_at: row.get("created_at"),
                 updated_at: row.get("updated_at"),
                 access_count: row.get("access_count"),
@@ -656,6 +700,7 @@ impl Mem0Engine {
         &self,
         fact: &ExtractedFact,
         session_id: Uuid,
+        metadata: &MemoryCaptureMetadata,
     ) -> Result<Option<Memory>, String> {
         let embedding = self.embed(&fact.fact).await?;
         let embedding_str = format_vector(&embedding);
@@ -705,6 +750,14 @@ impl Mem0Engine {
                             Type::TEXT,
                         ),
                         (
+                            &metadata.source_agent as &(dyn tokio_postgres::types::ToSql + Sync),
+                            Type::TEXT,
+                        ),
+                        (
+                            &metadata.trigger as &(dyn tokio_postgres::types::ToSql + Sync),
+                            Type::TEXT,
+                        ),
+                        (
                             &now as &(dyn tokio_postgres::types::ToSql + Sync),
                             Type::TIMESTAMPTZ,
                         ),
@@ -747,6 +800,14 @@ impl Mem0Engine {
                         Type::UUID,
                     ),
                     (
+                        &metadata.source_agent as &(dyn tokio_postgres::types::ToSql + Sync),
+                        Type::TEXT,
+                    ),
+                    (
+                        &metadata.trigger as &(dyn tokio_postgres::types::ToSql + Sync),
+                        Type::TEXT,
+                    ),
+                    (
                         &now as &(dyn tokio_postgres::types::ToSql + Sync),
                         Type::TIMESTAMPTZ,
                     ),
@@ -764,6 +825,8 @@ impl Mem0Engine {
             fact: fact.fact.clone(),
             category: fact.category.clone(),
             source_session_id: Some(session_id),
+            source_agent: metadata.source_agent.clone(),
+            trigger: metadata.trigger.clone(),
             created_at: now,
             updated_at: now,
             access_count: 0,
@@ -827,6 +890,8 @@ mod tests {
                 fact: "User prefers dark mode".to_string(),
                 category: "preference".to_string(),
                 source_session_id: None,
+                source_agent: None,
+                trigger: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
                 access_count: 3,
@@ -836,6 +901,8 @@ mod tests {
                 fact: "Project uses Rust".to_string(),
                 category: "project".to_string(),
                 source_session_id: None,
+                source_agent: None,
+                trigger: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
                 access_count: 1,


### PR DESCRIPTION
Closes #297

Changes:
- add source_agent and trigger metadata to stored mem0 memories
- expose metadata in memory recall, capture, store, and graph API responses
- preserve metadata on dedup updates and backfill columns on existing tables