### PR TITLE
feat(webchat): fix continuity message bootstrap (#246)

### DIFF
--- a/crates/rune-gateway/src/webchat.html
+++ b/crates/rune-gateway/src/webchat.html
@@ -250,6 +250,7 @@
   const authBadgeEl = document.getElementById('auth-badge');
   const sessionHintEl = document.getElementById('session-hint');
   const query = new URLSearchParams(location.search);
+  const continuityMessage = '__RUNE_WEBCHAT_CONTINUITY_MESSAGE__';
 
   let ws = null;
   const sessionStorageKey = 'rune.webchat.session_id';


### PR DESCRIPTION
Closes #246

Changes:
- define the embedded WebChat continuityMessage constant before it is used by session restore/startup flows
- keep the server-side placeholder replacement intact so the UI shows the correct resume/new-session continuity hint
- prevent runtime ReferenceError in the browser when opening, resuming, or switching WebChat sessions