### PR TITLE
feat(channels): scaffold google chat config fields (#248)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -8,6 +8,9 @@ run_migrations = true
 
 [channels]
 # telegram_token = "YOUR_BOT_TOKEN"
+# google_chat_service_account = "/path/to/google-chat-service-account.json"
+# google_chat_listen_addr = "0.0.0.0:3300"
+# google_chat_verification_token = "shared-secret"
 
 [ms365]
 # tenant_id = "00000000-0000-0000-0000-000000000000"

--- a/crates/rune-channels/tests/adapter_factory_tests.rs
+++ b/crates/rune-channels/tests/adapter_factory_tests.rs
@@ -316,3 +316,12 @@ async fn create_adapter_uses_configured_optional_listener_and_channel_fields() {
     assert!(create_adapter("whatsapp", &config).is_ok());
     assert!(create_adapter("signal", &config).is_ok());
 }
+
+#[test]
+fn channels_config_defaults_google_chat_fields_safely() {
+    let config = ChannelsConfig::default();
+
+    assert_eq!(config.google_chat_service_account, None);
+    assert_eq!(config.google_chat_listen_addr, None);
+    assert_eq!(config.google_chat_verification_token, None);
+}

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -94,6 +94,10 @@ impl AppConfig {
         out.channels.whatsapp_access_token = mask(&self.channels.whatsapp_access_token);
         out.channels.whatsapp_app_secret = mask(&self.channels.whatsapp_app_secret);
         out.channels.whatsapp_verify_token = mask(&self.channels.whatsapp_verify_token);
+        out.channels.google_chat_service_account =
+            mask(&self.channels.google_chat_service_account);
+        out.channels.google_chat_verification_token =
+            mask(&self.channels.google_chat_verification_token);
         out.mem0.embedding_api_key = mask(&self.mem0.embedding_api_key);
         out.mem0.postgres_url = mask(&self.mem0.postgres_url);
         out
@@ -1063,6 +1067,15 @@ pub struct ChannelsConfig {
     /// Base URL of the signal-cli REST API daemon.
     #[serde(default)]
     pub signal_api_url: Option<String>,
+    /// Google Chat service account credentials JSON path or inline JSON.
+    #[serde(default)]
+    pub google_chat_service_account: Option<String>,
+    /// Google Chat webhook/listener bind address for inbound events.
+    #[serde(default)]
+    pub google_chat_listen_addr: Option<String>,
+    /// Optional Google Chat verification token for inbound webhook validation.
+    #[serde(default)]
+    pub google_chat_verification_token: Option<String>,
 }
 
 /// Memory indexing and retrieval settings.


### PR DESCRIPTION
Closes #248

Changes:
- add Google Chat channel configuration fields to ChannelsConfig
- redact Google Chat secrets in AppConfig::redacted
- document example Google Chat config values in config.example.toml
- add defaulting coverage for the new fields in channel config tests