### PR TITLE
feat(channels): add Teams adapter factory wiring (#247)

### DIFF
--- a/crates/rune-channels/src/lib.rs
+++ b/crates/rune-channels/src/lib.rs
@@ -3,6 +3,7 @@
 mod discord;
 mod signal;
 mod slack;
+mod teams;
 mod telegram;
 pub mod types;
 mod whatsapp;
@@ -10,6 +11,7 @@ mod whatsapp;
 pub use discord::DiscordAdapter;
 pub use signal::SignalAdapter;
 pub use slack::SlackAdapter;
+pub use teams::TeamsAdapter;
 pub use telegram::TelegramAdapter;
 pub use types::*;
 pub use whatsapp::WhatsAppAdapter;
@@ -131,6 +133,27 @@ pub fn create_adapter(
                 .as_deref()
                 .unwrap_or("http://localhost:8080");
             Ok(Box::new(SignalAdapter::new(number, api_url)))
+        }
+        "teams" => {
+            let app_id = config
+                .teams_app_id
+                .as_deref()
+                .ok_or_else(|| ChannelError::Provider {
+                    message: "teams_app_id is required for the Teams adapter".into(),
+                })?;
+            let app_password =
+                config
+                    .teams_app_password
+                    .as_deref()
+                    .ok_or_else(|| ChannelError::Provider {
+                        message: "teams_app_password is required for the Teams adapter".into(),
+                    })?;
+            Ok(Box::new(TeamsAdapter::new(
+                app_id,
+                app_password,
+                config.teams_tenant_id.as_deref(),
+                config.teams_listen_addr.clone(),
+            )))
         }
         other => Err(ChannelError::Provider {
             message: format!("unknown channel adapter kind: {other}"),

--- a/crates/rune-channels/src/teams.rs
+++ b/crates/rune-channels/src/teams.rs
@@ -1,0 +1,161 @@
+//! Microsoft Teams channel adapter.
+//!
+//! Current scope is focused on adapter-factory parity: the adapter can be
+//! constructed from config and exposes the normalized [`ChannelAdapter`] trait,
+//! while inbound webhook hosting and outbound Bot Framework calls remain follow-up
+//! work.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::{ChannelAdapter, ChannelError, DeliveryReceipt, InboundEvent, OutboundAction};
+
+const TEAMS_API_BASE: &str = "https://smba.trafficmanager.net";
+
+/// Microsoft Teams adapter placeholder backed by Bot Framework credentials.
+///
+/// This adapter currently supports construction and normalized trait wiring so
+/// the runtime can recognize/configure Teams as a first-class channel kind.
+/// Transport-specific send/receive behavior is intentionally left for follow-up
+/// implementation work.
+pub struct TeamsAdapter {
+    app_id: String,
+    app_password: String,
+    tenant_id: Option<String>,
+    listen_addr: Option<String>,
+    api_base: String,
+    client: Client,
+}
+
+impl TeamsAdapter {
+    pub fn new(
+        app_id: &str,
+        app_password: &str,
+        tenant_id: Option<&str>,
+        listen_addr: Option<String>,
+    ) -> Self {
+        Self::with_api_base(app_id, app_password, tenant_id, listen_addr, TEAMS_API_BASE)
+    }
+
+    fn with_api_base(
+        app_id: &str,
+        app_password: &str,
+        tenant_id: Option<&str>,
+        listen_addr: Option<String>,
+        api_base: &str,
+    ) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+
+        Self {
+            app_id: app_id.to_string(),
+            app_password: app_password.to_string(),
+            tenant_id: tenant_id.map(ToOwned::to_owned),
+            listen_addr,
+            api_base: api_base.trim_end_matches('/').to_string(),
+            client,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    #[cfg(test)]
+    pub fn tenant_id(&self) -> Option<&str> {
+        self.tenant_id.as_deref()
+    }
+
+    #[cfg(test)]
+    pub fn listen_addr(&self) -> Option<&str> {
+        self.listen_addr.as_deref()
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for TeamsAdapter {
+    async fn receive(&mut self) -> Result<InboundEvent, ChannelError> {
+        let _ = (
+            &self.app_id,
+            &self.app_password,
+            &self.tenant_id,
+            &self.listen_addr,
+            &self.api_base,
+            &self.client,
+        );
+
+        Err(ChannelError::NotImplemented)
+    }
+
+    async fn send(&self, action: OutboundAction) -> Result<DeliveryReceipt, ChannelError> {
+        let _ = (
+            &self.app_id,
+            &self.app_password,
+            &self.tenant_id,
+            &self.listen_addr,
+            &self.api_base,
+            &self.client,
+            action,
+        );
+
+        Err(ChannelError::NotImplemented)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn teams_adapter_constructs() {
+        let adapter = TeamsAdapter::new(
+            "app-id",
+            "app-password",
+            Some("tenant-id"),
+            Some("127.0.0.1:3400".into()),
+        );
+
+        assert_eq!(adapter.app_id(), "app-id");
+        assert_eq!(adapter.tenant_id(), Some("tenant-id"));
+        assert_eq!(adapter.listen_addr(), Some("127.0.0.1:3400"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn teams_adapter_send_and_receive_are_explicitly_unimplemented() {
+        let mut adapter = TeamsAdapter::new("app-id", "app-password", None, None);
+
+        let receive_err = adapter
+            .receive()
+            .await
+            .expect_err("receive should be stubbed");
+        assert!(matches!(receive_err, ChannelError::NotImplemented));
+
+        let send_err = adapter
+            .send(OutboundAction::Send {
+                channel_id: ChannelId::new(),
+                chat_id: "chat-1".into(),
+                content: "hello".into(),
+            })
+            .await
+            .expect_err("send should be stubbed");
+        assert!(matches!(send_err, ChannelError::NotImplemented));
+    }
+
+    #[test]
+    fn teams_message_types_are_available() {
+        let _message = ChannelMessage {
+            channel_id: ChannelId::new(),
+            raw_chat_id: "conversation-1".into(),
+            sender: "user-1".into(),
+            content: "hello".into(),
+            attachments: vec![],
+            timestamp: Utc::now(),
+            provider_message_id: "provider-1".into(),
+        };
+    }
+}

--- a/crates/rune-channels/tests/adapter_factory_tests.rs
+++ b/crates/rune-channels/tests/adapter_factory_tests.rs
@@ -89,6 +89,29 @@ fn signal_adapter_requires_number() {
 }
 
 #[test]
+fn teams_adapter_requires_app_id() {
+    let config = ChannelsConfig::default();
+    let err = match create_adapter("teams", &config) {
+        Ok(_) => panic!("teams should require app id"),
+        Err(err) => err,
+    };
+    assert_provider_error(err, "teams_app_id is required");
+}
+
+#[test]
+fn teams_adapter_requires_app_password() {
+    let config = ChannelsConfig {
+        teams_app_id: Some("app-id".into()),
+        ..ChannelsConfig::default()
+    };
+    let err = match create_adapter("teams", &config) {
+        Ok(_) => panic!("teams should require app password"),
+        Err(err) => err,
+    };
+    assert_provider_error(err, "teams_app_password is required");
+}
+
+#[test]
 fn unknown_adapter_kind_returns_provider_error() {
     let config = ChannelsConfig::default();
     let err = match create_adapter("matrix", &config) {
@@ -150,6 +173,18 @@ async fn configured_adapter_kinds_construct_successfully() {
         },
     );
     assert!(signal.is_ok());
+
+    let teams = create_adapter(
+        "teams",
+        &ChannelsConfig {
+            teams_app_id: Some("app-id".into()),
+            teams_app_password: Some("app-password".into()),
+            teams_tenant_id: Some("tenant-id".into()),
+            teams_listen_addr: Some("127.0.0.1:3400".into()),
+            ..ChannelsConfig::default()
+        },
+    );
+    assert!(teams.is_ok());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -94,10 +94,11 @@ impl AppConfig {
         out.channels.whatsapp_access_token = mask(&self.channels.whatsapp_access_token);
         out.channels.whatsapp_app_secret = mask(&self.channels.whatsapp_app_secret);
         out.channels.whatsapp_verify_token = mask(&self.channels.whatsapp_verify_token);
-        out.channels.google_chat_service_account =
-            mask(&self.channels.google_chat_service_account);
+        out.channels.google_chat_service_account = mask(&self.channels.google_chat_service_account);
         out.channels.google_chat_verification_token =
             mask(&self.channels.google_chat_verification_token);
+        out.channels.teams_app_id = mask(&self.channels.teams_app_id);
+        out.channels.teams_app_password = mask(&self.channels.teams_app_password);
         out.mem0.embedding_api_key = mask(&self.mem0.embedding_api_key);
         out.mem0.postgres_url = mask(&self.mem0.postgres_url);
         out
@@ -1076,6 +1077,18 @@ pub struct ChannelsConfig {
     /// Optional Google Chat verification token for inbound webhook validation.
     #[serde(default)]
     pub google_chat_verification_token: Option<String>,
+    /// Microsoft Teams / Azure Bot app id.
+    #[serde(default)]
+    pub teams_app_id: Option<String>,
+    /// Microsoft Teams / Azure Bot app password or client secret.
+    #[serde(default)]
+    pub teams_app_password: Option<String>,
+    /// Optional Azure AD tenant id for single-tenant bot auth.
+    #[serde(default)]
+    pub teams_tenant_id: Option<String>,
+    /// Local listener bind address for inbound Bot Framework activities.
+    #[serde(default)]
+    pub teams_listen_addr: Option<String>,
 }
 
 /// Memory indexing and retrieval settings.


### PR DESCRIPTION
Closes #247

Changes:
- add a Teams channel adapter type implementing the normalized adapter trait
- wire the Teams adapter into create_adapter with config validation for app id/password
- extend ChannelsConfig and factory tests for Teams-specific settings