### PR TITLE
feat(models): add openrouter and perplexity providers (#249)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -49,6 +49,21 @@ models = [
   "Kimi-K2.5",
 ]
 
+
+[[models.providers]]
+name = "openrouter"
+kind = "openrouter"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+models = ["openai/gpt-4o-mini", "anthropic/claude-3.5-sonnet"]
+
+[[models.providers]]
+name = "perplexity"
+kind = "perplexity"
+base_url = "https://api.perplexity.ai"
+api_key_env = "PERPLEXITY_API_KEY"
+models = ["sonar", "sonar-pro"]
+
 [[models.providers]]
 name = "openai-codex"
 kind = "openai"

--- a/crates/rune-models/src/lib.rs
+++ b/crates/rune-models/src/lib.rs
@@ -237,6 +237,24 @@ pub fn provider_from_config(
                 )))
             }
         }
+        "openrouter" => {
+            let api_key = resolve_api_key(cfg)?;
+            let base_url = if cfg.base_url.is_empty() {
+                "https://openrouter.ai/api/v1"
+            } else {
+                cfg.base_url.as_str()
+            };
+            Ok(Box::new(OpenAiProvider::new(base_url, &api_key)))
+        }
+        "perplexity" => {
+            let api_key = resolve_api_key(cfg)?;
+            let base_url = if cfg.base_url.is_empty() {
+                "https://api.perplexity.ai"
+            } else {
+                cfg.base_url.as_str()
+            };
+            Ok(Box::new(OpenAiProvider::new(base_url, &api_key)))
+        }
         "bedrock" | "aws-bedrock" | "aws_bedrock" => {
             let (access_key_id, secret_access_key) = resolve_aws_credentials(cfg)?;
             let region = cfg.deployment_name.as_deref().unwrap_or_default();
@@ -519,6 +537,14 @@ mod tests {
         let mistral = provider_from_config(&provider_cfg("mistral", "mistral"))
             .expect("mistral kind should construct mistral provider");
         assert!(format!("{mistral:?}").contains("MistralProvider"));
+
+        let openrouter = provider_from_config(&provider_cfg("openrouter", "openrouter"))
+            .expect("openrouter kind should construct openai-compatible provider");
+        assert!(format!("{openrouter:?}").contains("OpenAiProvider"));
+
+        let perplexity = provider_from_config(&provider_cfg("perplexity", "perplexity"))
+            .expect("perplexity kind should construct openai-compatible provider");
+        assert!(format!("{perplexity:?}").contains("OpenAiProvider"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #249\n\nChanges:\n- add explicit provider kinds for OpenRouter and Perplexity\n- route both through the existing OpenAI-compatible provider implementation\n- document example TOML config entries and model IDs