### PR TITLE
feat(cli): add spell management command alias (#59)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -119,6 +119,11 @@ pub enum Command {
         #[command(subcommand)]
         action: SkillsAction,
     },
+    /// Inspect installed spells discovered by the gateway.
+    Spells {
+        #[command(subcommand)]
+        action: SpellsAction,
+    },
     /// Inspect workspace memory files and retrieval state.
     Memory {
         #[command(subcommand)]
@@ -1629,6 +1634,29 @@ pub enum SkillsAction {
     /// Disable a discovered skill in the gateway registry.
     Disable {
         /// Skill name.
+        name: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SpellsAction {
+    /// List installed spells discovered by the gateway.
+    List,
+    /// Show details for a single installed spell.
+    Info {
+        /// Spell name.
+        name: String,
+    },
+    /// Re-scan the spells directory and report load/remove counts.
+    Check,
+    /// Enable a discovered spell in the gateway registry.
+    Enable {
+        /// Spell name.
+        name: String,
+    },
+    /// Disable a discovered spell in the gateway registry.
+    Disable {
+        /// Spell name.
         name: String,
     },
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -38,8 +38,8 @@ use cli::{
     Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction,
     Ms365TeamsAction, Ms365TodoAction, Ms365UsersAction, PluginsAction, ProcessAction,
     RemindersAction, SandboxAction, SecretsAction, SecurityAction, ServiceAction, ServiceTarget,
-    SessionsAction, SkillsAction, SystemAction, SystemEventAction, SystemHeartbeatAction,
-    UpdateAction,
+    SessionsAction, SkillsAction, SpellsAction, SystemAction, SystemEventAction,
+    SystemHeartbeatAction, UpdateAction,
 };
 use client::{
     GatewayClient, config_file, config_get, config_set, config_unset, show_config, validate_config,
@@ -2198,6 +2198,28 @@ pub async fn run(cli: Cli) -> Result<()> {
                 println!("{}", render(&result, format));
             }
             SkillsAction::Disable { name } => {
+                let result = client.skills_disable(&name).await?;
+                println!("{}", render(&result, format));
+            }
+        },
+        Command::Spells { action } => match action {
+            SpellsAction::List => {
+                let result = client.skills_list().await?;
+                println!("{}", render(&result, format));
+            }
+            SpellsAction::Info { name } => {
+                let result = client.skills_info(&name).await?;
+                println!("{}", render(&result, format));
+            }
+            SpellsAction::Check => {
+                let result = client.skills_check().await?;
+                println!("{}", render(&result, format));
+            }
+            SpellsAction::Enable { name } => {
+                let result = client.skills_enable(&name).await?;
+                println!("{}", render(&result, format));
+            }
+            SpellsAction::Disable { name } => {
                 let result = client.skills_disable(&name).await?;
                 println!("{}", render(&result, format));
             }


### PR DESCRIPTION
Closes #59

Changes:
- add top-level `rune spells` CLI command with list/info/check/enable/disable actions
- wire spell actions to the existing gateway-backed spell registry endpoints
- keep `rune skills` intact as a compatibility path while exposing the issue-required spell command surface