### PR TITLE
docs(storage): align backup and spells path contract (#70)

### DIFF
--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -136,7 +136,7 @@ Implement:
 - `GatewayConfig`: `host`, `port`, `auth_token` (optional)
 - `DatabaseConfig`: `database_url` (optional — triggers embedded PG when absent), `max_connections`, `run_migrations`
 - `ModelsConfig`: vec of `ModelProviderConfig` (provider name, endpoint, deployment_name, api_version, api_key_env, model_alias)
-- `PathsConfig` with defaults: `db_dir` → `/data/db`, `sessions_dir` → `/data/sessions`, `memory_dir` → `/data/memory`, `media_dir` → `/data/media`, `skills_dir` → `/data/skills`, `logs_dir` → `/data/logs`, `backups_dir` → `/data/backups`, `config_dir` → `/config`, `secrets_dir` → `/secrets`
+- `PathsConfig` with defaults: `db_dir` → `/data/db`, `sessions_dir` → `/data/sessions`, `memory_dir` → `/data/memory`, `media_dir` → `/data/media`, `spells_dir` → `/data/spells`, legacy `skills_dir` → `/data/skills`, `logs_dir` → `/data/logs`, `backups_dir` → `/data/backups`, `config_dir` → `/config`, `secrets_dir` → `/secrets`
 - Layered loading: defaults → config file (TOML) → env vars → CLI overrides
 - Use `figment` for layered defaults → config file (TOML) → env vars → CLI overrides to match the confirmed stack
 - `ConfigError` type

--- a/docs/operator/DEPLOYMENT.md
+++ b/docs/operator/DEPLOYMENT.md
@@ -129,7 +129,8 @@ The runtime should expose a stable logical directory layout:
 - `/data/sessions`
 - `/data/memory`
 - `/data/media`
-- `/data/skills`
+- `/data/spells`
+- `/data/skills` (legacy compatibility alias)
 - `/data/logs`
 - `/data/backups`
 - `/config`
@@ -154,7 +155,8 @@ Local-first mode uses `~/.rune/` as the data root. Docker mode uses `/data/` (pl
 | Sessions | `~/.rune/sessions/` | `/data/sessions` | Transcripts, exports, session artifacts |
 | Memory | `~/.rune/memory/` | `/data/memory` | Daily notes, long-term memory, workspace knowledge |
 | Media | `~/.rune/media/` | `/data/media` | Attachments, audio, images, TTS outputs |
-| Skills | `~/.rune/skills/` | `/data/skills` | Installed skills, plugin bundles |
+| Spells | `~/.rune/spells/` | `/data/spells` | Installed Rune-native spells |
+| Skills (legacy) | `~/.rune/skills/` | `/data/skills` | Compatibility path for legacy skill bundles |
 | Logs | `~/.rune/logs/` | `/data/logs` | Structured logs, debug bundles, diagnostic dumps |
 | Backups | `~/.rune/backups/` | `/data/backups` | Export archives, snapshot bundles |
 | Config | `~/.rune/config/` | `/config` | Config overlays, provider/channel config |
@@ -587,7 +589,7 @@ Operators should follow one explicit workflow regardless of whether the capture 
 2. **Quiesce or coordinate writes** before capture.
    - For embedded PostgreSQL or filesystem snapshots, stop the runtime or otherwise guarantee a consistent checkpoint/snapshot boundary.
 3. **Capture every required durable domain**.
-   - Include DB state, sessions, memory, media when retained, skills, logs/exports as policy requires, config overlays, and `/data/backups` when prior archives are part of the recovery posture.
+   - Include DB state, sessions, memory, media when retained, spells plus any legacy skills content, logs/exports as policy requires, config overlays, and `/data/backups` when prior archives are part of the recovery posture.
    - Preserve secret references/config needed to reconnect after restore, but never secret values.
 4. **Record what the artifact contains and excludes**.
    - Operators need a manifest or equivalent notes naming capture time, Rune version, included domains, and excluded domains with reason.
@@ -614,7 +616,7 @@ Run these checks after every restore:
 3. scheduler/reminder inspection to confirm jobs, run history, and next-run derivation look sane
 4. session/transcript inspection to confirm recent history is readable
 5. approval/audit inspection to confirm pending approvals and durable audit trails remain visible
-6. memory/skills/media spot checks for the deployment-specific domains that were restored
+6. memory/spells/media spot checks for the deployment-specific domains that were restored
 
 ## 12.7 Recovery expectations and limits
 

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -229,17 +229,17 @@ Operator surface for durable-state snapshot and recovery workflows.
 
 | Subcommand | Purpose | Status |
 |---|---|---|
-| `rune backup create [--output <path>]` | Snapshot all durable state domains into a restorable archive | Not yet shipped |
-| `rune backup restore <archive>` | Restore runtime state from a backup archive | Not yet shipped |
-| `rune backup list` | List available backup archives in the configured backups directory | Not yet shipped |
+| `rune backup create [--label <name>]` | Request a durable-state backup artifact from the gateway | Shipped gateway-backed surface |
+| `rune backup restore <id> --confirm` | Request restore of a specific backup identifier | Shipped gateway-backed surface |
+| `rune backup list` | List available backup archives in the configured backups directory | Shipped gateway-backed surface |
 
 ### Behavioral contract
 
 The `backup` family implements the workflow contract defined in [PROTOCOLS.md §15.4](../parity/PROTOCOLS.md#154-backup-and-restore-workflow-contract):
 
-- **Create** captures all 9 durable domains (db, sessions, memory, media, skills, logs, backups staging, config, secret references) into a self-contained archive at `/data/backups` (Docker) or `~/.rune/backups/` (local). Secret values are never included.
-- **Restore** requires the runtime to be stopped or quiesced. Restores into the expected path layout and emits post-restore verification steps (`rune doctor`, health/status, scheduler state, transcript inspectability).
-- **List** shows available archives with timestamp, size, and version compatibility.
+- **Create** requests a backup artifact that captures all 9 durable domains (db, sessions, memory, media, skills/spells, logs, backups staging, config, secret references) into the configured backups root: `/data/backups` (Docker) or `~/.rune/backups/` (local). Secret values are never included.
+- **Restore** requires explicit `--confirm`, targets a backup identifier rather than an arbitrary path, restores into the expected path layout, and should be followed by `rune doctor`, health/status checks, scheduler inspection, and transcript inspectability checks.
+- **List** returns known backup identifiers plus timestamp/label metadata so operators can choose the correct restore point.
 
 See [DEPLOYMENT.md §12](../operator/DEPLOYMENT.md#12-backup-and-restore-expectations) for deployment-mode-specific backup strategy guidance.
 

--- a/docs/specs/phases-08-14.md
+++ b/docs/specs/phases-08-14.md
@@ -2664,6 +2664,7 @@ Returns the currently active `AppConfig` as JSON. Sensitive fields (API keys, to
     "sessions_dir": "/data/sessions",
     "memory_dir": "/data/memory",
     "media_dir": "/data/media",
+    "spells_dir": "/data/spells",
     "skills_dir": "/data/skills",
     "logs_dir": "/data/logs",
     "backups_dir": "/data/backups",


### PR DESCRIPTION
Closes #70

Changes:
- align backup CLI docs with the shipped gateway-backed create/list/restore surface
- document  as the canonical Rune-native path while keeping  as legacy compatibility
- update deployment/spec references so backup and restore guidance includes spells + legacy skills coverage