### PR TITLE
feat(mobile): add shared API client primitives (#277)

### DIFF
--- a/apps/mobile/src/api/api-types.ts
+++ b/apps/mobile/src/api/api-types.ts
@@ -1,0 +1,440 @@
+// Health & Status
+export interface HealthResponse {
+  status: string;
+  service: string;
+  version: string;
+  uptime_seconds: number;
+  session_count: number;
+  ws_subscribers: number;
+}
+
+export interface StatusPaths {
+  sessions_dir: string;
+  memory_dir: string;
+  logs_dir: string;
+}
+
+export interface StatusResponse {
+  status: string;
+  version: string;
+  bind: string;
+  auth_enabled: boolean;
+  configured_model_providers: number;
+  active_model_backend: string;
+  registered_tools: number;
+  session_count: number;
+  cron_job_count: number;
+  ws_subscribers: number;
+  uptime_seconds: number;
+  config_paths: StatusPaths;
+}
+
+// Dashboard
+export interface DashboardSummaryResponse {
+  gateway_status: string;
+  bind: string;
+  uptime_seconds: number;
+  default_model: string | null;
+  provider_count: number;
+  configured_model_count: number;
+  session_count: number;
+  auth_enabled: boolean;
+  ws_subscribers: number;
+  channels: string[];
+}
+
+export interface DashboardModelItem {
+  provider_name: string;
+  provider_kind: string;
+  model_id: string;
+  raw_model: string;
+  is_default: boolean;
+}
+
+export interface DashboardSessionItem {
+  id: string;
+  kind: string;
+  status: string;
+  channel_ref: string | null;
+  routing_ref: string | null;
+  created_at: string;
+  last_activity_at: string;
+}
+
+export interface DashboardDiagnosticItem {
+  level: string;
+  source: string;
+  message: string;
+  observed_at: string;
+}
+
+export interface DashboardDiagnosticsResponse {
+  structured_errors_available: boolean;
+  items: DashboardDiagnosticItem[];
+}
+
+// Actions
+export interface ActionResponse {
+  success: boolean;
+  message: string;
+}
+
+// Cron
+export interface CronStatusResponse {
+  total_jobs: number;
+  enabled_jobs: number;
+  due_jobs: number;
+}
+
+export interface CronScheduleAt {
+  kind: "at";
+  at: string;
+}
+
+export interface CronScheduleEvery {
+  kind: "every";
+  every_ms: number;
+  anchor_ms?: number;
+}
+
+export interface CronScheduleCron {
+  kind: "cron";
+  expr: string;
+  tz?: string;
+}
+
+export type CronSchedule = CronScheduleAt | CronScheduleEvery | CronScheduleCron;
+
+export interface CronPayloadSystemEvent {
+  kind: "system_event";
+  text: string;
+}
+
+export interface CronPayloadAgentTurn {
+  kind: "agent_turn";
+  message: string;
+  model?: string;
+  timeout_seconds?: number;
+}
+
+export type CronPayload = CronPayloadSystemEvent | CronPayloadAgentTurn;
+
+export interface CronJobResponse {
+  id: string;
+  name: string | null;
+  schedule: CronSchedule;
+  payload: CronPayload;
+  session_target: string;
+  enabled: boolean;
+  created_at: string;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  run_count: number;
+}
+
+export interface CronRunResponse {
+  job_id: string;
+  started_at: string;
+  finished_at: string | null;
+  status: string;
+  output: string | null;
+}
+
+export interface CronMutationResponse {
+  success: boolean;
+  job_id: string;
+  message: string;
+}
+
+export interface CronWakeResponse {
+  success: boolean;
+  mode: string;
+  text: string;
+  context_messages: number | null;
+  message: string;
+}
+
+export interface CronJobRequest {
+  name?: string;
+  schedule: CronSchedule;
+  payload: CronPayload;
+  sessionTarget: string;
+  enabled?: boolean;
+}
+
+export interface CronUpdateRequest {
+  name?: string;
+  enabled?: boolean;
+  schedule?: CronSchedule;
+  payload?: CronPayload;
+}
+
+export interface CronWakeRequest {
+  text: string;
+  mode?: string;
+  contextMessages?: number;
+}
+
+// Sessions
+export interface SessionListItem {
+  id: string;
+  kind: string;
+  status: string;
+  requester_session_id?: string | null;
+  channel: string | null;
+  created_at: string;
+  last_activity_at?: string;
+  updated_at?: string;
+  turn_count: number;
+  usage_prompt_tokens: number;
+  usage_completion_tokens: number;
+  latest_model: string | null;
+  preview?: string;
+}
+
+export interface SessionResponse {
+  id: string;
+  kind: string;
+  status: string;
+  requester_session_id: string | null;
+  channel_ref: string | null;
+  created_at: string;
+  updated_at: string;
+  turn_count: number;
+  latest_model: string | null;
+  usage_prompt_tokens: number;
+  usage_completion_tokens: number;
+  last_turn_started_at: string | null;
+  last_turn_ended_at: string | null;
+}
+
+export interface SessionStatusResponse {
+  session_id: string;
+  runtime: string;
+  status: string;
+  current_model: string | null;
+  model_override: string | null;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  estimated_cost: string | null;
+  turn_count: number;
+  uptime_seconds: number;
+  last_turn_started_at: string | null;
+  last_turn_ended_at: string | null;
+  reasoning: string;
+  verbose: boolean;
+  elevated: boolean;
+  approval_mode: string;
+  security_mode: string;
+  subagent_lifecycle: string | null;
+  subagent_runtime_status: string | null;
+  subagent_runtime_attached: boolean | null;
+  subagent_status_updated_at: string | null;
+  subagent_last_note: string | null;
+  unresolved: string[];
+}
+
+export interface CreateSessionRequest {
+  kind?: string;
+  workspace_root?: string;
+  requester_session_id?: string;
+  channel_ref?: string;
+}
+
+export interface PendingAttachment {
+  name: string;
+  mime_type?: string;
+  size_bytes?: number;
+}
+
+export interface SendMessageRequest {
+  content: string;
+  model?: string;
+  attachments?: File[];
+}
+
+export interface MessageResponse {
+  turn_id: string;
+  assistant_reply: string | null;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+  };
+  latency_ms: number;
+}
+
+export interface TranscriptEntry {
+  id: string;
+  turn_id: string | null;
+  seq: number;
+  kind: string;
+  payload: unknown;
+  created_at: string;
+}
+
+
+export interface AgentListItem {
+  id: string;
+  default: boolean;
+  model: string | null;
+  workspace: string | null;
+  system_prompt: string | null;
+}
+
+export interface SkillItem {
+  name: string;
+  description: string;
+  enabled: boolean;
+  binary_path: string | null;
+  source_dir: string;
+  parameters: unknown;
+}
+
+// Approvals
+export interface ApprovalRequestResponse {
+  id: string;
+  subject_type: string;
+  subject_id: string;
+  reason: string;
+  decision: string | null;
+  decided_by: string | null;
+  decided_at: string | null;
+  approval_status: string | null;
+  approval_status_updated_at: string | null;
+  resumed_at: string | null;
+  completed_at: string | null;
+  resume_result_summary: string | null;
+  command: string | null;
+  presented_payload: unknown;
+  created_at: string;
+}
+
+export interface SubmitApprovalDecisionRequest {
+  id: string;
+  decision: string;
+  decided_by?: string;
+}
+
+export interface ApprovalPolicyResponse {
+  tool_name: string;
+  decision: string;
+  decided_at: string;
+}
+
+export interface SetApprovalPolicyRequest {
+  decision: string;
+}
+
+// Heartbeat
+export interface HeartbeatState {
+  enabled: boolean;
+  last_heartbeat_at: string | null;
+  interval_seconds: number;
+}
+
+// Reminders
+export interface ReminderResponse {
+  id: string;
+  message: string;
+  target: string;
+  fire_at: string;
+  delivered: boolean;
+  created_at: string;
+  delivered_at: string | null;
+}
+
+export interface ReminderAddRequest {
+  message: string;
+  fire_at: string;
+  target?: string;
+}
+
+// WebSocket
+export interface SessionEvent {
+  session_id: string;
+  kind: string;
+  payload: unknown;
+}
+
+export type A2uiTarget = "inline" | "panel";
+
+export interface A2uiComponent {
+  type: string;
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface A2uiPushEvent {
+  action: "push";
+  session_id: string;
+  component: A2uiComponent;
+  target: A2uiTarget;
+  timestamp: string;
+}
+
+export interface A2uiRemoveEvent {
+  action: "remove";
+  session_id: string;
+  component_id: string;
+  timestamp: string;
+}
+
+export interface A2uiResetEvent {
+  action: "reset";
+  session_id: string;
+  timestamp: string;
+}
+
+export interface A2uiFormSubmitEvent {
+  action: "form_submit";
+  session_id: string;
+  callback_id: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface A2uiActionEvent {
+  action: "action";
+  session_id: string;
+  component_id: string;
+  action_target: string;
+  timestamp: string;
+}
+
+export type A2uiEvent =
+  | A2uiPushEvent
+  | A2uiRemoveEvent
+  | A2uiResetEvent
+  | A2uiFormSubmitEvent
+  | A2uiActionEvent;
+
+// TTS/STT
+export interface TtsVoiceEntry {
+  id: string;
+  name: string;
+  language: string | null;
+}
+
+export interface TtsStatusResponse {
+  available: boolean;
+  enabled: boolean;
+  provider: string;
+  voice: string;
+  model: string;
+  auto_mode: string;
+  voices: TtsVoiceEntry[];
+}
+
+export interface SttStatusResponse {
+  available: boolean;
+  enabled: boolean;
+  provider: string;
+  model: string;
+}
+
+export interface TranscribeResponse {
+  text: string;
+  language: string | null;
+  duration_seconds: number | null;
+}

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,0 +1,48 @@
+import { getToken } from "../lib/auth";
+import { getGatewayUrl } from "../store/app-store";
+
+export interface ApiClientOptions extends RequestInit {
+  baseUrl?: string;
+  token?: string | null;
+  headers?: HeadersInit;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function resolveBaseUrl(explicitBaseUrl?: string): string {
+  const baseUrl = explicitBaseUrl ?? getGatewayUrl();
+  if (!baseUrl) {
+    throw new Error("Gateway base URL is not configured");
+  }
+  return trimTrailingSlash(baseUrl);
+}
+
+export async function buildAuthHeaders(
+  headers?: HeadersInit,
+  explicitToken?: string | null,
+): Promise<Headers> {
+  const nextHeaders = new Headers(headers);
+  const token = explicitToken ?? (await getToken());
+  if (token) {
+    nextHeaders.set("Authorization", `Bearer ${token}`);
+  }
+  if (!nextHeaders.has("Accept")) {
+    nextHeaders.set("Accept", "application/json");
+  }
+  return nextHeaders;
+}
+
+export async function apiFetch(path: string, options: ApiClientOptions = {}): Promise<Response> {
+  const baseUrl = resolveBaseUrl(options.baseUrl);
+  const headers = await buildAuthHeaders(options.headers, options.token);
+  const url = path.startsWith("http://") || path.startsWith("https://")
+    ? path
+    : `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+
+  return fetch(url, {
+    ...options,
+    headers,
+  });
+}

--- a/apps/mobile/src/hooks/use-a2ui.ts
+++ b/apps/mobile/src/hooks/use-a2ui.ts
@@ -1,0 +1,71 @@
+import { useReducer, useMemo } from "react";
+import type { A2uiComponent, A2uiTarget, SessionEvent } from "../api/api-types";
+
+interface A2uiState {
+  inline: A2uiComponent[];
+  panel: A2uiComponent[];
+}
+
+type A2uiAction =
+  | { type: "push"; component: A2uiComponent; target: A2uiTarget }
+  | { type: "remove"; component_id: string }
+  | { type: "reset" };
+
+function a2uiReducer(state: A2uiState, action: A2uiAction): A2uiState {
+  switch (action.type) {
+    case "push": {
+      const list = action.target === "panel" ? "panel" : "inline";
+      const filtered = state[list].filter((c) => c.id !== action.component.id);
+      return { ...state, [list]: [...filtered, action.component] };
+    }
+    case "remove":
+      return {
+        inline: state.inline.filter((c) => c.id !== action.component_id),
+        panel: state.panel.filter((c) => c.id !== action.component_id),
+      };
+    case "reset":
+      return { inline: [], panel: [] };
+    default:
+      return state;
+  }
+}
+
+export function useA2ui(events: SessionEvent[]) {
+  const [state, dispatch] = useReducer(a2uiReducer, {
+    inline: [],
+    panel: [],
+  });
+
+  // Process any a2ui events from the stream.
+  useMemo(() => {
+    for (const event of events) {
+      if (event.kind !== "a2ui") continue;
+
+      const payload = event.payload as Record<string, unknown> | null;
+      if (!payload || typeof payload.action !== "string") continue;
+
+      switch (payload.action) {
+        case "push": {
+          const component = payload.component as A2uiComponent | undefined;
+          const target = (payload.target as A2uiTarget) || "inline";
+          if (component && typeof component.id === "string" && typeof component.type === "string") {
+            dispatch({ type: "push", component, target });
+          }
+          break;
+        }
+        case "remove": {
+          const componentId = payload.component_id as string | undefined;
+          if (componentId) {
+            dispatch({ type: "remove", component_id: componentId });
+          }
+          break;
+        }
+        case "reset":
+          dispatch({ type: "reset" });
+          break;
+      }
+    }
+  }, [events]);
+
+  return { state };
+}

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = "rune-auth-token";
+
+let token: string | null = null;
+
+export async function getToken(): Promise<string | null> {
+  return token;
+}
+
+export async function setToken(nextToken: string): Promise<void> {
+  token = nextToken;
+}
+
+export async function clearToken(): Promise<void> {
+  token = null;
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  return !!(await getToken());
+}
+
+export { STORAGE_KEY };

--- a/apps/mobile/src/lib/chat-utils.ts
+++ b/apps/mobile/src/lib/chat-utils.ts
@@ -1,0 +1,70 @@
+import type { TranscriptEntry } from "../api/api-types";
+
+export function normalizeTranscriptKind(kind: string): string {
+  switch (kind) {
+    case "user_message":
+      return "user";
+    case "assistant_message":
+      return "assistant";
+    default:
+      return kind;
+  }
+}
+
+export function getPayloadText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (payload && typeof payload === "object") {
+    const p = payload as Record<string, unknown>;
+    if (typeof p.content === "string") return p.content;
+    if (typeof p.text === "string") return p.text;
+    if (typeof p.message === "string") return p.message;
+    if (typeof p.error === "string") return p.error;
+    return JSON.stringify(payload, null, 2);
+  }
+  return String(payload ?? "");
+}
+
+export function getEntrySignature(entry: TranscriptEntry): string {
+  return JSON.stringify({
+    id: entry.id.startsWith("ws-") || entry.id.startsWith("optimistic-") ? null : entry.id,
+    seq: entry.seq,
+    kind: normalizeTranscriptKind(entry.kind),
+    payload: entry.payload,
+    turn_id: entry.turn_id,
+    created_at: entry.created_at,
+  });
+}
+
+export function isLiveEntry(entry: TranscriptEntry): boolean {
+  return entry.id.startsWith("ws-") || entry.id.startsWith("optimistic-");
+}
+
+export function isTranscriptTextualEntry(entry: TranscriptEntry): boolean {
+  const kind = normalizeTranscriptKind(entry.kind);
+  return kind === "user" || kind === "assistant";
+}
+
+export function getSessionPreviewText(entries: TranscriptEntry[], fallback = "No transcript yet"): string {
+  const candidate = [...entries]
+    .sort((a, b) => b.seq - a.seq)
+    .find((entry) => {
+      if (!isTranscriptTextualEntry(entry)) return false;
+      const text = getPayloadText(entry.payload).replace(/<thinking>[\s\S]*?<\/thinking>/gi, " ").trim();
+      return text.length > 0;
+    });
+
+  if (!candidate) return fallback;
+
+  const cleaned = getPayloadText(candidate.payload)
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return cleaned.length > 0 ? cleaned : fallback;
+}
+
+export function truncatePreview(text: string, maxLength = 120): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, maxLength - 1)}…`;
+}

--- a/apps/mobile/src/lib/websocket.ts
+++ b/apps/mobile/src/lib/websocket.ts
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import type { MutableRefObject } from "react";
+import { getToken } from "./auth";
+import { getGatewayUrl } from "../store/app-store";
+import type { SessionEvent } from "../api/api-types";
+
+interface UseSessionEventsOptions {
+  enabled?: boolean;
+  clearOnSessionChange?: boolean;
+}
+
+interface EventFramePayload {
+  session_id?: unknown;
+  kind?: unknown;
+  data?: unknown;
+  payload?: unknown;
+}
+
+interface EventFrame {
+  type?: unknown;
+  event?: unknown;
+  payload?: EventFramePayload;
+}
+
+function normalizeBaseUrl(baseUrl: string): URL {
+  return new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+}
+
+export async function buildWebSocketUrl(path = "/ws") {
+  const baseUrl = getGatewayUrl();
+  if (!baseUrl) {
+    throw new Error("Gateway base URL is not configured");
+  }
+
+  const url = normalizeBaseUrl(baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.pathname = path;
+
+  const token = await getToken();
+  if (token) {
+    url.searchParams.set("token", token);
+  }
+
+  return url.toString();
+}
+
+function isSessionEvent(value: unknown): value is SessionEvent {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<SessionEvent>;
+  return (
+    typeof candidate.session_id === "string" &&
+    typeof candidate.kind === "string" &&
+    "payload" in candidate
+  );
+}
+
+function isEventFrame(value: unknown): value is EventFrame {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as EventFrame;
+  return (
+    candidate.type === "event" &&
+    typeof candidate.event === "string" &&
+    !!candidate.payload &&
+    typeof candidate.payload === "object"
+  );
+}
+
+function parseSessionEvent(value: unknown): SessionEvent | null {
+  if (isSessionEvent(value)) {
+    return value;
+  }
+
+  if (!isEventFrame(value)) {
+    return null;
+  }
+
+  const payload = value.payload;
+  if (!payload) {
+    return null;
+  }
+
+  const sessionId = typeof payload.session_id === "string" ? payload.session_id : null;
+  const kind = typeof payload.kind === "string" ? payload.kind : value.event;
+
+  if (!sessionId || typeof kind !== "string") {
+    return null;
+  }
+
+  return {
+    session_id: sessionId,
+    kind,
+    payload: payload.data ?? payload.payload ?? payload,
+  };
+}
+
+function closeWebSocket(wsRef: MutableRefObject<WebSocket | null>) {
+  wsRef.current?.close();
+  wsRef.current = null;
+}
+
+function scheduleReconnect(
+  connect: () => void,
+  reconnectTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  retriesRef: MutableRefObject<number>,
+) {
+  const delay = Math.min(1000 * 2 ** retriesRef.current, 30000);
+  retriesRef.current += 1;
+  reconnectTimerRef.current = setTimeout(connect, delay);
+}
+
+export function useSessionEvents(
+  sessionId: string | undefined,
+  options?: UseSessionEventsOptions,
+) {
+  const enabled = options?.enabled ?? !!sessionId;
+  const clearOnSessionChange = options?.clearOnSessionChange ?? true;
+
+  const [sessionEvents, setSessionEvents] = useState<Record<string, SessionEvent[]>>({});
+  const [connected, setConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retriesRef = useRef(0);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const clearEvents = useCallback(() => {
+    if (!sessionId) return;
+    setSessionEvents((prev) => {
+      if (!(sessionId in prev)) return prev;
+      return { ...prev, [sessionId]: [] };
+    });
+  }, [sessionId]);
+
+  const shouldSubscribe = useMemo(
+    () => enabled && typeof sessionId === "string" && sessionId.length > 0,
+    [enabled, sessionId],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      clearReconnectTimer();
+      closeWebSocket(wsRef);
+      return;
+    }
+
+    if (clearOnSessionChange && sessionId) {
+      setSessionEvents((prev) => {
+        if (!(sessionId in prev)) return prev;
+        return { ...prev, [sessionId]: [] };
+      });
+    }
+
+    let disposed = false;
+
+    const connect = async () => {
+      if (disposed) return;
+
+      clearReconnectTimer();
+      closeWebSocket(wsRef);
+
+      let socketUrl: string;
+      try {
+        socketUrl = await buildWebSocketUrl("/ws");
+      } catch {
+        scheduleReconnect(connect, reconnectTimerRef, retriesRef);
+        return;
+      }
+
+      const ws = new WebSocket(socketUrl);
+      wsRef.current = ws;
+      setConnected(false);
+
+      ws.onopen = () => {
+        if (disposed || wsRef.current !== ws) return;
+        setConnected(true);
+        retriesRef.current = 0;
+
+        if (shouldSubscribe && sessionId) {
+          ws.send(JSON.stringify({ type: "subscribe", session_id: sessionId }));
+        }
+      };
+
+      ws.onmessage = (e) => {
+        if (disposed || wsRef.current !== ws) return;
+
+        try {
+          const parsed = JSON.parse(e.data) as unknown;
+          const event = parseSessionEvent(parsed);
+          if (!event) return;
+          if (sessionId && event.session_id !== sessionId) return;
+          setSessionEvents((prev) => ({
+            ...prev,
+            [event.session_id]: [...(prev[event.session_id] ?? []), event],
+          }));
+        } catch {
+          // ignore non-JSON or unsupported frame shapes
+        }
+      };
+
+      ws.onclose = () => {
+        if (wsRef.current === ws) {
+          wsRef.current = null;
+        }
+        setConnected(false);
+
+        if (disposed) return;
+
+        scheduleReconnect(connect, reconnectTimerRef, retriesRef);
+      };
+
+      ws.onerror = () => {
+        ws.close();
+      };
+    };
+
+    void connect();
+
+    return () => {
+      disposed = true;
+      clearReconnectTimer();
+      closeWebSocket(wsRef);
+    };
+  }, [clearOnSessionChange, clearReconnectTimer, enabled, sessionId, shouldSubscribe]);
+
+  const events = sessionId ? (sessionEvents[sessionId] ?? []) : [];
+
+  return { events, connected, clearEvents };
+}
+
+export { parseSessionEvent };

--- a/apps/mobile/src/store/app-store.ts
+++ b/apps/mobile/src/store/app-store.ts
@@ -1,0 +1,19 @@
+export interface AppPreferences {
+  gatewayUrl: string | null;
+}
+
+let state: AppPreferences = {
+  gatewayUrl: null,
+};
+
+export function getGatewayUrl(): string | null {
+  return state.gatewayUrl;
+}
+
+export function setGatewayUrl(gatewayUrl: string | null): void {
+  state = { ...state, gatewayUrl };
+}
+
+export function getAppState(): AppPreferences {
+  return state;
+}


### PR DESCRIPTION
Closes #277

Changes:
- copy shared API type definitions into apps/mobile
- add a portable fetch client with configurable base URL and bearer auth support
- adapt websocket session event hook to read gateway config instead of window.location
- copy chat transcript utilities and A2UI hook for mobile use
- add minimal mobile auth/config modules to support the new client primitives