### PR TITLE
feat(mobile): add auth flow scaffold (#276)

### DIFF
--- a/apps/mobile/app/(auth)/connect.tsx
+++ b/apps/mobile/app/(auth)/connect.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Button, Text, TextInput, View } from "react-native";
+import { router } from "expo-router";
+import { setToken } from "../../src/lib/auth";
+import { setGatewayUrl } from "../../src/store/app-store";
+
+async function verifyGateway(baseUrl: string): Promise<void> {
+  const normalized = baseUrl.replace(/\/+$/, "");
+  const response = await fetch(`${normalized}/health`, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Gateway health check failed with ${response.status}`);
+  }
+}
+
+export default function ConnectScreen() {
+  const [gatewayUrl, setGatewayUrlInput] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async () => {
+    try {
+      setSubmitting(true);
+      setError(null);
+      await verifyGateway(gatewayUrl);
+      setGatewayUrl(gatewayUrl);
+      await setToken(bearerToken.trim());
+      router.replace("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to connect to gateway");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: "center", padding: 24, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: "600" }}>Connect to Rune Gateway</Text>
+      <TextInput
+        autoCapitalize="none"
+        autoCorrect={false}
+        placeholder="https://gateway.example.com"
+        value={gatewayUrl}
+        onChangeText={setGatewayUrlInput}
+        style={{ borderWidth: 1, borderColor: "#ccc", borderRadius: 8, padding: 12 }}
+      />
+      <TextInput
+        autoCapitalize="none"
+        autoCorrect={false}
+        placeholder="Bearer token"
+        secureTextEntry
+        value={bearerToken}
+        onChangeText={setBearerToken}
+        style={{ borderWidth: 1, borderColor: "#ccc", borderRadius: 8, padding: 12 }}
+      />
+      {error ? <Text style={{ color: "#c00" }}>{error}</Text> : null}
+      <Button title={submitting ? "Connecting..." : "Connect"} onPress={() => void onSubmit()} />
+    </View>
+  );
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from "react";
+import { Slot, useRouter, useSegments } from "expo-router";
+import { GatewayProvider, useGateway } from "../src/providers/GatewayProvider";
+
+function AuthGate() {
+  const router = useRouter();
+  const segments = useSegments();
+  const { authenticated } = useGateway();
+
+  useEffect(() => {
+    const inAuthGroup = segments[0] === "(auth)";
+    if (!authenticated && !inAuthGroup) {
+      router.replace("/(auth)/connect");
+    }
+  }, [authenticated, router, segments]);
+
+  return <Slot />;
+}
+
+export default function RootLayout() {
+  return (
+    <GatewayProvider>
+      <AuthGate />
+    </GatewayProvider>
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@rune/mobile",
+  "private": true,
+  "version": "0.1.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "expo": "*",
+    "expo-router": "*",
+    "expo-secure-store": "*",
+    "react": "*",
+    "zustand": "*"
+  }
+}

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -1,17 +1,34 @@
+import * as SecureStore from "expo-secure-store";
+
 const STORAGE_KEY = "rune-auth-token";
 
 let token: string | null = null;
+let hydrated = false;
+
+async function hydrateToken(): Promise<void> {
+  if (hydrated) {
+    return;
+  }
+
+  token = await SecureStore.getItemAsync(STORAGE_KEY);
+  hydrated = true;
+}
 
 export async function getToken(): Promise<string | null> {
+  await hydrateToken();
   return token;
 }
 
 export async function setToken(nextToken: string): Promise<void> {
   token = nextToken;
+  hydrated = true;
+  await SecureStore.setItemAsync(STORAGE_KEY, nextToken);
 }
 
 export async function clearToken(): Promise<void> {
   token = null;
+  hydrated = true;
+  await SecureStore.deleteItemAsync(STORAGE_KEY);
 }
 
 export async function isAuthenticated(): Promise<boolean> {

--- a/apps/mobile/src/providers/GatewayProvider.tsx
+++ b/apps/mobile/src/providers/GatewayProvider.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { isAuthenticated } from "../lib/auth";
+import { getGatewayUrl, useAppStore } from "../store/app-store";
+
+interface GatewayContextValue {
+  gatewayUrl: string | null;
+  connected: boolean;
+  authenticated: boolean;
+  refreshAuth: () => Promise<boolean>;
+}
+
+const GatewayContext = createContext<GatewayContextValue | null>(null);
+
+export function GatewayProvider({ children }: { children: React.ReactNode }) {
+  const gatewayUrl = useAppStore((state) => state.gatewayUrl);
+  const [authenticated, setAuthenticated] = useState(false);
+
+  const refreshAuth = async (): Promise<boolean> => {
+    const next = !!getGatewayUrl() && (await isAuthenticated());
+    setAuthenticated(next);
+    return next;
+  };
+
+  useEffect(() => {
+    void refreshAuth();
+  }, [gatewayUrl]);
+
+  const value = useMemo<GatewayContextValue>(
+    () => ({
+      gatewayUrl,
+      connected: !!gatewayUrl,
+      authenticated,
+      refreshAuth,
+    }),
+    [authenticated, gatewayUrl],
+  );
+
+  return <GatewayContext.Provider value={value}>{children}</GatewayContext.Provider>;
+}
+
+export function useGateway(): GatewayContextValue {
+  const context = useContext(GatewayContext);
+  if (!context) {
+    throw new Error("useGateway must be used within GatewayProvider");
+  }
+  return context;
+}

--- a/apps/mobile/src/store/app-store.ts
+++ b/apps/mobile/src/store/app-store.ts
@@ -1,19 +1,27 @@
+import { create } from "zustand";
+
 export interface AppPreferences {
   gatewayUrl: string | null;
 }
 
-let state: AppPreferences = {
+interface AppState extends AppPreferences {
+  setGatewayUrl: (gatewayUrl: string | null) => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
   gatewayUrl: null,
-};
+  setGatewayUrl: (gatewayUrl) => set({ gatewayUrl }),
+}));
 
 export function getGatewayUrl(): string | null {
-  return state.gatewayUrl;
+  return useAppStore.getState().gatewayUrl;
 }
 
 export function setGatewayUrl(gatewayUrl: string | null): void {
-  state = { ...state, gatewayUrl };
+  useAppStore.getState().setGatewayUrl(gatewayUrl);
 }
 
 export function getAppState(): AppPreferences {
-  return state;
+  const { gatewayUrl } = useAppStore.getState();
+  return { gatewayUrl };
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["react"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["app", "src"]
+}


### PR DESCRIPTION
Closes #276

Changes:
- add Expo mobile package manifest and TS config scaffold
- persist bearer token with expo-secure-store
- replace ad-hoc app state with Zustand store for gateway URL
- add GatewayProvider connection/auth context
- add root auth gate and connect screen with /health verification