### PR TITLE
feat(spells): add local spell search command (#62)

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -1640,6 +1640,11 @@ pub enum SkillsAction {
 
 #[derive(Debug, Subcommand)]
 pub enum SpellsAction {
+    /// Search installed spells by name, description, tag, trigger, or namespace.
+    Search {
+        /// Query text to match against installed spell metadata.
+        query: String,
+    },
     /// List installed spells discovered by the gateway.
     List,
     /// Show details for a single installed spell.

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -24,7 +24,8 @@ use crate::output::{
     ScannedModelDetail, SecretsApplyResponse, SecretsAuditResponse, SecretsConfigureResponse,
     SecretsReloadResponse, SecurityAuditResponse, SessionDetailResponse, SessionListResponse,
     SessionStatusCard, SessionSummary, SessionTreeNode, SessionTreeResponse, SkillCheckResponse,
-    SkillInfoResponse, SkillListResponse, SkillSummary, StatusResponse, SystemEventListResponse,
+    SkillInfoResponse, SkillListResponse, SkillSummary, SpellSearchResponse, StatusResponse,
+    SystemEventListResponse,
 };
 
 /// HTTP client that talks to the Rune gateway API.
@@ -351,6 +352,41 @@ impl GatewayClient {
         } else {
             bail!("Gateway returned HTTP {}", resp.status());
         }
+    }
+
+    /// Search installed spells using the existing `/skills` inventory.
+    pub async fn spells_search(&self, query: &str) -> Result<SpellSearchResponse> {
+        let skills = self.skills_list().await?;
+        let query_lower = query.to_lowercase();
+        let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+
+        let mut spells: Vec<SkillSummary> = skills
+            .skills
+            .into_iter()
+            .filter(|skill| {
+                let namespace = skill.namespace.as_deref().unwrap_or_default();
+                let haystack = [
+                    skill.name.as_str(),
+                    skill.description.as_str(),
+                    namespace,
+                    skill.kind.as_str(),
+                    &skill.tags.join(" "),
+                    &skill.triggers.join(" "),
+                ]
+                .join(" ")
+                .to_lowercase();
+
+                query_words.iter().all(|word| haystack.contains(*word))
+            })
+            .collect();
+
+        spells.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(SpellSearchResponse {
+            query: query.to_string(),
+            total: spells.len(),
+            spells,
+        })
     }
 
     /// `GET /skills`

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -51,7 +51,7 @@ use output::{
     ModelAliasDetail, ModelAliasesResponse, ModelAuthProviderDetail, ModelAuthResponse,
     ModelFallbackChainDetail, ModelFallbacksResponse, ModelListResponse, ModelProviderDetail,
     ModelScanResponse, ModelSetImageResponse, ModelSetResponse, ModelStatusResponse, OutputFormat,
-    TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
+    SpellSearchResponse, TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
 };
 use service::{ServiceInstallOptions, install_service_definition, print_service_definition};
 
@@ -2203,6 +2203,10 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
         },
         Command::Spells { action } => match action {
+            SpellsAction::Search { query } => {
+                let result: SpellSearchResponse = client.spells_search(&query).await?;
+                println!("{}", render(&result, format));
+            }
             SpellsAction::List => {
                 let result = client.skills_list().await?;
                 println!("{}", render(&result, format));

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -766,6 +766,32 @@ impl fmt::Display for SkillSummary {
     }
 }
 
+
+/// Response for `rune spells search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpellSearchResponse {
+    pub query: String,
+    pub total: usize,
+    pub spells: Vec<SkillSummary>,
+}
+
+impl fmt::Display for SpellSearchResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.spells.is_empty() {
+            return write!(f, "No spells matched \"{}\".", self.query);
+        }
+
+        writeln!(f, "Matched {} spell(s) for \"{}\":", self.total, self.query)?;
+        for (idx, spell) in self.spells.iter().enumerate() {
+            if idx > 0 {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+            write!(f, "{spell}")?;
+        }
+        Ok(())
+    }
+}
 /// Response for `rune skills list`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillListResponse {
@@ -5447,6 +5473,25 @@ mod tests {
         assert_eq!(parsed["mode"], "coder");
     }
 
+
+    fn sample_skill(name: &str, description: &str, enabled: bool) -> SkillSummary {
+        SkillSummary {
+            name: name.into(),
+            description: description.into(),
+            enabled,
+            source_dir: format!("/data/skills/{name}"),
+            binary_path: Some(format!("/data/skills/{name}/run.sh")),
+            namespace: Some("core".into()),
+            version: Some("1.0.0".into()),
+            author: Some("Rune".into()),
+            kind: "workflow".into(),
+            requires: vec!["fs".into()],
+            tags: vec!["automation".into()],
+            match_rules: None,
+            triggers: vec!["manual".into()],
+        }
+    }
+
     #[test]
     fn render_skill_list_empty() {
         let response = SkillListResponse { skills: vec![] };
@@ -5457,20 +5502,8 @@ mod tests {
     fn render_skill_list_human() {
         let response = SkillListResponse {
             skills: vec![
-                SkillSummary {
-                    name: "alpha".into(),
-                    description: "First skill".into(),
-                    enabled: true,
-                    source_dir: "/data/skills/alpha".into(),
-                    binary_path: Some("/data/skills/alpha/run.sh".into()),
-                },
-                SkillSummary {
-                    name: "beta".into(),
-                    description: "Second skill".into(),
-                    enabled: false,
-                    source_dir: "/data/skills/beta".into(),
-                    binary_path: None,
-                },
+                sample_skill("alpha", "First skill", true),
+                SkillSummary { binary_path: None, ..sample_skill("beta", "Second skill", false) },
             ],
         };
         let out = render(&response, OutputFormat::Human);
@@ -5485,13 +5518,7 @@ mod tests {
     #[test]
     fn render_skill_list_json() {
         let response = SkillListResponse {
-            skills: vec![SkillSummary {
-                name: "alpha".into(),
-                description: "First skill".into(),
-                enabled: true,
-                source_dir: "/data/skills/alpha".into(),
-                binary_path: Some("/data/skills/alpha/run.sh".into()),
-            }],
+            skills: vec![sample_skill("alpha", "First skill", true)],
         };
         let out = render(&response, OutputFormat::Json);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -5506,13 +5533,7 @@ mod tests {
     #[test]
     fn render_skill_info_human() {
         let response = SkillInfoResponse {
-            skill: SkillSummary {
-                name: "alpha".into(),
-                description: "First skill".into(),
-                enabled: true,
-                source_dir: "/data/skills/alpha".into(),
-                binary_path: Some("/data/skills/alpha/run.sh".into()),
-            },
+            skill: sample_skill("alpha", "First skill", true),
         };
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Skill: alpha"));
@@ -5525,13 +5546,7 @@ mod tests {
     #[test]
     fn render_skill_info_json() {
         let response = SkillInfoResponse {
-            skill: SkillSummary {
-                name: "alpha".into(),
-                description: "First skill".into(),
-                enabled: true,
-                source_dir: "/data/skills/alpha".into(),
-                binary_path: Some("/data/skills/alpha/run.sh".into()),
-            },
+            skill: sample_skill("alpha", "First skill", true),
         };
         let out = render(&response, OutputFormat::Json);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();


### PR DESCRIPTION
Closes #62

Changes:
- add `rune spells search <query>` to filter installed spells by metadata
- reuse the existing `/skills` inventory as the initial spell index for discovery
- add human/json output for search results