### PR TITLE
feat(rust-patterns): add validation tool execution (#303)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -47,7 +47,10 @@ use rune_runtime::{
     scheduler::{ReminderStore, Scheduler},
     session_loop::SessionLoop,
 };
-use rune_spells_rust_patterns::rust_patterns_tool_definition;
+use rune_spells_rust_patterns::{
+    RustPatternsToolExecutor, rust_patterns_tool_definition,
+    rust_patterns_validate_tool_definition,
+};
 use rune_spells_security_audit::security_audit_tool_definition;
 use rune_store::models::{NewToolExecution, SessionRow, TurnRow};
 use rune_store::repos::{
@@ -1681,6 +1684,11 @@ impl ToolExecutor for AppToolExecutor {
                     .execute(call)
                     .await
             }
+            "rust_pattern" | "rust_pattern_validate" => {
+                RustPatternsToolExecutor::new(self.workspace_root.clone())
+                    .execute(call)
+                    .await
+            }
             "comms_send" => match &self.comms {
                 Some(comms) => comms.execute(call).await,
                 None => Err(ToolError::UnknownTool {
@@ -2016,6 +2024,7 @@ fn register_real_tool_definitions(registry: &mut ToolRegistry, browse_enabled: b
 
     registry.register(security_audit_tool_definition());
     registry.register(rust_patterns_tool_definition());
+    registry.register(rust_patterns_validate_tool_definition());
 }
 
 /// Build the model provider from config, falling back to echo if none configured.

--- a/crates/rune-spells/rust-patterns/Cargo.toml
+++ b/crates/rune-spells/rust-patterns/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 rune-core = { path = "../../rune-core" }
 rune-tools = { path = "../../rune-tools" }
 serde.workspace = true
@@ -14,4 +15,5 @@ toml.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+tokio.workspace = true
 tempfile.workspace = true

--- a/crates/rune-spells/rust-patterns/src/lib.rs
+++ b/crates/rune-spells/rust-patterns/src/lib.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub mod tool;
+pub use tool::{RustPatternsToolExecutor, rust_patterns_validate_tool_definition};
+
 #[derive(Debug, Error)]
 pub enum RustPatternsError {
     #[error("pattern directory not found: {0}")]
@@ -40,6 +43,7 @@ pub struct PatternQuery {
     pub context_file: Option<PathBuf>,
     pub task_description: Option<String>,
     pub error_message: Option<String>,
+    pub patterns_dir: Option<PathBuf>,
     pub max_results: usize,
 }
 
@@ -57,6 +61,7 @@ impl Default for PatternQuery {
             context_file: None,
             task_description: None,
             error_message: None,
+            patterns_dir: None,
             max_results: 3,
         }
     }
@@ -126,6 +131,7 @@ pub fn rust_patterns_tool_definition() -> rune_tools::ToolDefinition {
                 "context_file": { "type": "string", "description": "Rust file path used for import-based pattern detection" },
                 "task_description": { "type": "string", "description": "Free-form task text used for relevance matching" },
                 "error_message": { "type": "string", "description": "Error text used for debugging-oriented relevance matching" },
+                "patterns_dir": { "type": "string", "description": "Optional alternate pattern directory for hot-reloading TOML pattern files" },
                 "max_results": { "type": "integer", "description": "Maximum number of patterns to return (default: 3)" }
             }
         }),
@@ -135,7 +141,11 @@ pub fn rust_patterns_tool_definition() -> rune_tools::ToolDefinition {
 }
 
 pub fn rust_pattern(query: PatternQuery) -> Result<QueryResult, RustPatternsError> {
-    let topics = load_pattern_library(default_patterns_dir())?;
+    let patterns_dir = query
+        .patterns_dir
+        .clone()
+        .unwrap_or_else(default_patterns_dir);
+    let topics = load_pattern_library(patterns_dir)?;
     let mut scored = Vec::new();
 
     let requested_topic = query.topic.as_ref().map(|t| normalize(t));
@@ -319,6 +329,9 @@ fn load_pattern_library(dir: PathBuf) -> Result<Vec<LoadedTopic>, RustPatternsEr
     if !dir.exists() {
         return Err(RustPatternsError::PatternDirMissing(dir));
     }
+    if !dir.is_dir() {
+        return Err(RustPatternsError::PatternDirNotDirectory(dir));
+    }
 
     let mut topics = Vec::new();
     for entry in fs::read_dir(&dir).map_err(|source| RustPatternsError::ReadFile {
@@ -395,11 +408,7 @@ fn collect_import_signals(path: &Path) -> Result<Vec<String>, RustPatternsError>
         }
 
         if let Some(rest) = trimmed.strip_prefix("extern crate ") {
-            let crate_name = rest
-                .split([';', ' '])
-                .next()
-                .unwrap_or_default()
-                .trim();
+            let crate_name = rest.split([';', ' ']).next().unwrap_or_default().trim();
             if !crate_name.is_empty() {
                 signals.push(normalize(crate_name));
             }
@@ -503,7 +512,6 @@ mod tests {
         assert_eq!(result.patterns[0].topic, "axum_web");
     }
 
-
     #[test]
     fn query_by_extern_crate_imports_prefers_pyo3_patterns() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -560,5 +568,119 @@ use axum::Json;
         assert_eq!(report.scanned_files, 1);
         assert_eq!(report.findings.len(), 1);
         assert!(report.findings[0].issue.contains("unwrap"));
+    }
+}
+
+#[cfg(test)]
+mod hot_reload_tests {
+    use super::*;
+
+    #[test]
+    fn query_uses_custom_patterns_dir_for_hot_reload() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let patterns_dir = tmp.path().join("patterns");
+        fs::create_dir_all(&patterns_dir).expect("create patterns dir");
+        fs::write(
+            patterns_dir.join("custom.toml"),
+            r#"[meta]
+topic = "custom_topic"
+tags = ["custom", "demo"]
+relevance_signals = ["custom"]
+
+[[patterns]]
+name = "custom pattern"
+when = "Testing hot reload from a custom pattern directory"
+code = "let demo = true;"
+rationale = "Queries should load directly from the supplied TOML directory without recompiling"
+anti_pattern = "Hard-coding all patterns into the binary"
+"#,
+        )
+        .expect("write pattern file");
+
+        let result = rust_pattern(PatternQuery {
+            topic: Some("custom_topic".into()),
+            patterns_dir: Some(patterns_dir),
+            ..Default::default()
+        })
+        .expect("query should work");
+
+        assert_eq!(result.patterns.len(), 1);
+        assert_eq!(result.patterns[0].topic, "custom_topic");
+        assert_eq!(result.patterns[0].name, "custom pattern");
+    }
+
+    #[test]
+    fn query_errors_when_patterns_dir_is_a_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("not_a_dir.toml");
+        fs::write(&file, "[meta]\ntopic='bad'\npatterns=[]\n").expect("write file");
+
+        let error = rust_pattern(PatternQuery {
+            patterns_dir: Some(file.clone()),
+            ..Default::default()
+        })
+        .expect_err("file path should be rejected as a patterns dir");
+
+        match error {
+            RustPatternsError::PatternDirNotDirectory(path) => assert_eq!(path, file),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod hot_reload_tests {
+    use super::*;
+
+    #[test]
+    fn query_uses_custom_patterns_dir_for_hot_reload() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let patterns_dir = tmp.path().join("patterns");
+        fs::create_dir_all(&patterns_dir).expect("create patterns dir");
+        fs::write(
+            patterns_dir.join("custom.toml"),
+            r#"[meta]
+topic = "custom_topic"
+tags = ["custom", "demo"]
+relevance_signals = ["custom"]
+
+[[patterns]]
+name = "custom pattern"
+when = "Testing hot reload from a custom pattern directory"
+code = "let demo = true;"
+rationale = "Queries should load directly from the supplied TOML directory without recompiling"
+anti_pattern = "Hard-coding all patterns into the binary"
+"#,
+        )
+        .expect("write pattern file");
+
+        let result = rust_pattern(PatternQuery {
+            topic: Some("custom_topic".into()),
+            patterns_dir: Some(patterns_dir),
+            ..Default::default()
+        })
+        .expect("query should work");
+
+        assert_eq!(result.patterns.len(), 1);
+        assert_eq!(result.patterns[0].topic, "custom_topic");
+        assert_eq!(result.patterns[0].name, "custom pattern");
+    }
+
+    #[test]
+    fn query_errors_when_patterns_dir_is_a_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("not_a_dir.toml");
+        fs::write(&file, "[meta]\ntopic='bad'\npatterns=[]\n").expect("write file");
+
+        let error = rust_pattern(PatternQuery {
+            patterns_dir: Some(file.clone()),
+            ..Default::default()
+        })
+        .expect_err("file path should be rejected as a patterns dir");
+
+        match error {
+            RustPatternsError::PatternDirNotDirectory(path) => assert_eq!(path, file),
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/rune-spells/rust-patterns/src/tool.rs
+++ b/crates/rune-spells/rust-patterns/src/tool.rs
@@ -1,0 +1,220 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use rune_core::ToolCategory;
+use rune_tools::{ToolCall, ToolDefinition, ToolError, ToolExecutor, ToolResult};
+use serde::Deserialize;
+
+use crate::{PatternQuery, rust_pattern, validate_rune_codebase};
+
+pub struct RustPatternsToolExecutor {
+    workspace_root: PathBuf,
+}
+
+impl RustPatternsToolExecutor {
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+        }
+    }
+
+    fn resolve_path(&self, tool: &str, raw: &str) -> Result<PathBuf, ToolError> {
+        let candidate = Path::new(raw);
+        if candidate.is_absolute() {
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "absolute paths are not allowed".into(),
+            });
+        }
+
+        let workspace_root = self
+            .workspace_root
+            .canonicalize()
+            .map_err(|e| ToolError::ExecutionFailed(format!("workspace root invalid: {e}")))?;
+        let joined = workspace_root.join(candidate);
+        let canonical = if joined.exists() {
+            joined
+                .canonicalize()
+                .map_err(|e| ToolError::ExecutionFailed(format!("path resolution failed: {e}")))?
+        } else {
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "path does not exist".into(),
+            });
+        };
+        if !canonical.starts_with(&workspace_root) {
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "path escapes workspace boundary".into(),
+            });
+        }
+        Ok(canonical)
+    }
+
+    fn optional_path(&self, call: &ToolCall, key: &str) -> Result<Option<PathBuf>, ToolError> {
+        call.arguments
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(|raw| self.resolve_path(&call.tool_name, raw))
+            .transpose()
+    }
+
+    fn parse_query(&self, call: &ToolCall) -> Result<PatternQuery, ToolError> {
+        #[derive(Deserialize)]
+        struct RawQuery {
+            topic: Option<String>,
+            tags: Option<Vec<String>>,
+            context_file: Option<String>,
+            task_description: Option<String>,
+            error_message: Option<String>,
+            patterns_dir: Option<String>,
+            max_results: Option<usize>,
+        }
+
+        let raw: RawQuery = serde_json::from_value(call.arguments.clone()).map_err(|e| {
+            ToolError::InvalidArguments {
+                tool: call.tool_name.clone(),
+                reason: format!("invalid rust_pattern arguments: {e}"),
+            }
+        })?;
+
+        let context_file = raw
+            .context_file
+            .as_deref()
+            .map(|value| self.resolve_path(&call.tool_name, value))
+            .transpose()?;
+        let patterns_dir = raw
+            .patterns_dir
+            .as_deref()
+            .map(|value| self.resolve_path(&call.tool_name, value))
+            .transpose()?;
+
+        Ok(PatternQuery {
+            topic: raw.topic,
+            tags: raw.tags,
+            context_file,
+            task_description: raw.task_description,
+            error_message: raw.error_message,
+            patterns_dir,
+            max_results: raw.max_results.unwrap_or(3),
+        })
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RustPatternsToolExecutor {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
+        match call.tool_name.as_str() {
+            "rust_pattern" => {
+                let query = self.parse_query(&call)?;
+                let result =
+                    rust_pattern(query).map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+                let output = serde_json::to_string_pretty(&result).map_err(|e| {
+                    ToolError::ExecutionFailed(format!(
+                        "failed to serialize rust_pattern result: {e}"
+                    ))
+                })?;
+                Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output,
+                    is_error: false,
+                    tool_execution_id: None,
+                })
+            }
+            "rust_pattern_validate" => {
+                let root = self
+                    .optional_path(&call, "path")?
+                    .unwrap_or_else(|| self.workspace_root.clone());
+                let report = validate_rune_codebase(&root);
+                let output = serde_json::to_string_pretty(&report).map_err(|e| {
+                    ToolError::ExecutionFailed(format!(
+                        "failed to serialize rust_pattern_validate result: {e}"
+                    ))
+                })?;
+                Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output,
+                    is_error: false,
+                    tool_execution_id: None,
+                })
+            }
+            other => Err(ToolError::UnknownTool {
+                name: other.to_string(),
+            }),
+        }
+    }
+}
+
+pub fn rust_patterns_validate_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "rust_pattern_validate".into(),
+        description: "Scan Rust files for common anti-patterns from the rust-patterns spell, including unwrap() in non-test code and blocking sleep in async contexts.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Optional workspace-relative directory or Rust file path to validate; defaults to the workspace root"
+                }
+            }
+        }),
+        category: ToolCategory::FileRead,
+        requires_approval: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rune_core::ToolCallId;
+    use tempfile::tempdir;
+
+    fn tool_call(name: &str, arguments: serde_json::Value) -> ToolCall {
+        ToolCall {
+            tool_call_id: ToolCallId::new(),
+            tool_name: name.to_string(),
+            arguments,
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_tool_returns_report_for_workspace_relative_path() {
+        let tmp = tempdir().expect("tempdir");
+        let file = tmp.path().join("sample.rs");
+        std::fs::write(&file, "fn demo() { let _ = Some(1).unwrap(); }\n").expect("write");
+
+        let executor = RustPatternsToolExecutor::new(tmp.path());
+        let result = executor
+            .execute(tool_call(
+                "rust_pattern_validate",
+                serde_json::json!({ "path": "." }),
+            ))
+            .await
+            .expect("tool execution should succeed");
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("unwrap"));
+    }
+
+    #[tokio::test]
+    async fn validate_tool_rejects_absolute_paths() {
+        let tmp = tempdir().expect("tempdir");
+        let executor = RustPatternsToolExecutor::new(tmp.path());
+        let absolute = tmp.path().to_string_lossy().to_string();
+
+        let error = executor
+            .execute(tool_call(
+                "rust_pattern_validate",
+                serde_json::json!({ "path": absolute }),
+            ))
+            .await
+            .expect_err("absolute paths should be rejected");
+
+        match error {
+            ToolError::InvalidArguments { tool, .. } => {
+                assert_eq!(tool, "rust_pattern_validate");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #303

Changes:
- add a rust-patterns tool executor for rust_pattern queries
- add rust_pattern_validate for workspace-safe anti-pattern scanning
- register the new tool in the gateway and cover it with executor tests