### PR TITLE
feat(gateway): expose orchestration session status fields (#50)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -1345,6 +1345,19 @@ pub struct SessionStatusResponse {
     pub session_id: String,
     pub runtime: String,
     pub status: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orchestration_status: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub delegation_roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delegation_depth: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1445,6 +1458,32 @@ pub async fn get_session_status(
     let reasoning = metadata_string(metadata, "reasoning").unwrap_or_else(|| "off".to_string());
     let verbose = metadata_bool(metadata, "verbose").unwrap_or(false);
     let elevated = metadata_bool(metadata, "elevated").unwrap_or(false);
+    let parent_session_id = row.requester_session_id.map(|id| id.to_string());
+    let session_mode = metadata_string(metadata, "mode");
+    let orchestration_status = metadata_string(metadata, "orchestration_status")
+        .or_else(|| metadata_string(metadata, "subagent_lifecycle"));
+    let delegation_roles = metadata
+        .get("delegation_roles")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let delegation_depth = if parent_session_id.is_some() {
+        Some(metadata
+            .get("delegation_depth")
+            .and_then(|value| value.as_u64())
+            .map(|value| value as u32)
+            .unwrap_or(1))
+    } else {
+        metadata
+            .get("delegation_depth")
+            .and_then(|value| value.as_u64())
+            .map(|value| value as u32)
+    };
     let subagent_lifecycle = metadata_string(metadata, "subagent_lifecycle");
     let subagent_runtime_status = metadata_string(metadata, "subagent_runtime_status");
     let subagent_runtime_attached = metadata_bool(metadata, "subagent_runtime_attached");
@@ -1478,6 +1517,13 @@ pub async fn get_session_status(
             row.status
         ),
         status: row.status,
+        kind: row.kind,
+        channel_ref: row.channel_ref,
+        parent_session_id,
+        session_mode,
+        orchestration_status,
+        delegation_roles,
+        delegation_depth,
         current_model,
         model_override,
         prompt_tokens: aggregate.usage_prompt_tokens,

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -562,6 +562,34 @@ impl RpcDispatcher {
             .get("elevated")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let parent_session_id = row.requester_session_id.map(|id| id.to_string());
+        let session_mode = metadata_str(metadata, "mode");
+        let orchestration_status = metadata_str(metadata, "orchestration_status")
+            .or_else(|| metadata_str(metadata, "subagent_lifecycle"));
+        let delegation_roles = metadata
+            .get("delegation_roles")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let delegation_depth = if parent_session_id.is_some() {
+            Some(
+                metadata
+                    .get("delegation_depth")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32)
+                    .unwrap_or(1),
+            )
+        } else {
+            metadata
+                .get("delegation_depth")
+                .and_then(Value::as_u64)
+                .map(|value| value as u32)
+        };
         let subagent_lifecycle = metadata_str(metadata, "subagent_lifecycle");
         let subagent_runtime_status = metadata_str(metadata, "subagent_runtime_status");
         let subagent_runtime_attached = metadata
@@ -599,6 +627,11 @@ impl RpcDispatcher {
             "status": row.status,
             "kind": row.kind,
             "channel_ref": row.channel_ref,
+            "parent_session_id": parent_session_id,
+            "session_mode": session_mode,
+            "orchestration_status": orchestration_status,
+            "delegation_roles": delegation_roles,
+            "delegation_depth": delegation_depth,
             "current_model": current_model,
             "model_override": model_override,
             "turn_count": turn_count,

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -6246,6 +6246,13 @@ async fn get_session_status_returns_parity_card_fields() {
     assert_eq!(json["session_id"], session_id);
     // Session transitions: created → ready (auto) → running (on message).
     assert_eq!(json["status"], "running");
+    assert_eq!(json["kind"], "direct");
+    assert_eq!(json["channel_ref"], Value::Null);
+    assert_eq!(json["parent_session_id"], Value::Null);
+    assert_eq!(json["session_mode"], Value::Null);
+    assert_eq!(json["orchestration_status"], Value::Null);
+    assert_eq!(json["delegation_roles"], serde_json::json!([]));
+    assert_eq!(json["delegation_depth"], Value::Null);
     assert_eq!(json["current_model"], "fake-model");
     assert_eq!(json["prompt_tokens"], 10);
     assert_eq!(json["completion_tokens"], 5);
@@ -6384,6 +6391,16 @@ async fn get_session_status_surfaces_subagent_metadata() {
         "kind=subagent | channel=local | status=running"
     );
     assert_eq!(json["status"], "running");
+    assert_eq!(json["kind"], "subagent");
+    assert_eq!(json["channel_ref"], Value::Null);
+    assert_eq!(
+        json["parent_session_id"],
+        "33333333-3333-3333-3333-333333333333"
+    );
+    assert_eq!(json["session_mode"], Value::Null);
+    assert_eq!(json["orchestration_status"], "steered");
+    assert_eq!(json["delegation_roles"], serde_json::json!([]));
+    assert_eq!(json["delegation_depth"], 1);
     assert_eq!(json["current_model"], "gpt-5.4");
     assert_eq!(json["model_override"], "gpt-5.4");
     assert_eq!(json["estimated_cost"], "not available");
@@ -6403,6 +6420,134 @@ async fn get_session_status_surfaces_subagent_metadata() {
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("host/node/sandbox parity and PTY fidelity are not yet parity-complete")));
     assert!(unresolved.iter().any(|item| item.as_str() == Some("subagent runtime execution remains conservative; durable lifecycle inspection is available but full remote/runtime attachment parity is not complete")));
+}
+
+#[tokio::test]
+async fn get_session_status_surfaces_orchestration_metadata() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+
+    let parent_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let session_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let now = chrono::Utc::now();
+    session_repo
+        .create(NewSession {
+            id: session_id,
+            kind: "subagent".into(),
+            status: "running".into(),
+            workspace_root: None,
+            channel_ref: Some("telegram:ops".into()),
+            requester_session_id: Some(parent_id),
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "mode": "architect",
+                "orchestration_status": "delegated",
+                "delegation_roles": ["architect", "coder"],
+                "delegation_depth": 2,
+                "selected_model": "gpt-5.4"
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "subagent");
+    assert_eq!(json["channel_ref"], "telegram:ops");
+    assert_eq!(json["parent_session_id"], parent_id.to_string());
+    assert_eq!(json["session_mode"], "architect");
+    assert_eq!(json["orchestration_status"], "delegated");
+    assert_eq!(json["delegation_roles"], serde_json::json!(["architect", "coder"]));
+    assert_eq!(json["delegation_depth"], 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #50

Changes:
- add orchestration-focused fields to session status responses for REST and WS-RPC
- surface parent linkage, session mode, delegation roles/depth, and orchestration status from metadata
- extend gateway session status tests to cover direct, subagent, and orchestration metadata cases