### PR TITLE
feat(context-budget): add checkpoint and gc tool definitions (#305)

### DIFF
--- a/crates/rune-tools/src/context_budget_tool.rs
+++ b/crates/rune-tools/src/context_budget_tool.rs
@@ -1,0 +1,56 @@
+use rune_core::ToolCategory;
+
+use crate::definition::ToolDefinition;
+
+pub fn context_budget_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "context_budget".into(),
+        description: "Report current context budget usage across runtime partitions.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {}
+        }),
+        category: ToolCategory::MemoryAccess,
+        requires_approval: false,
+    }
+}
+
+pub fn context_checkpoint_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "context_checkpoint".into(),
+        description: "Create a persistent pre-compaction checkpoint with task status, key decisions, and next step.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": { "type": "string", "description": "Current task progress summary" },
+                "key_decisions": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Significant decisions made so far"
+                },
+                "next_step": { "type": "string", "description": "Immediate next action required" }
+            },
+            "required": ["status", "next_step"]
+        }),
+        category: ToolCategory::MemoryAccess,
+        requires_approval: false,
+    }
+}
+
+pub fn context_gc_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "context_gc".into(),
+        description: "Trigger context garbage collection and partition-aware compaction.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "aggressive": {
+                    "type": "boolean",
+                    "description": "Whether to use more aggressive compaction heuristics"
+                }
+            }
+        }),
+        category: ToolCategory::MemoryAccess,
+        requires_approval: false,
+    }
+}

--- a/crates/rune-tools/src/lib.rs
+++ b/crates/rune-tools/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod acp_tool;
 pub mod approval;
 pub mod comms_tool;
+pub mod context_budget_tool;
 pub mod cron_tool;
 mod definition;
 mod error;

--- a/crates/rune-tools/src/stubs.rs
+++ b/crates/rune-tools/src/stubs.rs
@@ -166,6 +166,9 @@ pub fn register_builtin_stubs(registry: &mut ToolRegistry) {
     registry.register(crate::git_tool::git_tool_definition());
     registry.register(crate::image_generation_tool::image_generation_tool_definition());
     registry.register(crate::document_tools::document_extract_tool_definition());
+    registry.register(crate::context_budget_tool::context_budget_tool_definition());
+    registry.register(crate::context_budget_tool::context_checkpoint_tool_definition());
+    registry.register(crate::context_budget_tool::context_gc_tool_definition());
 }
 
 /// Validate that a tool call's arguments satisfy the `required` fields in the tool schema.

--- a/crates/rune-tools/src/tests.rs
+++ b/crates/rune-tools/src/tests.rs
@@ -94,7 +94,7 @@ fn register_builtin_stubs_populates_expected_tools() {
     let mut reg = ToolRegistry::new();
     register_builtin_stubs(&mut reg);
 
-    assert_eq!(reg.len(), 13);
+    assert_eq!(reg.len(), 16);
 
     let expected = [
         "read_file",
@@ -109,6 +109,9 @@ fn register_builtin_stubs_populates_expected_tools() {
         "web_fetch",
         "git",
         "image_generation",
+        "context_budget",
+        "context_checkpoint",
+        "context_gc",
     ];
     for name in expected {
         assert!(reg.lookup(name).is_ok(), "missing builtin: {name}");
@@ -232,4 +235,14 @@ fn tool_definition_roundtrips_through_serde() {
 
     let restored: ToolDefinition = serde_json::from_value(json).unwrap();
     assert_eq!(restored.name, "read_file");
+}
+
+#[test]
+fn context_budget_tool_definitions_are_registered() {
+    let mut reg = ToolRegistry::new();
+    register_builtin_stubs(&mut reg);
+
+    assert!(reg.lookup("context_budget").is_ok());
+    assert!(reg.lookup("context_checkpoint").is_ok());
+    assert!(reg.lookup("context_gc").is_ok());
 }


### PR DESCRIPTION
Closes #305

Changes:
- add built-in tool definitions for context_budget, context_checkpoint, and context_gc
- register the new context budgeting tools in the builtin stub registry
- extend tool registry tests to cover the new context budgeting surface

Validation:
- cargo check ✅
- cargo test -p rune-tools ⚠️ fails due to pre-existing missing trait methods in test stubs (delete_chunk/delete_all in memory repos), unrelated to this change