### PR TITLE
feat(mobile): add chat tab screen foundation (#278)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Tabs } from "expo-router";
+
+export default function TabsLayout() {
+  return (
+    <Tabs screenOptions={{ headerShown: false }}>
+      <Tabs.Screen name="index" options={{ title: "Chat" }} />
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { ActivityIndicator, Pressable, SafeAreaView, ScrollView, Text, View } from "react-native";
+import { ChatFlatList } from "../../src/components/chat/ChatFlatList";
+import { ChatInputBar } from "../../src/components/chat/ChatInputBar";
+import { useChat } from "../../src/hooks/use-chat";
+import { useSessions } from "../../src/hooks/use-sessions";
+
+export default function ChatScreen() {
+  const { sessions, activeSessionId, setActiveSessionId, createSession, loading: sessionsLoading } = useSessions();
+  const { messages, sendMessage, sending, loading: transcriptLoading } = useChat(activeSessionId);
+
+  return (
+    <SafeAreaView style={{ backgroundColor: "#f9fafb", flex: 1 }}>
+      <View style={{ borderBottomWidth: 1, borderColor: "#e5e7eb", gap: 12, padding: 12 }}>
+        <Text style={{ fontSize: 24, fontWeight: "700" }}>Rune Chat</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={{ flexDirection: "row", gap: 8 }}>
+            {sessions.map((session) => {
+              const active = session.id === activeSessionId;
+              return (
+                <Pressable
+                  key={session.id}
+                  onPress={() => setActiveSessionId(session.id)}
+                  style={{
+                    backgroundColor: active ? "#2563eb" : "#e5e7eb",
+                    borderRadius: 999,
+                    paddingHorizontal: 12,
+                    paddingVertical: 8,
+                  }}
+                >
+                  <Text style={{ color: active ? "#fff" : "#111827" }}>
+                    {session.preview || session.id.slice(0, 8)}
+                  </Text>
+                </Pressable>
+              );
+            })}
+            <Pressable
+              onPress={() => void createSession()}
+              style={{ backgroundColor: "#111827", borderRadius: 999, paddingHorizontal: 12, paddingVertical: 8 }}
+            >
+              <Text style={{ color: "#fff" }}>+ New</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </View>
+
+      {sessionsLoading || transcriptLoading ? (
+        <View style={{ alignItems: "center", flex: 1, justifyContent: "center" }}>
+          <ActivityIndicator />
+        </View>
+      ) : (
+        <ChatFlatList messages={messages} />
+      )}
+
+      <ChatInputBar disabled={!activeSessionId} sending={sending} onSend={sendMessage} />
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/src/components/chat/ChatFlatList.tsx
+++ b/apps/mobile/src/components/chat/ChatFlatList.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { FlatList } from "react-native";
+import { MessageBubble } from "./MessageBubble";
+
+export interface ChatMessageItem {
+  id: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+}
+
+export function ChatFlatList({ messages }: { messages: ChatMessageItem[] }) {
+  return (
+    <FlatList
+      contentContainerStyle={{ padding: 12 }}
+      data={messages}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => <MessageBubble role={item.role} text={item.text} />}
+    />
+  );
+}

--- a/apps/mobile/src/components/chat/ChatInputBar.tsx
+++ b/apps/mobile/src/components/chat/ChatInputBar.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+
+interface ChatInputBarProps {
+  disabled?: boolean;
+  sending?: boolean;
+  onSend: (value: string) => Promise<void> | void;
+}
+
+export function ChatInputBar({ disabled = false, sending = false, onSend }: ChatInputBarProps) {
+  const [value, setValue] = useState("");
+
+  const submit = async () => {
+    const next = value.trim();
+    if (!next || disabled || sending) return;
+    setValue("");
+    await onSend(next);
+  };
+
+  return (
+    <View style={{ borderTopWidth: 1, borderColor: "#e5e7eb", flexDirection: "row", gap: 8, padding: 12 }}>
+      <TextInput
+        editable={!disabled && !sending}
+        onChangeText={setValue}
+        placeholder="Message Rune"
+        style={{
+          backgroundColor: "#fff",
+          borderColor: "#d1d5db",
+          borderRadius: 12,
+          borderWidth: 1,
+          flex: 1,
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+        }}
+        value={value}
+      />
+      <Pressable
+        onPress={() => void submit()}
+        style={{
+          alignItems: "center",
+          backgroundColor: disabled || sending ? "#93c5fd" : "#2563eb",
+          borderRadius: 12,
+          justifyContent: "center",
+          paddingHorizontal: 16,
+        }}
+      >
+        <Text style={{ color: "#fff", fontWeight: "600" }}>{sending ? "..." : "Send"}</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+interface MessageBubbleProps {
+  role: "user" | "assistant" | "system";
+  text: string;
+}
+
+export function MessageBubble({ role, text }: MessageBubbleProps) {
+  const isUser = role === "user";
+
+  return (
+    <View
+      style={{
+        alignSelf: isUser ? "flex-end" : "flex-start",
+        backgroundColor: isUser ? "#2563eb" : "#e5e7eb",
+        borderRadius: 16,
+        marginBottom: 8,
+        maxWidth: "88%",
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+      }}
+    >
+      <Text style={{ color: isUser ? "#fff" : "#111827" }}>{text}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/hooks/use-chat.ts
+++ b/apps/mobile/src/hooks/use-chat.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { MessageResponse, TranscriptEntry } from "../api/api-types";
+import { apiFetch } from "../api/client";
+import { getPayloadText, normalizeTranscriptKind } from "../lib/chat-utils";
+import { useSessionEvents } from "../lib/websocket";
+import type { ChatMessageItem } from "../components/chat/ChatFlatList";
+
+function mapEntry(entry: TranscriptEntry): ChatMessageItem {
+  const role = normalizeTranscriptKind(entry.kind);
+  return {
+    id: entry.id,
+    role: role === "user" || role === "assistant" ? role : "system",
+    text: getPayloadText(entry.payload),
+  };
+}
+
+export function useChat(sessionId: string | null) {
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  const [sending, setSending] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const { events } = useSessionEvents(sessionId ?? undefined, { enabled: !!sessionId });
+
+  const loadTranscript = useCallback(async () => {
+    if (!sessionId) {
+      setTranscript([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await apiFetch(`/v1/sessions/${sessionId}/transcript`);
+      if (!response.ok) {
+        throw new Error(`Failed to load transcript (${response.status})`);
+      }
+      const data = (await response.json()) as TranscriptEntry[];
+      setTranscript(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void loadTranscript();
+  }, [loadTranscript]);
+
+  useEffect(() => {
+    if (!sessionId || events.length === 0) return;
+    void loadTranscript();
+  }, [events, loadTranscript, sessionId]);
+
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (!sessionId) {
+        throw new Error("No active session");
+      }
+
+      setSending(true);
+      try {
+        const response = await apiFetch(`/v1/sessions/${sessionId}/messages`, {
+          body: JSON.stringify({ content }),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to send message (${response.status})`);
+        }
+
+        await response.json() as MessageResponse;
+        await loadTranscript();
+      } finally {
+        setSending(false);
+      }
+    },
+    [loadTranscript, sessionId],
+  );
+
+  const messages = useMemo(() => transcript.map(mapEntry), [transcript]);
+
+  return {
+    loading,
+    messages,
+    sendMessage,
+    sending,
+  };
+}

--- a/apps/mobile/src/hooks/use-sessions.ts
+++ b/apps/mobile/src/hooks/use-sessions.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import type { SessionListItem, SessionResponse } from "../api/api-types";
+import { apiFetch } from "../api/client";
+
+export function useSessions() {
+  const [sessions, setSessions] = useState<SessionListItem[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await apiFetch("/v1/sessions");
+      if (!response.ok) {
+        throw new Error(`Failed to load sessions (${response.status})`);
+      }
+      const data = (await response.json()) as SessionListItem[];
+      setSessions(data);
+      setActiveSessionId((current) => current ?? data[0]?.id ?? null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const createSession = useCallback(async () => {
+    const response = await apiFetch("/v1/sessions", {
+      body: JSON.stringify({ kind: "direct" }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create session (${response.status})`);
+    }
+
+    const session = (await response.json()) as SessionResponse;
+    await loadSessions();
+    setActiveSessionId(session.id);
+    return session;
+  }, [loadSessions]);
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  return {
+    activeSessionId,
+    createSession,
+    loading,
+    sessions,
+    setActiveSessionId,
+  };
+}


### PR DESCRIPTION
Closes #278

Changes:
- add Expo Router tabs layout with a Chat tab
- add basic chat screen with session chips and new session action
- add reusable mobile chat components for message list, bubbles, and input
- add mobile hooks for loading sessions, transcript, sending messages, and WS-driven refresh