### PR TITLE
feat(ui): improve mobile admin shell responsiveness (#60)

### DIFF
--- a/ui/src/components/layout/AdminNavbar.tsx
+++ b/ui/src/components/layout/AdminNavbar.tsx
@@ -104,14 +104,14 @@ export function AdminNavbar() {
       {/* Subtle gradient accent */}
       <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-accent/5 pointer-events-none z-0" />
 
-      <div className="relative z-10 mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between sm:h-18">
+      <div className="relative z-10 mx-auto w-full max-w-7xl px-3 sm:px-6 lg:px-8">
+        <div className="flex min-h-16 items-center justify-between gap-3 py-2 sm:min-h-[4.5rem]">
           {/* Left: Logo + Admin badge + nav links */}
-          <div className="flex items-center gap-4">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
             <Link
               to="/chat"
               search={chatLinkSearch}
-              className="flex items-center gap-2 rounded-md px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="flex min-w-0 items-center gap-2 rounded-md px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
             >
               <img
                 src="/assets/rune-logo-icon.svg"
@@ -173,13 +173,13 @@ export function AdminNavbar() {
           </div>
 
           {/* Right: actions */}
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <ThemeToggle />
 
             {/* Mobile menu trigger */}
             <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
               <SheetTrigger asChild className="lg:hidden">
-                <Button variant="ghost" size="icon">
+                <Button variant="ghost" size="icon" className="h-11 w-11">
                   <Menu className="h-5 w-5" />
                   <span className="sr-only">Open admin menu</span>
                 </Button>

--- a/ui/src/routes/_admin.tsx
+++ b/ui/src/routes/_admin.tsx
@@ -8,9 +8,9 @@ export const Route = createFileRoute("/_admin")({
 
 function AdminLayout() {
   return (
-    <div className="flex h-[100dvh] flex-col overflow-hidden bg-gradient-to-br from-background to-muted/20">
+    <div className="admin-shell flex min-h-[100dvh] flex-col bg-gradient-to-br from-background to-muted/20">
       <AdminNavbar />
-      <main className="mx-auto min-h-0 w-full max-w-7xl flex-1 overflow-hidden px-5 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-6 sm:px-8 sm:pt-8 lg:px-10 lg:pb-10">
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pt-6 lg:px-10 lg:pb-10 lg:pt-8">
         <Outlet />
       </main>
       <AdminBottomNav />

--- a/ui/src/routes/_admin/index.tsx
+++ b/ui/src/routes/_admin/index.tsx
@@ -51,14 +51,14 @@ function DashboardPage() {
   const { data: diagnostics } = useDashboardDiagnostics();
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6 sm:space-y-8">
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Dashboard</h1>
         <p className="mt-1 text-muted-foreground">Gateway overview and system health</p>
       </div>
 
       {/* Stat cards */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Gateway Status</CardTitle>
@@ -152,7 +152,7 @@ function DashboardPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-6">
         {/* Diagnostics panel */}
         <Card>
           <CardHeader>
@@ -201,7 +201,8 @@ function DashboardPage() {
             {!sessions?.length ? (
               <p className="text-sm text-muted-foreground">No sessions</p>
             ) : (
-              <Table>
+              <div className="overflow-x-auto">
+              <Table className="min-w-[24rem]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>ID</TableHead>
@@ -239,6 +240,7 @@ function DashboardPage() {
                   ))}
                 </TableBody>
               </Table>
+              </div>
             )}
           </CardContent>
         </Card>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -12,6 +12,27 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  overflow-x: hidden;
+}
+
+img,
+svg,
+video,
+canvas {
+  max-width: 100%;
+}
+
+.admin-shell {
+  overflow-x: clip;
+}
+
 /* Typography scale and section rhythm */
 :root {
   --font-size-xs: clamp(0.75rem, 0.71rem + 0.18vw, 0.8125rem);


### PR DESCRIPTION
Closes #60

Changes:
- relax the admin layout so mobile pages can scroll without horizontal overflow
- tighten navbar spacing and enlarge the mobile menu trigger tap target
- make the dashboard header, card grid, and recent sessions table fit small viewports better