### PR TITLE
feat(mobile): add auto tts settings toggle (#279)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,47 +1,76 @@
 import React from "react";
 import { Pressable, SafeAreaView, Text, View } from "react-native";
 import { useNotificationStore } from "../../src/store/notification-store";
+import { useAppStore } from "../../src/store/app-store";
+
+function ToggleCard({
+  title,
+  description,
+  enabled,
+  onToggle,
+}: {
+  title: string;
+  description: string;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <View
+      style={{
+        backgroundColor: "#fff",
+        borderColor: "#e5e7eb",
+        borderRadius: 16,
+        borderWidth: 1,
+        gap: 8,
+        padding: 16,
+      }}
+    >
+      <Text style={{ color: "#111827", fontSize: 18, fontWeight: "700" }}>{title}</Text>
+      <Text style={{ color: "#6b7280" }}>{description}</Text>
+      <Pressable
+        onPress={onToggle}
+        style={{
+          alignItems: "center",
+          backgroundColor: enabled ? "#2563eb" : "#e5e7eb",
+          borderRadius: 12,
+          paddingVertical: 12,
+        }}
+      >
+        <Text style={{ color: enabled ? "#fff" : "#111827", fontWeight: "700" }}>
+          {enabled ? "Enabled" : "Disabled"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
 
 export default function SettingsScreen() {
   const approvalsEnabled = useNotificationStore((state) => state.approvalsEnabled);
   const setApprovalsEnabled = useNotificationStore((state) => state.setApprovalsEnabled);
+  const autoTtsEnabled = useAppStore((state) => state.autoTtsEnabled);
+  const setAutoTtsEnabled = useAppStore((state) => state.setAutoTtsEnabled);
 
   return (
     <SafeAreaView style={{ backgroundColor: "#f9fafb", flex: 1 }}>
       <View style={{ borderBottomWidth: 1, borderColor: "#e5e7eb", gap: 4, padding: 16 }}>
         <Text style={{ fontSize: 24, fontWeight: "700" }}>Settings</Text>
-        <Text style={{ color: "#6b7280" }}>Notification preferences for operator alerts.</Text>
+        <Text style={{ color: "#6b7280" }}>Notification and voice preferences for operator alerts.</Text>
       </View>
 
       <View style={{ gap: 12, padding: 16 }}>
-        <View
-          style={{
-            backgroundColor: "#fff",
-            borderColor: "#e5e7eb",
-            borderRadius: 16,
-            borderWidth: 1,
-            gap: 8,
-            padding: 16,
-          }}
-        >
-          <Text style={{ color: "#111827", fontSize: 18, fontWeight: "700" }}>Approval notifications</Text>
-          <Text style={{ color: "#6b7280" }}>
-            Fire a local notification when the pending approval count increases.
-          </Text>
-          <Pressable
-            onPress={() => setApprovalsEnabled(!approvalsEnabled)}
-            style={{
-              alignItems: "center",
-              backgroundColor: approvalsEnabled ? "#2563eb" : "#e5e7eb",
-              borderRadius: 12,
-              paddingVertical: 12,
-            }}
-          >
-            <Text style={{ color: approvalsEnabled ? "#fff" : "#111827", fontWeight: "700" }}>
-              {approvalsEnabled ? "Enabled" : "Disabled"}
-            </Text>
-          </Pressable>
-        </View>
+        <ToggleCard
+          title="Approval notifications"
+          description="Fire a local notification when the pending approval count increases."
+          enabled={approvalsEnabled}
+          onToggle={() => setApprovalsEnabled(!approvalsEnabled)}
+        />
+
+        <ToggleCard
+          title="Auto-play TTS"
+          description="Automatically play synthesized assistant audio replies when voice mode is enabled."
+          enabled={autoTtsEnabled}
+          onToggle={() => setAutoTtsEnabled(!autoTtsEnabled)}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/src/store/app-store.ts
+++ b/apps/mobile/src/store/app-store.ts
@@ -1,15 +1,19 @@
 import { create } from "zustand";
 
 export interface AppPreferences {
+  autoTtsEnabled: boolean;
   gatewayUrl: string | null;
 }
 
 interface AppState extends AppPreferences {
+  setAutoTtsEnabled: (autoTtsEnabled: boolean) => void;
   setGatewayUrl: (gatewayUrl: string | null) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
+  autoTtsEnabled: false,
   gatewayUrl: null,
+  setAutoTtsEnabled: (autoTtsEnabled) => set({ autoTtsEnabled }),
   setGatewayUrl: (gatewayUrl) => set({ gatewayUrl }),
 }));
 
@@ -21,7 +25,15 @@ export function setGatewayUrl(gatewayUrl: string | null): void {
   useAppStore.getState().setGatewayUrl(gatewayUrl);
 }
 
+export function getAutoTtsEnabled(): boolean {
+  return useAppStore.getState().autoTtsEnabled;
+}
+
+export function setAutoTtsEnabled(autoTtsEnabled: boolean): void {
+  useAppStore.getState().setAutoTtsEnabled(autoTtsEnabled);
+}
+
 export function getAppState(): AppPreferences {
-  const { gatewayUrl } = useAppStore.getState();
-  return { gatewayUrl };
+  const { autoTtsEnabled, gatewayUrl } = useAppStore.getState();
+  return { autoTtsEnabled, gatewayUrl };
 }


### PR DESCRIPTION
Closes #279

Changes:
- add autoTtsEnabled to the mobile app store
- expose an Auto-play TTS toggle in mobile settings
- keep the change focused on the issue's settings slice