### PR TITLE
fix(runtime): derive spell namespace from parent directories only (#300)

### DIFF
--- a/crates/rune-runtime/src/spell_loader.rs
+++ b/crates/rune-runtime/src/spell_loader.rs
@@ -243,8 +243,8 @@ fn path_to_namespace(rel: &Path) -> Option<String> {
         return None;
     }
 
-    // All components form the dotted namespace (including the leaf which is the spell dir name)
-    Some(components.join("."))
+    // Namespace is the parent path only; the leaf directory is the spell name, not part of the namespace
+    Some(components[..components.len() - 1].join("."))
 }
 
 /// Load a single spell from a SPELL.md (or SKILL.md) file path.


### PR DESCRIPTION
Closes #300

Changes:
- derive spell namespaces from parent directories only
- keep the spell leaf directory as the spell name instead of part of the namespace
- align recursive namespace loading with the documented layout