### PR TITLE
feat(mobile): add theme preference support (#283)

### DIFF
--- a/apps/mobile/app/(auth)/connect.tsx
+++ b/apps/mobile/app/(auth)/connect.tsx
@@ -3,6 +3,7 @@ import { Button, Text, TextInput, View } from "react-native";
 import { router } from "expo-router";
 import { setToken } from "../../src/lib/auth";
 import { setGatewayUrl } from "../../src/store/app-store";
+import { useTheme } from "../../src/hooks/use-theme";
 
 async function verifyGateway(baseUrl: string): Promise<void> {
   const normalized = baseUrl.replace(/\/+$/, "");
@@ -16,6 +17,7 @@ async function verifyGateway(baseUrl: string): Promise<void> {
 }
 
 export default function ConnectScreen() {
+  const colors = useTheme();
   const [gatewayUrl, setGatewayUrlInput] = useState("");
   const [bearerToken, setBearerToken] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -37,26 +39,28 @@ export default function ConnectScreen() {
   };
 
   return (
-    <View style={{ flex: 1, justifyContent: "center", padding: 24, gap: 12 }}>
-      <Text style={{ fontSize: 24, fontWeight: "600" }}>Connect to Rune Gateway</Text>
+    <View style={{ backgroundColor: colors.background, flex: 1, justifyContent: "center", padding: 24, gap: 12 }}>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: "600" }}>Connect to Rune Gateway</Text>
       <TextInput
         autoCapitalize="none"
         autoCorrect={false}
         placeholder="https://gateway.example.com"
+        placeholderTextColor={colors.textMuted}
         value={gatewayUrl}
         onChangeText={setGatewayUrlInput}
-        style={{ borderWidth: 1, borderColor: "#ccc", borderRadius: 8, padding: 12 }}
+        style={{ borderWidth: 1, borderColor: colors.border, borderRadius: 8, padding: 12, color: colors.text }}
       />
       <TextInput
         autoCapitalize="none"
         autoCorrect={false}
         placeholder="Bearer token"
+        placeholderTextColor={colors.textMuted}
         secureTextEntry
         value={bearerToken}
         onChangeText={setBearerToken}
-        style={{ borderWidth: 1, borderColor: "#ccc", borderRadius: 8, padding: 12 }}
+        style={{ borderWidth: 1, borderColor: colors.border, borderRadius: 8, padding: 12, color: colors.text }}
       />
-      {error ? <Text style={{ color: "#c00" }}>{error}</Text> : null}
+      {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
       <Button title={submitting ? "Connecting..." : "Connect"} onPress={() => void onSubmit()} />
     </View>
   );

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -4,15 +4,17 @@ import { ChatFlatList } from "../../src/components/chat/ChatFlatList";
 import { ChatInputBar } from "../../src/components/chat/ChatInputBar";
 import { useChat } from "../../src/hooks/use-chat";
 import { useSessions } from "../../src/hooks/use-sessions";
+import { useTheme } from "../../src/hooks/use-theme";
 
 export default function ChatScreen() {
+  const colors = useTheme();
   const { sessions, activeSessionId, setActiveSessionId, createSession, loading: sessionsLoading } = useSessions();
   const { messages, sendMessage, sending, loading: transcriptLoading } = useChat(activeSessionId);
 
   return (
-    <SafeAreaView style={{ backgroundColor: "#f9fafb", flex: 1 }}>
-      <View style={{ borderBottomWidth: 1, borderColor: "#e5e7eb", gap: 12, padding: 12 }}>
-        <Text style={{ fontSize: 24, fontWeight: "700" }}>Rune Chat</Text>
+    <SafeAreaView style={{ backgroundColor: colors.background, flex: 1 }}>
+      <View style={{ borderBottomWidth: 1, borderColor: colors.border, gap: 12, padding: 12 }}>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: "700" }}>Rune Chat</Text>
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           <View style={{ flexDirection: "row", gap: 8 }}>
             {sessions.map((session) => {
@@ -22,13 +24,13 @@ export default function ChatScreen() {
                   key={session.id}
                   onPress={() => setActiveSessionId(session.id)}
                   style={{
-                    backgroundColor: active ? "#2563eb" : "#e5e7eb",
+                    backgroundColor: active ? colors.primary : colors.surfaceMuted,
                     borderRadius: 999,
                     paddingHorizontal: 12,
                     paddingVertical: 8,
                   }}
                 >
-                  <Text style={{ color: active ? "#fff" : "#111827" }}>
+                  <Text style={{ color: active ? colors.onPrimary : colors.text }}>
                     {session.preview || session.id.slice(0, 8)}
                   </Text>
                 </Pressable>
@@ -36,9 +38,9 @@ export default function ChatScreen() {
             })}
             <Pressable
               onPress={() => void createSession()}
-              style={{ backgroundColor: "#111827", borderRadius: 999, paddingHorizontal: 12, paddingVertical: 8 }}
+              style={{ backgroundColor: colors.text, borderRadius: 999, paddingHorizontal: 12, paddingVertical: 8 }}
             >
-              <Text style={{ color: "#fff" }}>+ New</Text>
+              <Text style={{ color: colors.background }}>+ New</Text>
             </Pressable>
           </View>
         </ScrollView>
@@ -46,7 +48,7 @@ export default function ChatScreen() {
 
       {sessionsLoading || transcriptLoading ? (
         <View style={{ alignItems: "center", flex: 1, justifyContent: "center" }}>
-          <ActivityIndicator />
+          <ActivityIndicator color={colors.primary} />
         </View>
       ) : (
         <ChatFlatList messages={messages} />

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -2,41 +2,44 @@ import React from "react";
 import { Pressable, SafeAreaView, Text, View } from "react-native";
 import { useNotificationStore } from "../../src/store/notification-store";
 import { useAppStore } from "../../src/store/app-store";
+import { useTheme } from "../../src/hooks/use-theme";
 
 function ToggleCard({
   title,
   description,
   enabled,
   onToggle,
+  colors,
 }: {
   title: string;
   description: string;
   enabled: boolean;
   onToggle: () => void;
+  colors: ReturnType<typeof useTheme>;
 }) {
   return (
     <View
       style={{
-        backgroundColor: "#fff",
-        borderColor: "#e5e7eb",
+        backgroundColor: colors.surface,
+        borderColor: colors.border,
         borderRadius: 16,
         borderWidth: 1,
         gap: 8,
         padding: 16,
       }}
     >
-      <Text style={{ color: "#111827", fontSize: 18, fontWeight: "700" }}>{title}</Text>
-      <Text style={{ color: "#6b7280" }}>{description}</Text>
+      <Text style={{ color: colors.text, fontSize: 18, fontWeight: "700" }}>{title}</Text>
+      <Text style={{ color: colors.textMuted }}>{description}</Text>
       <Pressable
         onPress={onToggle}
         style={{
           alignItems: "center",
-          backgroundColor: enabled ? "#2563eb" : "#e5e7eb",
+          backgroundColor: enabled ? colors.primary : colors.surfaceMuted,
           borderRadius: 12,
           paddingVertical: 12,
         }}
       >
-        <Text style={{ color: enabled ? "#fff" : "#111827", fontWeight: "700" }}>
+        <Text style={{ color: enabled ? colors.onPrimary : colors.text, fontWeight: "700" }}>
           {enabled ? "Enabled" : "Disabled"}
         </Text>
       </Pressable>
@@ -44,25 +47,75 @@ function ToggleCard({
   );
 }
 
+function ThemeCard() {
+  const colors = useTheme();
+  const themePreference = useAppStore((state) => state.themePreference);
+  const setThemePreference = useAppStore((state) => state.setThemePreference);
+  const options = [
+    { label: "Dark", value: "dark" },
+    { label: "Light", value: "light" },
+    { label: "System", value: "system" },
+  ] as const;
+
+  return (
+    <View
+      style={{
+        backgroundColor: colors.surface,
+        borderColor: colors.border,
+        borderRadius: 16,
+        borderWidth: 1,
+        gap: 12,
+        padding: 16,
+      }}
+    >
+      <Text style={{ color: colors.text, fontSize: 18, fontWeight: "700" }}>Theme</Text>
+      <Text style={{ color: colors.textMuted }}>Dark is the default. Switch to light or follow the system theme.</Text>
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        {options.map((option) => {
+          const active = option.value === themePreference;
+          return (
+            <Pressable
+              key={option.value}
+              onPress={() => setThemePreference(option.value)}
+              style={{
+                backgroundColor: active ? colors.primary : colors.surfaceMuted,
+                borderRadius: 999,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+              }}
+            >
+              <Text style={{ color: active ? colors.onPrimary : colors.text, fontWeight: "700" }}>{option.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
 export default function SettingsScreen() {
+  const colors = useTheme();
   const approvalsEnabled = useNotificationStore((state) => state.approvalsEnabled);
   const setApprovalsEnabled = useNotificationStore((state) => state.setApprovalsEnabled);
   const autoTtsEnabled = useAppStore((state) => state.autoTtsEnabled);
   const setAutoTtsEnabled = useAppStore((state) => state.setAutoTtsEnabled);
 
   return (
-    <SafeAreaView style={{ backgroundColor: "#f9fafb", flex: 1 }}>
-      <View style={{ borderBottomWidth: 1, borderColor: "#e5e7eb", gap: 4, padding: 16 }}>
-        <Text style={{ fontSize: 24, fontWeight: "700" }}>Settings</Text>
-        <Text style={{ color: "#6b7280" }}>Notification and voice preferences for operator alerts.</Text>
+    <SafeAreaView style={{ backgroundColor: colors.background, flex: 1 }}>
+      <View style={{ borderBottomWidth: 1, borderColor: colors.border, gap: 4, padding: 16 }}>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: "700" }}>Settings</Text>
+        <Text style={{ color: colors.textMuted }}>Notification, voice, and display preferences for operator alerts.</Text>
       </View>
 
       <View style={{ gap: 12, padding: 16 }}>
+        <ThemeCard />
+
         <ToggleCard
           title="Approval notifications"
           description="Fire a local notification when the pending approval count increases."
           enabled={approvalsEnabled}
           onToggle={() => setApprovalsEnabled(!approvalsEnabled)}
+          colors={colors}
         />
 
         <ToggleCard
@@ -70,6 +123,7 @@ export default function SettingsScreen() {
           description="Automatically play synthesized assistant audio replies when voice mode is enabled."
           enabled={autoTtsEnabled}
           onToggle={() => setAutoTtsEnabled(!autoTtsEnabled)}
+          colors={colors}
         />
       </View>
     </SafeAreaView>

--- a/apps/mobile/src/components/layout/TabBar.tsx
+++ b/apps/mobile/src/components/layout/TabBar.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { Text, View } from "react-native";
 import { BottomTabBar, type BottomTabBarProps } from "@react-navigation/bottom-tabs";
 import { useApprovalsBadge } from "../../hooks/use-approvals-badge";
+import { useTheme } from "../../hooks/use-theme";
 
 export function TabBar(props: BottomTabBarProps) {
+  const colors = useTheme();
   const { count, visible } = useApprovalsBadge();
 
   return (
@@ -21,7 +23,7 @@ export function TabBar(props: BottomTabBarProps) {
           <View
             style={{
               alignItems: "center",
-              backgroundColor: "#dc2626",
+              backgroundColor: colors.danger,
               borderRadius: 999,
               justifyContent: "center",
               minWidth: 20,
@@ -29,7 +31,7 @@ export function TabBar(props: BottomTabBarProps) {
               height: 20,
             }}
           >
-            <Text style={{ color: "#fff", fontSize: 12, fontWeight: "700" }}>{count}</Text>
+            <Text style={{ color: colors.onPrimary, fontSize: 12, fontWeight: "700" }}>{count}</Text>
           </View>
         </View>
       ) : null}

--- a/apps/mobile/src/hooks/use-theme.ts
+++ b/apps/mobile/src/hooks/use-theme.ts
@@ -1,0 +1,18 @@
+import { useColorScheme } from "react-native";
+import { getTheme, type ThemeMode } from "../theme";
+import { useAppStore } from "../store/app-store";
+
+export function useThemePreference(): ThemeMode {
+  const preference = useAppStore((state) => state.themePreference);
+  const systemScheme = useColorScheme();
+
+  if (preference === "system") {
+    return systemScheme === "light" ? "light" : "dark";
+  }
+
+  return preference;
+}
+
+export function useTheme() {
+  return getTheme(useThemePreference());
+}

--- a/apps/mobile/src/store/app-store.ts
+++ b/apps/mobile/src/store/app-store.ts
@@ -1,20 +1,26 @@
 import { create } from "zustand";
 
+export type ThemePreference = "system" | "light" | "dark";
+
 export interface AppPreferences {
   autoTtsEnabled: boolean;
   gatewayUrl: string | null;
+  themePreference: ThemePreference;
 }
 
 interface AppState extends AppPreferences {
   setAutoTtsEnabled: (autoTtsEnabled: boolean) => void;
   setGatewayUrl: (gatewayUrl: string | null) => void;
+  setThemePreference: (themePreference: ThemePreference) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
   autoTtsEnabled: false,
   gatewayUrl: null,
+  themePreference: "dark",
   setAutoTtsEnabled: (autoTtsEnabled) => set({ autoTtsEnabled }),
   setGatewayUrl: (gatewayUrl) => set({ gatewayUrl }),
+  setThemePreference: (themePreference) => set({ themePreference }),
 }));
 
 export function getGatewayUrl(): string | null {
@@ -33,7 +39,15 @@ export function setAutoTtsEnabled(autoTtsEnabled: boolean): void {
   useAppStore.getState().setAutoTtsEnabled(autoTtsEnabled);
 }
 
+export function getThemePreference(): ThemePreference {
+  return useAppStore.getState().themePreference;
+}
+
+export function setThemePreference(themePreference: ThemePreference): void {
+  useAppStore.getState().setThemePreference(themePreference);
+}
+
 export function getAppState(): AppPreferences {
-  const { autoTtsEnabled, gatewayUrl } = useAppStore.getState();
-  return { autoTtsEnabled, gatewayUrl };
+  const { autoTtsEnabled, gatewayUrl, themePreference } = useAppStore.getState();
+  return { autoTtsEnabled, gatewayUrl, themePreference };
 }

--- a/apps/mobile/src/theme.ts
+++ b/apps/mobile/src/theme.ts
@@ -1,0 +1,31 @@
+export const palette = {
+  light: {
+    background: "#f9fafb",
+    surface: "#ffffff",
+    surfaceMuted: "#e5e7eb",
+    border: "#e5e7eb",
+    text: "#111827",
+    textMuted: "#6b7280",
+    primary: "#2563eb",
+    danger: "#dc2626",
+    onPrimary: "#ffffff",
+  },
+  dark: {
+    background: "#030712",
+    surface: "#111827",
+    surfaceMuted: "#1f2937",
+    border: "#374151",
+    text: "#f9fafb",
+    textMuted: "#9ca3af",
+    primary: "#60a5fa",
+    danger: "#f87171",
+    onPrimary: "#030712",
+  },
+} as const;
+
+export type ThemeMode = keyof typeof palette;
+export type ThemeColors = (typeof palette)[ThemeMode];
+
+export function getTheme(mode: ThemeMode): ThemeColors {
+  return palette[mode];
+}


### PR DESCRIPTION
Closes #283

Changes:
- add a mobile theme palette with dark mode as the default
- add settings controls for dark, light, or system theme preference
- wire key mobile screens and the approvals badge to the selected theme