### PR TITLE
feat(provider): improve prompt caching and 429 retries

### DIFF
--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -487,6 +487,18 @@ impl TurnRepo for MemTurnRepo {
         Ok(turn.clone())
     }
 
+    async fn list_usage(
+        &self,
+        _from: Option<chrono::DateTime<chrono::Utc>>,
+        _to: Option<chrono::DateTime<chrono::Utc>>,
+        limit: u32,
+    ) -> Result<Vec<TurnRow>, StoreError> {
+        let mut turns = self.turns.lock().await.clone();
+        turns.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        turns.truncate(limit as usize);
+        Ok(turns)
+    }
+
     async fn mark_stale_failed(&self, _stale_secs: i64) -> Result<u64, StoreError> {
         Ok(0)
     }


### PR DESCRIPTION
Implements the first prompt-caching slice from #368 by making the system prefix deterministic and longer, sorting tool schemas for stable prefix overlap, and improving 429 Retry-After handling to respect HTTP-date values and retry only rate limits with exponential backoff.\n\nCloses #370\nRefs #371