### PR TITLE
feat(runtime): fix retry metrics build regression (#371)

### DIFF
--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -39,7 +39,7 @@ use crate::ms365::{
 };
 use crate::pairing::DeviceRegistry;
 use crate::routes;
-use crate::state::{AppState, SessionEvent};
+use crate::state::{AppState, SessionEvent, TokenMetricsStore};
 use crate::supervisor::{BackgroundSupervisor, SupervisorDeps};
 use crate::webchat;
 use crate::ws;
@@ -279,6 +279,7 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         ms365_files_service: services.ms365_files_service,
         ms365_users_service: services.ms365_users_service,
         comms_client,
+        token_metrics: TokenMetricsStore::new(),
     };
 
     // Build operator delivery for heartbeat/scheduled output to Telegram.

--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -918,12 +918,8 @@ impl TurnExecutor {
 
             usage.add(&response.usage);
             if let Some(recorder) = &self.usage_recorder {
-                recorder(
-                    self.model_provider.name().to_string(),
-                    active_model.clone(),
-                    response.usage.clone(),
-                )
-                .await;
+                let (provider, model) = provider_and_model_for_log(&request);
+                recorder(provider.to_string(), model.to_string(), response.usage.clone()).await;
             }
 
             // If model returned tool calls → execute them and loop


### PR DESCRIPTION
Closes #371

Changes:
- fix usage recorder metadata capture in TurnExecutor retry path by deriving provider/model from the request instead of nonexistent variables
- initialize gateway AppState token_metrics store so the build succeeds with the new admin token metrics route
- validate with cargo check