### PR TITLE
feat(provider): split stable prompt prefix from turn messages (#370)

### DIFF
--- a/crates/rune-models/src/types.rs
+++ b/crates/rune-models/src/types.rs
@@ -59,9 +59,9 @@ pub struct FunctionDefinition {
 /// Request to a model provider.
 #[derive(Clone, Debug, Serialize)]
 pub struct CompletionRequest {
-    pub messages: Vec<ChatMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stable_prefix_messages: Option<Vec<ChatMessage>>,
+    pub messages: Vec<ChatMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rune-models/tests/provider_tests.rs
+++ b/crates/rune-models/tests/provider_tests.rs
@@ -1733,6 +1733,7 @@ async fn foundry_openai_request_golden_shape() {
 
     let p = AzureFoundryProvider::with_api_version(&server.uri(), "my-foundry-key", "2024-05-01");
     let request = CompletionRequest {
+        stable_prefix_messages: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -1850,6 +1851,7 @@ async fn foundry_anthropic_extracts_system_message() {
 
     let p = AzureFoundryProvider::new(&server.uri(), "key");
     let request = CompletionRequest {
+        stable_prefix_messages: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -1962,6 +1964,7 @@ async fn foundry_anthropic_request_golden_shape() {
 
     let p = AzureFoundryProvider::with_api_version(&server.uri(), "my-foundry-key", "2023-06-01");
     let request = CompletionRequest {
+        stable_prefix_messages: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -2144,6 +2147,7 @@ fn anthropic_error_body(error_type: &str, message: &str) -> serde_json::Value {
 
 fn claude_request() -> CompletionRequest {
     CompletionRequest {
+        stable_prefix_messages: None,
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
@@ -2445,7 +2449,9 @@ async fn azure_maps_retry_after_http_date() {
     let p = AzureOpenAiProvider::new(&server.uri(), "dep", "2024-06-01", "k");
     let err = p.complete(&simple_request()).await.unwrap_err();
     match err {
-        ModelError::RateLimited { retry_after_secs, .. } => {
+        ModelError::RateLimited {
+            retry_after_secs, ..
+        } => {
             assert!(retry_after_secs.is_some());
         }
         other => panic!("expected RateLimited, got {other:?}"),

--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -58,7 +58,18 @@ pub struct TurnExecutor {
     /// Global approval mode — "yolo" auto-approves all tool calls.
     approval_mode: String,
     agent_registry: Option<Arc<crate::agent_registry::AgentRegistry>>,
-    usage_recorder: Option<Arc<dyn Fn(String, String, Usage) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> + Send + Sync>>,
+    usage_recorder: Option<
+        Arc<
+            dyn Fn(
+                    String,
+                    String,
+                    Usage,
+                )
+                    -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+                + Send
+                + Sync,
+        >,
+    >,
 }
 
 impl TurnExecutor {
@@ -361,7 +372,12 @@ impl TurnExecutor {
         let cached_prompt_tokens = i32::try_from(usage.cached_prompt_tokens).ok();
         let _ = self
             .turn_repo
-            .update_usage(turn.id, prompt_tokens, completion_tokens, cached_prompt_tokens)
+            .update_usage(
+                turn.id,
+                prompt_tokens,
+                completion_tokens,
+                cached_prompt_tokens,
+            )
             .await?;
 
         // 5. Finalize turn status
@@ -685,7 +701,12 @@ impl TurnExecutor {
         let cached_prompt_tokens = i32::try_from(usage.cached_prompt_tokens).ok();
         let _ = self
             .turn_repo
-            .update_usage(turn_uuid, prompt_tokens, completion_tokens, cached_prompt_tokens)
+            .update_usage(
+                turn_uuid,
+                prompt_tokens,
+                completion_tokens,
+                cached_prompt_tokens,
+            )
             .await?;
 
         let (final_status, ended_at, approval_status, approval_summary) = match &result {
@@ -846,7 +867,6 @@ impl TurnExecutor {
                 Some(&memory_context),
                 &extra_system_sections,
             );
-            let stable_prefix_messages = messages.first().cloned().map(|message| vec![message]);
 
             // Build tool definitions for the request
             let mut tool_defs: Vec<rune_models::ToolDefinition> = self
@@ -867,9 +887,10 @@ impl TurnExecutor {
             // Azure automatic prefix caching.
             tool_defs.sort_by(|a, b| a.function.name.cmp(&b.function.name));
 
+            let stable_prefix_messages = messages.first().cloned().map(|message| vec![message]);
             let request = CompletionRequest {
-                messages,
                 stable_prefix_messages,
+                messages: messages.into_iter().skip(1).collect(),
                 model: model_ref.map(str::to_owned),
                 temperature: None,
                 max_tokens: None,
@@ -919,7 +940,12 @@ impl TurnExecutor {
             usage.add(&response.usage);
             if let Some(recorder) = &self.usage_recorder {
                 let (provider, model) = provider_and_model_for_log(&request);
-                recorder(provider.to_string(), model.to_string(), response.usage.clone()).await;
+                recorder(
+                    provider.to_string(),
+                    model.to_string(),
+                    response.usage.clone(),
+                )
+                .await;
             }
 
             // If model returned tool calls → execute them and loop
@@ -1190,7 +1216,9 @@ impl TurnExecutor {
             match self.model_provider.complete(request).await {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    if attempt < MAX_RETRIES && matches!(e, rune_models::ModelError::RateLimited { .. }) {
+                    if attempt < MAX_RETRIES
+                        && matches!(e, rune_models::ModelError::RateLimited { .. })
+                    {
                         let initial_delay = match &e {
                             rune_models::ModelError::RateLimited {
                                 retry_after_secs: Some(ra),

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use rune_core::{SessionKind, SessionStatus, ToolCategory};
 use rune_models::{
     CompletionRequest, CompletionResponse, FinishReason, FunctionCall, ModelError, ModelProvider,
-    ToolCallRequest, Usage,
+    Role, ToolCallRequest, Usage,
 };
 use rune_store::StoreError;
 use rune_store::models::*;
@@ -2485,7 +2485,10 @@ async fn resumed_session_notice_skips_non_restored_sessions() {
         .await;
 
     let sent = sent.lock().await.clone();
-    assert!(sent.is_empty(), "notice should not be sent for sessions that were not restored during startup");
+    assert!(
+        sent.is_empty(),
+        "notice should not be sent for sessions that were not restored during startup"
+    );
 }
 
 #[tokio::test]
@@ -2568,7 +2571,10 @@ async fn create_session_full_persists_mode_in_metadata() {
         .unwrap();
 
     assert_eq!(
-        session.metadata.get("mode").and_then(|value| value.as_str()),
+        session
+            .metadata
+            .get("mode")
+            .and_then(|value| value.as_str()),
         Some("architect")
     );
 }
@@ -2618,7 +2624,10 @@ async fn prompt_prefix_is_stable_across_consecutive_turns() {
     );
 
     executor.execute(session.id, "hello", None).await.unwrap();
-    executor.execute(session.id, "follow-up", None).await.unwrap();
+    executor
+        .execute(session.id, "follow-up", None)
+        .await
+        .unwrap();
 
     let requests = model_handle.requests().await;
     assert!(requests.len() >= 2);
@@ -2627,4 +2636,48 @@ async fn prompt_prefix_is_stable_across_consecutive_turns() {
     let second_system = requests[1].messages[0].content.clone().unwrap();
     assert_eq!(first_system, second_system);
     assert!(first_system.contains("## Prompt Cache Padding"));
+}
+
+#[tokio::test]
+async fn request_stable_prefix_is_split_from_variable_messages() {
+    let h = TestHarness::new();
+    let engine = h.session_engine();
+    let session = engine
+        .create_session(
+            SessionKind::Direct,
+            Some(h.workspace_root.to_string_lossy().to_string()),
+        )
+        .await
+        .unwrap();
+
+    let model = Arc::new(FakeModelProvider::new(vec![
+        FakeModelProvider::text_response("ok"),
+    ]));
+    let model_handle = model.clone();
+    let executor = h.turn_executor(
+        model,
+        Arc::new(FakeToolExecutor::new(vec![])),
+        ToolRegistry::new(),
+    );
+
+    executor.execute(session.id, "hello", None).await.unwrap();
+
+    let requests = model_handle.requests().await;
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+
+    let stable = request.stable_prefix_messages.as_ref().unwrap();
+    assert_eq!(stable.len(), 1);
+    assert_eq!(stable[0].role, Role::System);
+    assert!(
+        stable[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .contains("## Prompt Cache Padding")
+    );
+
+    assert!(!request.messages.is_empty());
+    assert_eq!(request.messages[0].role, Role::User);
+    assert_eq!(request.messages[0].content.as_deref(), Some("hello"));
 }


### PR DESCRIPTION
Closes #370

Changes:
- move the stable system prompt into  instead of duplicating it in 
- keep variable turn content in  so Azure/OpenAI requests preserve a deterministic cached prefix
- add runtime and provider test coverage for the prefix split