### PR TITLE
feat(provider): stabilize prompt prefix tool payloads (#370)

### DIFF
--- a/crates/rune-models/src/provider/azure.rs
+++ b/crates/rune-models/src/provider/azure.rs
@@ -81,7 +81,7 @@ impl ModelProvider for AzureOpenAiProvider {
                 .collect(),
             temperature: request.temperature,
             max_tokens: request.max_tokens,
-            tools: &request.tools,
+            tools: &request.stable_prefix_tools.as_ref().or(request.tools.as_ref()).cloned(),
         };
 
         debug!(url = %self.url, msg_count = body.messages.len(), "Azure OpenAI completion request");

--- a/crates/rune-models/src/provider/openai.rs
+++ b/crates/rune-models/src/provider/openai.rs
@@ -175,7 +175,7 @@ impl ModelProvider for OpenAiProvider {
             model: &request.model,
             temperature: &request.temperature,
             max_completion_tokens: request.max_tokens,
-            tools: &request.tools,
+            tools: &request.stable_prefix_tools.as_ref().or(request.tools.as_ref()).cloned(),
             stream: false,
             stream_options: None,
         };
@@ -215,7 +215,7 @@ impl ModelProvider for OpenAiProvider {
             model: &request.model,
             temperature: &request.temperature,
             max_completion_tokens: request.max_tokens,
-            tools: &request.tools,
+            tools: &request.stable_prefix_tools.as_ref().or(request.tools.as_ref()).cloned(),
             stream: true,
             stream_options: Some(StreamOptions {
                 include_usage: true,

--- a/crates/rune-models/src/types.rs
+++ b/crates/rune-models/src/types.rs
@@ -61,6 +61,8 @@ pub struct FunctionDefinition {
 pub struct CompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stable_prefix_messages: Option<Vec<ChatMessage>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable_prefix_tools: Option<Vec<ToolDefinition>>,
     pub messages: Vec<ChatMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,

--- a/crates/rune-models/tests/provider_tests.rs
+++ b/crates/rune-models/tests/provider_tests.rs
@@ -27,6 +27,7 @@ fn simple_request() -> CompletionRequest {
             tool_calls: None,
         }],
         stable_prefix_messages: None,
+        stable_prefix_tools: None,
         model: Some("gpt-4o".into()),
         temperature: None,
         max_tokens: None,
@@ -260,6 +261,7 @@ async fn azure_request_golden_shape_full() {
                 tool_calls: None,
             },
         ],
+        stable_prefix_tools: None,
         stable_prefix_messages: Some(vec![ChatMessage {
             role: Role::System,
             content: Some("You are helpful.".into()),
@@ -1734,6 +1736,7 @@ async fn foundry_openai_request_golden_shape() {
     let p = AzureFoundryProvider::with_api_version(&server.uri(), "my-foundry-key", "2024-05-01");
     let request = CompletionRequest {
         stable_prefix_messages: None,
+        stable_prefix_tools: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -1852,6 +1855,7 @@ async fn foundry_anthropic_extracts_system_message() {
     let p = AzureFoundryProvider::new(&server.uri(), "key");
     let request = CompletionRequest {
         stable_prefix_messages: None,
+        stable_prefix_tools: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -1965,6 +1969,7 @@ async fn foundry_anthropic_request_golden_shape() {
     let p = AzureFoundryProvider::with_api_version(&server.uri(), "my-foundry-key", "2023-06-01");
     let request = CompletionRequest {
         stable_prefix_messages: None,
+        stable_prefix_tools: None,
         messages: vec![
             ChatMessage {
                 role: Role::System,
@@ -2148,6 +2153,7 @@ fn anthropic_error_body(error_type: &str, message: &str) -> serde_json::Value {
 fn claude_request() -> CompletionRequest {
     CompletionRequest {
         stable_prefix_messages: None,
+        stable_prefix_tools: None,
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
@@ -2477,6 +2483,7 @@ async fn azure_request_prepends_stable_prefix_messages() {
             tool_call_id: None,
             tool_calls: None,
         }],
+        stable_prefix_tools: None,
         stable_prefix_messages: Some(vec![ChatMessage {
             role: Role::System,
             content: Some("Stable prefix".into()),
@@ -2519,6 +2526,7 @@ async fn openai_request_prepends_stable_prefix_messages() {
             tool_call_id: None,
             tool_calls: None,
         }],
+        stable_prefix_tools: None,
         stable_prefix_messages: Some(vec![ChatMessage {
             role: Role::System,
             content: Some("Stable prefix".into()),

--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -888,17 +888,19 @@ impl TurnExecutor {
             tool_defs.sort_by(|a, b| a.function.name.cmp(&b.function.name));
 
             let stable_prefix_messages = messages.first().cloned().map(|message| vec![message]);
+            let stable_prefix_tools = if tool_defs.is_empty() {
+                None
+            } else {
+                Some(tool_defs.clone())
+            };
             let request = CompletionRequest {
                 stable_prefix_messages,
+                stable_prefix_tools,
                 messages: messages.into_iter().skip(1).collect(),
                 model: model_ref.map(str::to_owned),
                 temperature: None,
                 max_tokens: None,
-                tools: if tool_defs.is_empty() {
-                    None
-                } else {
-                    Some(tool_defs)
-                },
+                tools: None,
             };
 
             // Call model — try streaming when a chunk sender is available,

--- a/crates/rune-runtime/src/mem0.rs
+++ b/crates/rune-runtime/src/mem0.rs
@@ -372,6 +372,7 @@ impl Mem0Engine {
                 },
             ],
             stable_prefix_messages: None,
+        stable_prefix_tools: None,
             model: Some(self.config.extraction_model.clone()),
             temperature: Some(0.0),
             max_tokens: Some(1024),

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2681,3 +2681,47 @@ async fn request_stable_prefix_is_split_from_variable_messages() {
     assert_eq!(request.messages[0].role, Role::User);
     assert_eq!(request.messages[0].content.as_deref(), Some("hello"));
 }
+
+#[tokio::test]
+async fn request_stable_prefix_keeps_tools_out_of_variable_tail() {
+    let h = TestHarness::new();
+    let engine = h.session_engine();
+    let session = engine
+        .create_session(
+            SessionKind::Direct,
+            Some(h.workspace_root.to_string_lossy().to_string()),
+        )
+        .await
+        .unwrap();
+
+    let mut registry = ToolRegistry::new();
+    registry.register(RtToolDefinition {
+        name: "zeta_tool".into(),
+        description: "zeta".into(),
+        parameters: serde_json::json!({"type":"object"}),
+        category: ToolCategory::FileRead,
+        requires_approval: false,
+    });
+    registry.register(RtToolDefinition {
+        name: "alpha_tool".into(),
+        description: "alpha".into(),
+        parameters: serde_json::json!({"type":"object"}),
+        category: ToolCategory::FileRead,
+        requires_approval: false,
+    });
+
+    let model = Arc::new(FakeModelProvider::new(vec![FakeModelProvider::text_response("ok")]));
+    let model_handle = model.clone();
+    let executor = h.turn_executor(model, Arc::new(FakeToolExecutor::new(vec![])), registry);
+
+    executor.execute(session.id, "hello", None).await.unwrap();
+
+    let requests = model_handle.requests().await;
+    let request = &requests[0];
+    let stable_tools = request.stable_prefix_tools.as_ref().unwrap();
+    assert_eq!(stable_tools.len(), 2);
+    assert_eq!(stable_tools[0].function.name, "alpha_tool");
+    assert_eq!(stable_tools[1].function.name, "zeta_tool");
+    assert!(request.tools.is_none());
+    assert_eq!(request.messages[0].role, Role::User);
+}


### PR DESCRIPTION
Closes #370

Changes:
- move tool definitions into the stable prefix request segment for deterministic prompt assembly
- keep variable turn messages separate from the cached prefix payload
- add runtime/provider tests covering stable prefix tool ordering and request shaping