### PR TITLE
feat(runtime): restore restart notice state on startup (#284)

### DIFF
--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -125,32 +125,28 @@ impl SessionLoop {
         self
     }
 
+    pub(crate) async fn run_startup_restore(&self) -> Result<(), RuntimeError> {
+        let sessions = self.session_repo.list_active_channel_sessions().await?;
+        let mut index = self.sessions.lock().await;
+        let mut restored = self.restored_session_routes.lock().await;
+        for session in &sessions {
+            if let Some(ref channel_ref) = session.channel_ref {
+                index.insert(channel_ref.clone(), session.id);
+                restored.insert(channel_ref.clone(), session.last_activity_at.to_rfc3339());
+            }
+        }
+        if !sessions.is_empty() {
+            info!(count = sessions.len(), "restored active channel sessions from DB");
+        }
+        Ok(())
+    }
+
     /// Run the session loop forever, processing inbound events.
     pub async fn run(&self) -> Result<(), RuntimeError> {
         // Pre-populate the session index from DB so existing Channel
         // sessions resume after a gateway restart.
-        match self.session_repo.list_active_channel_sessions().await {
-            Ok(sessions) => {
-                let mut index = self.sessions.lock().await;
-                for session in &sessions {
-                    if let Some(ref channel_ref) = session.channel_ref {
-                        index.insert(channel_ref.clone(), session.id);
-                        self.restored_session_routes
-                            .lock()
-                            .await
-                            .insert(channel_ref.clone(), session.last_activity_at.to_rfc3339());
-                    }
-                }
-                if !sessions.is_empty() {
-                    info!(
-                        count = sessions.len(),
-                        "restored active channel sessions from DB"
-                    );
-                }
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to restore channel sessions from DB, starting fresh");
-            }
+        if let Err(e) = self.run_startup_restore().await {
+            warn!(error = %e, "failed to restore channel sessions from DB, starting fresh");
         }
 
         info!("session loop started, waiting for inbound events");

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2495,7 +2495,7 @@ async fn resumed_session_notice_skips_non_restored_sessions() {
 async fn resumed_session_notice_only_for_restored_channel_sessions() {
     let h = TestHarness::new();
     let engine = Arc::new(h.session_engine());
-    let existing = engine
+    let created = engine
         .create_session_full(
             SessionKind::Channel,
             Some(h.workspace_root.to_string_lossy().to_string()),
@@ -2530,6 +2530,16 @@ async fn resumed_session_notice_only_for_restored_channel_sessions() {
         timestamp: chrono::Utc::now(),
         provider_message_id: "msg-1".to_string(),
     };
+
+    let existing = h
+        .session_repo
+        .find_by_channel_ref("chat-1:user-1")
+        .await
+        .unwrap()
+        .expect("restored channel session");
+    assert_eq!(existing.id, created.id);
+
+    session_loop.run_startup_restore().await.unwrap();
 
     session_loop
         .maybe_send_resumed_session_notice(&msg, "chat-1:user-1", &existing)


### PR DESCRIPTION
Closes #284

Changes:
- factor channel-session startup restore into a reusable helper
- repopulate restored-session routing state before resumed-session notices
- cover restart notice behavior with the persisted-session test path