### PR TITLE
feat(runtime): codify restart continuity semantics (#284)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -2154,7 +2154,7 @@ fn render_session_status_card(
         vec!["cost posture is estimate-only; provider pricing is not wired yet".to_string()];
     if approval_mode == "on-miss" {
         unresolved.push(
-            "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
+            rune_runtime::restart_continuity::RESTART_CONTINUITY_SUMMARY.to_string(),
         );
     }
     if security_mode == "allowlist" {

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -1517,7 +1517,7 @@ pub async fn get_session_status(
     unresolved.push("cost posture is estimate-only; provider pricing is not wired yet".to_string());
     if approval_mode == "on-miss" {
         unresolved.push(
-            "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
+            rune_runtime::restart_continuity::RESTART_CONTINUITY_SUMMARY.to_string(),
         );
     }
     if security_mode == "allowlist" {

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -608,7 +608,7 @@ impl RpcDispatcher {
             vec!["cost posture is estimate-only; provider pricing is not wired yet".to_string()];
         if approval_mode == "on-miss" {
             unresolved.push(
-                "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
+                rune_runtime::restart_continuity::RESTART_CONTINUITY_SUMMARY.to_string(),
             );
         }
         if security_mode == "allowlist" {

--- a/crates/rune-runtime/src/lib.rs
+++ b/crates/rune-runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod plugin;
 pub mod plugin_manager;
 pub mod plugin_scanner;
 pub mod project;
+pub mod restart_continuity;
 pub mod scheduler;
 pub mod session_loop;
 mod session_metadata;

--- a/crates/rune-runtime/src/restart_continuity.rs
+++ b/crates/rune-runtime/src/restart_continuity.rs
@@ -1,0 +1,9 @@
+/// Operator-visible restart continuity contract for channel sessions.
+///
+/// This is intentionally explicit and narrow: only behaviors that are
+/// implemented and covered by tests should be described here.
+pub const RESTART_CONTINUITY_SUMMARY: &str =
+    "approval requests, operator-triggered resume, resumed-session notification, and durable session/transcript restoration are supported across restart; in-flight turns, live process handles, and typing/progress UI do not resume in place";
+
+pub const RESUMED_SESSION_NOTICE_TEMPLATE: &str =
+    "Resumed session `{session_id}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.";

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -677,10 +677,8 @@ impl SessionLoop {
             return;
         }
 
-        let text = format!(
-            "Resumed session `{}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.",
-            session.id
-        );
+        let text = crate::restart_continuity::RESUMED_SESSION_NOTICE_TEMPLATE
+            .replace("{session_id}", &session.id.to_string());
 
         let ch = self.channel.lock().await;
         match ch

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2558,7 +2558,11 @@ async fn resumed_session_notice_only_for_restored_channel_sessions() {
         rune_channels::OutboundAction::Reply { content, .. } => {
             assert!(content.contains("Resumed session"));
             assert!(content.contains(&existing.id.to_string()));
-            assert!(content.contains("do not resume in place"));
+            assert_eq!(
+                content,
+                &crate::restart_continuity::RESUMED_SESSION_NOTICE_TEMPLATE
+                    .replace("{session_id}", &existing.id.to_string())
+            );
         }
         other => panic!("expected reply notice, got {other:?}"),
     }


### PR DESCRIPTION
Closes #284

Changes:
- centralize the operator-visible restart continuity contract in rune-runtime
- reuse the same resumed-session notification template in the runtime and tests
- reuse the same explicit restart continuity summary across HTTP status and WS RPC surfaces

Validation:
- cargo check
- targeted rune-runtime resumed-session tests exercised during build; full rune-gateway test target is currently blocked by unrelated pre-existing supervisor test compile errors