### PR TITLE
docs(runtime): clarify partial restart continuity (#284)

### DIFF
--- a/crates/rune-runtime/src/restart_continuity.rs
+++ b/crates/rune-runtime/src/restart_continuity.rs
@@ -3,7 +3,7 @@
 /// This is intentionally explicit and narrow: only behaviors that are
 /// implemented and covered by tests should be described here.
 pub const RESTART_CONTINUITY_SUMMARY: &str =
-    "approval requests, operator-triggered resume, resumed-session notification, and durable session/transcript restoration are supported across restart; in-flight turns, live process handles, and typing/progress UI do not resume in place";
+    "restart continuity is intentionally partial: durable approval requests, operator-triggered resume, resumed-session notification, and session/transcript restoration are supported across restart; in-flight turns, live process handles, and typing/progress UI do not resume in place";
 
 pub const RESUMED_SESSION_NOTICE_TEMPLATE: &str =
     "Resumed session `{session_id}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.";


### PR DESCRIPTION
Closes #284

Changes:
- clarify the operator-facing restart continuity summary as intentionally partial
- keep the shipped guarantees explicit: durable approvals, operator-triggered resume, resumed-session notice, and session/transcript restoration
- keep the non-guarantees explicit: in-flight turns, live process handles, and typing/progress UI do not resume in place