### PR TITLE
docs(spells): clarify evolver scaffold status (#306)

### DIFF
--- a/docs/reference/SPELLS.md
+++ b/docs/reference/SPELLS.md
@@ -14,4 +14,5 @@ Spell manifests live under `crates/rune-spells/*/SPELL.md`. The inventory below 
 ## Notes
 
 - `Code Review` is intentionally documented as partial: mechanical checks ship today, while semantic review is still scaffolded behind the same tool contract.
+- `Evolver` is currently scaffold-only: the spell manifest exists, but the stable operator-facing tool surface is not exposed yet.
 - The inventory only lists Rune-native spells that are part of the Rust workspace. Prompt-only skills under `.state/skills/` are tracked separately from this spell inventory.


### PR DESCRIPTION
Closes #306

Changes:
- clarify in the spell inventory that Evolver is scaffold-only today
- make the operator-facing note match the existing manifest/inventory row
- avoid implying a stable exposed tool surface that does not exist yet