### PR TITLE
feat(tools): tighten context budget tool schemas (#397)

### DIFF
--- a/crates/rune-tools/src/context_budget_tool.rs
+++ b/crates/rune-tools/src/context_budget_tool.rs
@@ -5,10 +5,17 @@ use crate::definition::ToolDefinition;
 pub fn context_budget_tool_definition() -> ToolDefinition {
     ToolDefinition {
         name: "context_budget".into(),
-        description: "Report current context budget usage across runtime partitions.".into(),
+        description: "Report current context budget usage across runtime partitions, including overall usage, partition-level distribution, and recent compaction/checkpoint timestamps.".into(),
         parameters: serde_json::json!({
             "type": "object",
-            "properties": {}
+            "properties": {
+                "include_partitions": {
+                    "type": "boolean",
+                    "description": "Whether to include per-partition usage details in the report",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
         }),
         category: ToolCategory::MemoryAccess,
         requires_approval: false,
@@ -18,19 +25,29 @@ pub fn context_budget_tool_definition() -> ToolDefinition {
 pub fn context_checkpoint_tool_definition() -> ToolDefinition {
     ToolDefinition {
         name: "context_checkpoint".into(),
-        description: "Create a persistent pre-compaction checkpoint with task status, key decisions, and next step.".into(),
+        description: "Create a persistent pre-compaction checkpoint that records current task status, key decisions, and the immediate next step for restart continuity.".into(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {
-                "status": { "type": "string", "description": "Current task progress summary" },
+                "status": {
+                    "type": "string",
+                    "description": "Current task progress summary",
+                    "minLength": 1
+                },
                 "key_decisions": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Significant decisions made so far"
+                    "description": "Significant decisions made so far",
+                    "default": []
                 },
-                "next_step": { "type": "string", "description": "Immediate next action required" }
+                "next_step": {
+                    "type": "string",
+                    "description": "Immediate next action required",
+                    "minLength": 1
+                }
             },
-            "required": ["status", "next_step"]
+            "required": ["status", "next_step"],
+            "additionalProperties": false
         }),
         category: ToolCategory::MemoryAccess,
         requires_approval: false,
@@ -40,15 +57,22 @@ pub fn context_checkpoint_tool_definition() -> ToolDefinition {
 pub fn context_gc_tool_definition() -> ToolDefinition {
     ToolDefinition {
         name: "context_gc".into(),
-        description: "Trigger context garbage collection and partition-aware compaction.".into(),
+        description: "Trigger context garbage collection and partition-aware compaction, optionally using more aggressive cleanup heuristics when budgets are under pressure.".into(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {
                 "aggressive": {
                     "type": "boolean",
-                    "description": "Whether to use more aggressive compaction heuristics"
+                    "description": "Whether to use more aggressive compaction heuristics",
+                    "default": false
+                },
+                "create_checkpoint": {
+                    "type": "boolean",
+                    "description": "Whether to create a continuity checkpoint before compaction",
+                    "default": true
                 }
-            }
+            },
+            "additionalProperties": false
         }),
         category: ToolCategory::MemoryAccess,
         requires_approval: false,


### PR DESCRIPTION
Closes #397

Changes:
- expand context budget tool descriptions to better describe runtime output and intent
- tighten JSON schemas with explicit defaults, minLength constraints, and additionalProperties=false
- add optional flags for partition detail and checkpoint behavior to align with agent/UI expectations