### PR TITLE
feat(tools): register comms_send and comms_read as model-callable tools

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -1374,6 +1374,33 @@ impl CommsOps for CommsClientOps {
     ) -> Result<String, String> {
         self.client.send(msg_type, subject, body, priority).await
     }
+
+    async fn read_inbox(
+        &self,
+        mark_read: bool,
+    ) -> Result<Vec<rune_tools::comms_tool::CommsMessageSummary>, String> {
+        let messages = self.client.read_inbox().await;
+        let mut summaries = Vec::with_capacity(messages.len());
+
+        for (path, msg) in &messages {
+            summaries.push(rune_tools::comms_tool::CommsMessageSummary {
+                id: msg.id.clone(),
+                from: msg.from.clone(),
+                subject: msg.subject.clone(),
+                body: msg.body.clone(),
+                priority: msg.priority.clone(),
+                created_at: msg.created_at.clone(),
+            });
+
+            if mark_read {
+                if let Err(e) = self.client.archive(path).await {
+                    tracing::warn!(error = %e, "failed to archive comms message after read");
+                }
+            }
+        }
+
+        Ok(summaries)
+    }
 }
 
 struct AppToolExecutor {
@@ -1700,10 +1727,10 @@ impl ToolExecutor for AppToolExecutor {
                     .execute(call)
                     .await
             }
-            "comms_send" => match &self.comms {
+            "comms_send" | "comms_read" => match &self.comms {
                 Some(comms) => comms.execute(call).await,
                 None => Err(ToolError::UnknownTool {
-                    name: "comms_send".to_string(),
+                    name: call.tool_name.clone(),
                 }),
             },
             other if other.contains("__") => match &self.mcp {

--- a/crates/rune-tools/src/comms_tool.rs
+++ b/crates/rune-tools/src/comms_tool.rs
@@ -1,12 +1,24 @@
-//! Inter-agent comms tool — lets the agent send messages to peer agents.
+//! Inter-agent comms tool — lets the agent send and receive messages to/from peer agents.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rune_core::ToolCategory;
 
-use crate::definition::{ToolCall, ToolResult};
+use crate::definition::{ToolCall, ToolDefinition, ToolResult};
 use crate::error::ToolError;
 use crate::executor::ToolExecutor;
+
+/// A summary of a received comms message (for returning to the model).
+#[derive(serde::Serialize)]
+pub struct CommsMessageSummary {
+    pub id: String,
+    pub from: String,
+    pub subject: String,
+    pub body: String,
+    pub priority: String,
+    pub created_at: Option<String>,
+}
 
 /// Trait for comms operations, implemented by the runtime layer.
 #[async_trait]
@@ -20,9 +32,15 @@ pub trait CommsOps: Send + Sync {
         body: &str,
         priority: &str,
     ) -> Result<String, String>;
+
+    /// Read messages from inbox. Returns summaries and optionally archives them.
+    async fn read_inbox(
+        &self,
+        mark_read: bool,
+    ) -> Result<Vec<CommsMessageSummary>, String>;
 }
 
-/// Tool executor for inter-agent comms.
+/// Tool executor for inter-agent comms (handles both comms_send and comms_read).
 pub struct CommsToolExecutor<C: CommsOps> {
     comms: Arc<C>,
 }
@@ -36,6 +54,16 @@ impl<C: CommsOps> CommsToolExecutor<C> {
 #[async_trait]
 impl<C: CommsOps> ToolExecutor for CommsToolExecutor<C> {
     async fn execute(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
+        match call.tool_name.as_str() {
+            "comms_send" => self.handle_send(call).await,
+            "comms_read" => self.handle_read(call).await,
+            other => Err(ToolError::UnknownTool { name: other.to_string() }),
+        }
+    }
+}
+
+impl<C: CommsOps> CommsToolExecutor<C> {
+    async fn handle_send(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
         let args = &call.arguments;
         let to = args
             .get("to")
@@ -75,6 +103,96 @@ impl<C: CommsOps> ToolExecutor for CommsToolExecutor<C> {
             ))),
         }
     }
+
+    async fn handle_read(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
+        let mark_read = call
+            .arguments
+            .get("mark_read")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        match self.comms.read_inbox(mark_read).await {
+            Ok(messages) => {
+                let output = if messages.is_empty() {
+                    "No unread messages in inbox.".to_string()
+                } else {
+                    let count = messages.len();
+                    let json = serde_json::to_string_pretty(&messages)
+                        .unwrap_or_else(|_| format!("{count} messages (serialization failed)"));
+                    format!("{count} message(s) in inbox:\n{json}")
+                };
+                Ok(ToolResult {
+                    tool_call_id: call.tool_call_id,
+                    output,
+                    is_error: false,
+                    tool_execution_id: None,
+                })
+            }
+            Err(e) => Err(ToolError::ExecutionFailed(format!(
+                "comms read failed: {e}"
+            ))),
+        }
+    }
+}
+
+/// Tool definition for `comms_send` — send a message to a peer agent.
+pub fn comms_send_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "comms_send".into(),
+        description: "Send a message to a peer agent (e.g. OpenClaw). The message is delivered \
+            as a JSON file to the peer's inbox directory and will be picked up on the next poll."
+            .into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "to": {
+                    "type": "string",
+                    "description": "Recipient agent ID (e.g. 'openclaw'). Defaults to 'horizon-ai'."
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "Message subject line."
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Message body content."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Message type: 'status', 'request', 'question', 'directive'. Defaults to 'status'."
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Priority: 'p0' (urgent), 'p1' (normal), 'p2' (low). Defaults to 'p1'."
+                }
+            },
+            "required": ["body"]
+        }),
+        category: ToolCategory::External,
+        requires_approval: false,
+    }
+}
+
+/// Tool definition for `comms_read` — check inbox for messages from peer agents.
+pub fn comms_read_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "comms_read".into(),
+        description: "Check your comms inbox for messages from peer agents (e.g. OpenClaw). \
+            Returns unread messages as JSON. Use this to check if OpenClaw or other agents have \
+            sent you directives, questions, or status updates."
+            .into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "mark_read": {
+                    "type": "boolean",
+                    "description": "Move processed messages to an archive subfolder. Defaults to true."
+                }
+            }
+        }),
+        category: ToolCategory::External,
+        requires_approval: false,
+    }
 }
 
 #[cfg(test)]
@@ -96,12 +214,26 @@ mod tests {
         ) -> Result<String, String> {
             Ok(format!("msg-test-{subject}"))
         }
+
+        async fn read_inbox(
+            &self,
+            _mark_read: bool,
+        ) -> Result<Vec<CommsMessageSummary>, String> {
+            Ok(vec![CommsMessageSummary {
+                id: "msg-001".to_string(),
+                from: "openclaw".to_string(),
+                subject: "test directive".to_string(),
+                body: "Please fix CI".to_string(),
+                priority: "p1".to_string(),
+                created_at: Some("2026-03-27T12:00:00Z".to_string()),
+            }])
+        }
     }
 
-    fn make_call(args: serde_json::Value) -> ToolCall {
+    fn make_call(name: &str, args: serde_json::Value) -> ToolCall {
         ToolCall {
             tool_call_id: ToolCallId::new(),
-            tool_name: "comms_send".into(),
+            tool_name: name.into(),
             arguments: args,
         }
     }
@@ -109,7 +241,7 @@ mod tests {
     #[tokio::test]
     async fn send_returns_message_id() {
         let exec = CommsToolExecutor::new(Arc::new(MockComms));
-        let call = make_call(serde_json::json!({
+        let call = make_call("comms_send", serde_json::json!({
             "subject": "hello",
             "body": "test body"
         }));
@@ -121,7 +253,7 @@ mod tests {
     #[tokio::test]
     async fn empty_body_returns_error() {
         let exec = CommsToolExecutor::new(Arc::new(MockComms));
-        let call = make_call(serde_json::json!({
+        let call = make_call("comms_send", serde_json::json!({
             "subject": "hello",
             "body": ""
         }));
@@ -132,7 +264,7 @@ mod tests {
     #[tokio::test]
     async fn missing_body_returns_error() {
         let exec = CommsToolExecutor::new(Arc::new(MockComms));
-        let call = make_call(serde_json::json!({
+        let call = make_call("comms_send", serde_json::json!({
             "subject": "hello"
         }));
         let err = exec.execute(call).await.unwrap_err();
@@ -142,11 +274,28 @@ mod tests {
     #[tokio::test]
     async fn defaults_are_applied() {
         let exec = CommsToolExecutor::new(Arc::new(MockComms));
-        // Only provide the required body; all other fields should use defaults
-        let call = make_call(serde_json::json!({
+        let call = make_call("comms_send", serde_json::json!({
             "body": "status update"
         }));
         let result = exec.execute(call).await.unwrap();
         assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn read_returns_messages() {
+        let exec = CommsToolExecutor::new(Arc::new(MockComms));
+        let call = make_call("comms_read", serde_json::json!({}));
+        let result = exec.execute(call).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("1 message(s)"));
+        assert!(result.output.contains("test directive"));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_rejected() {
+        let exec = CommsToolExecutor::new(Arc::new(MockComms));
+        let call = make_call("comms_delete", serde_json::json!({}));
+        let err = exec.execute(call).await.unwrap_err();
+        assert!(matches!(err, ToolError::UnknownTool { .. }));
     }
 }

--- a/crates/rune-tools/src/stubs.rs
+++ b/crates/rune-tools/src/stubs.rs
@@ -169,6 +169,8 @@ pub fn register_builtin_stubs(registry: &mut ToolRegistry) {
     registry.register(crate::context_budget_tool::context_budget_tool_definition());
     registry.register(crate::context_budget_tool::context_checkpoint_tool_definition());
     registry.register(crate::context_budget_tool::context_gc_tool_definition());
+    registry.register(crate::comms_tool::comms_send_tool_definition());
+    registry.register(crate::comms_tool::comms_read_tool_definition());
 }
 
 /// Validate that a tool call's arguments satisfy the `required` fields in the tool schema.


### PR DESCRIPTION
## Summary

Register `comms_send` and `comms_read` as proper model-callable tools so Rune can natively communicate with OpenClaw through the .comms/ filesystem mailbox protocol.

### Changes

- **comms_tool.rs**: Extended `CommsOps` trait with `read_inbox()` method. Added `CommsMessageSummary` struct for clean serialization. Executor now handles both `comms_send` and `comms_read` via tool_name dispatch.
- **stubs.rs**: Registered `comms_send_tool_definition()` and `comms_read_tool_definition()` in `register_builtin_stubs()`.
- **main.rs (gateway)**: Implemented `read_inbox()` on `CommsClientOps` adapter. Updated dispatch to route both `comms_send` and `comms_read` to the comms executor.

### Tools Added

| Tool | Description |
|------|-------------|
| `comms_send` | Send a message to a peer agent (JSON file to peer inbox) |
| `comms_read` | Check inbox for messages from peer agents, optionally archive |

### Testing

- `cargo check` passes clean
- Unit tests cover: send, read, empty body rejection, defaults, unknown tool rejection
- Pre-existing CI failure in memory_tool.rs tests is unrelated (missing `delete_chunk`/`delete_all` trait impls)

Refs #307