### PR TITLE
fix(ci): install protobuf-compiler for lance-encoding build

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Problem
CI has been failing on **every PR and every push to main** because `lance-encoding` requires `protoc` (protobuf compiler) for its build script, but the GitHub Actions runner doesn't have it installed.

This has been **blocking 6+ PRs** (#400, #376, #369, #363, #339, #327) and preventing all CI from passing.

## Fix
Add `sudo apt-get install -y protobuf-compiler` as a step before the Rust toolchain installation.

## Impact
- Unblocks all open PRs
- Fixes main branch CI (currently red)