### PR TITLE
test(cli): cover doctor backend matrix rendering (#413)

### DIFF
--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -5329,6 +5329,10 @@ mod tests {
         };
         let out = render(&r, OutputFormat::Human);
         assert!(out.contains("Overall: degraded"));
+        assert!(out.contains("Topology: deployment=single-process, database=memory, models=local, search=embedded"));
+        assert!(out.contains("Paths:    profile=default, mode=workspace, auto_create_missing=true"));
+        assert!(out.contains("Backend Matrix:"));
+        assert!(out.contains("storage: sqlite (connected) — mode=standalone"));
         assert!(out.contains("Checks: 1/2 passing"));
         assert!(out.contains("db [fail]: unreachable"));
     }


### PR DESCRIPTION
## Summary
- extend doctor report rendering test to assert topology, paths, and backend matrix output
- keep doctor client parsing coverage for run/results responses with optional fields
- validated with targeted rune-cli tests and cargo check

## Testing
- cargo test -p rune-cli render_doctor_report
- cargo test -p rune-cli doctor_run_posts_and_parses_response
- cargo test -p rune-cli doctor_results_gets_and_parses_response
- cargo check