### PR TITLE
feat(runtime): enforce configurable tool concurrency

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -601,10 +601,12 @@ async fn build_services(
     let process_audit_store: Arc<dyn ProcessAuditStore> =
         Arc::new(DbProcessAuditStore::new(tool_execution_repo));
     let process_manager = ProcessManager::new().with_audit_store(process_audit_store.clone());
-    let lane_queue = Arc::new(LaneQueue::with_capacities(
+    let lane_queue = Arc::new(LaneQueue::with_limits(
         config.runtime.lanes.main_capacity,
         config.runtime.lanes.subagent_capacity,
         config.runtime.lanes.cron_capacity,
+        config.runtime.lanes.global_tool_capacity,
+        config.runtime.lanes.project_tool_capacity,
     ));
     let workspace_root = config
         .paths

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -749,6 +749,18 @@ pub struct LaneQueueConfig {
     pub main_capacity: usize,
     pub subagent_capacity: usize,
     pub cron_capacity: usize,
+    #[serde(default = "default_global_tool_capacity")]
+    pub global_tool_capacity: usize,
+    #[serde(default = "default_project_tool_capacity")]
+    pub project_tool_capacity: usize,
+}
+
+const fn default_global_tool_capacity() -> usize {
+    32
+}
+
+const fn default_project_tool_capacity() -> usize {
+    4
 }
 
 impl Default for LaneQueueConfig {
@@ -757,6 +769,8 @@ impl Default for LaneQueueConfig {
             main_capacity: 4,
             subagent_capacity: 8,
             cron_capacity: 1024,
+            global_tool_capacity: default_global_tool_capacity(),
+            project_tool_capacity: default_project_tool_capacity(),
         }
     }
 }
@@ -1974,6 +1988,8 @@ run_migrations = false
 main_capacity = 6
 subagent_capacity = 9
 cron_capacity = 128
+global_tool_capacity = 24
+project_tool_capacity = 3
 
 [memory]
 level = "keyword"
@@ -1989,6 +2005,8 @@ level = "keyword"
         assert_eq!(config.runtime.lanes.main_capacity, 6);
         assert_eq!(config.runtime.lanes.subagent_capacity, 9);
         assert_eq!(config.runtime.lanes.cron_capacity, 128);
+        assert_eq!(config.runtime.lanes.global_tool_capacity, 24);
+        assert_eq!(config.runtime.lanes.project_tool_capacity, 3);
         assert_eq!(config.memory.level, Some(MemoryLevel::Keyword));
         assert_eq!(config.memory.requested_level(), MemoryLevel::Keyword);
 
@@ -2021,6 +2039,8 @@ main_capacity = 4
         let config = AppConfig::load(Some(&path)).unwrap();
         assert_eq!(config.gateway.port, 9090);
         assert_eq!(config.runtime.lanes.main_capacity, 12);
+        assert_eq!(config.runtime.lanes.global_tool_capacity, 32);
+        assert_eq!(config.runtime.lanes.project_tool_capacity, 4);
         assert!(config.browser.enabled);
         assert_eq!(config.memory.level, Some(MemoryLevel::File));
         assert_eq!(config.memory.requested_level(), MemoryLevel::File);

--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -1008,6 +1008,18 @@ impl TurnExecutor {
                         arguments: args,
                     };
 
+                    let _tool_permit = if let Some(ref lq) = self.lane_queue {
+                        Some(
+                            lq.acquire_tool(resolve_project_key(
+                                call.project_key(),
+                                session.workspace_root.as_deref(),
+                            ))
+                            .await,
+                        )
+                    } else {
+                        None
+                    };
+
                     let tool_result = match self.tool_executor.execute(call.clone()).await {
                         Ok(result) => result,
                         Err(rune_tools::ToolError::ApprovalRequired { tool, details }) => {
@@ -1086,6 +1098,18 @@ impl TurnExecutor {
                                     tool_call_id: call.tool_call_id.clone(),
                                     tool_name: call.tool_name.clone(),
                                     arguments: auto_args,
+                                };
+
+                                let _tool_permit = if let Some(ref lq) = self.lane_queue {
+                                    Some(
+                                        lq.acquire_tool(resolve_project_key(
+                                            auto_call.project_key(),
+                                            session.workspace_root.as_deref(),
+                                        ))
+                                        .await,
+                                    )
+                                } else {
+                                    None
                                 };
 
                                 match self.tool_executor.execute(auto_call).await {
@@ -1341,6 +1365,16 @@ impl TurnExecutor {
             .await?;
         Ok(())
     }
+}
+
+
+fn resolve_project_key<'a>(explicit: Option<&'a str>, workspace_root: Option<&'a str>) -> Option<&'a str> {
+    explicit.or_else(|| {
+        workspace_root.and_then(|root| {
+            let trimmed = root.trim_end_matches('/');
+            trimmed.rsplit('/').next().filter(|segment| !segment.is_empty())
+        })
+    })
 }
 
 fn parse_session_kind(kind: &str) -> Result<SessionKind, RuntimeError> {


### PR DESCRIPTION
Shipped first implementation slice on branch `agent/rune/nonblocking-tools-417`: wired runtime tool concurrency limits into actual execution. Added configurable `[runtime.lanes] global_tool_capacity` and `project_tool_capacity`, gateway now constructs `LaneQueue::with_limits(...)`, and `TurnExecutor` now acquires per-tool permits using explicit `__project`/`project` metadata or workspace-root-derived project keys before running tool calls (including auto-approved retries).

Validation:
- `cargo test -p rune-runtime lane_queue`
- `cargo test -p rune-config file_values_override_defaults`
- `cargo test -p rune-config environment_values_override_file_values`
- `cargo check`

Remaining acceptance gaps on #417:
- responsive session loop during foreground tool execution
- interrupt-driven cancellation semantics
