### PR TITLE
feat(runtime): wire configurable tool concurrency limits (#417)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -598,10 +598,12 @@ async fn build_services(
     let process_audit_store: Arc<dyn ProcessAuditStore> =
         Arc::new(DbProcessAuditStore::new(tool_execution_repo));
     let process_manager = ProcessManager::new().with_audit_store(process_audit_store.clone());
-    let lane_queue = Arc::new(LaneQueue::with_capacities(
+    let lane_queue = Arc::new(LaneQueue::with_limits(
         config.runtime.lanes.main_capacity,
         config.runtime.lanes.subagent_capacity,
         config.runtime.lanes.cron_capacity,
+        config.runtime.lanes.global_tool_capacity,
+        config.runtime.lanes.project_tool_capacity,
     ));
     let workspace_root = config
         .paths

--- a/config.example.toml
+++ b/config.example.toml
@@ -91,6 +91,13 @@ workspace = "/home/hamza/.openclaw/workspace"
 id = "fast"
 model = "oc-01-anthropic/claude-sonnet-4-6"
 
+[runtime.lanes]
+main_capacity = 4
+subagent_capacity = 8
+cron_capacity = 1024
+global_tool_capacity = 32
+project_tool_capacity = 4
+
 [logging]
 level = "info"
 json = true

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -749,6 +749,18 @@ pub struct LaneQueueConfig {
     pub main_capacity: usize,
     pub subagent_capacity: usize,
     pub cron_capacity: usize,
+    #[serde(default = "default_global_tool_capacity")]
+    pub global_tool_capacity: usize,
+    #[serde(default = "default_project_tool_capacity")]
+    pub project_tool_capacity: usize,
+}
+
+fn default_global_tool_capacity() -> usize {
+    32
+}
+
+fn default_project_tool_capacity() -> usize {
+    4
 }
 
 impl Default for LaneQueueConfig {
@@ -757,6 +769,8 @@ impl Default for LaneQueueConfig {
             main_capacity: 4,
             subagent_capacity: 8,
             cron_capacity: 1024,
+            global_tool_capacity: default_global_tool_capacity(),
+            project_tool_capacity: default_project_tool_capacity(),
         }
     }
 }

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -967,6 +967,11 @@ impl RpcDispatcher {
                     "active": stats.cron_active,
                     "capacity": stats.cron_capacity,
                 },
+                "tools": {
+                    "active": stats.tool_active,
+                    "capacity": stats.tool_capacity,
+                    "per_project_capacity": stats.project_tool_capacity,
+                },
             })
         });
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1784,7 +1784,17 @@ async fn ws_rpc_status_matches_http_status_basics() {
     let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
 
     let state = AppState {
-        config: Arc::new(RwLock::new(AppConfig::default())),
+        config: Arc::new(RwLock::new({
+            let mut config = AppConfig::default();
+            config.runtime.lanes = LaneQueueConfig {
+                main_capacity: 2,
+                subagent_capacity: 3,
+                cron_capacity: 4,
+                global_tool_capacity: 20,
+                project_tool_capacity: 5,
+            };
+            config
+        })),
         started_at: Arc::new(Instant::now()),
         session_engine,
         turn_executor,
@@ -2023,6 +2033,8 @@ async fn status_reports_configured_lane_capacities() {
         main_capacity: 6,
         subagent_capacity: 9,
         cron_capacity: 128,
+        global_tool_capacity: 20,
+        project_tool_capacity: 5,
     };
     let device_repo = Arc::new(MemDeviceRepo::new());
     let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
@@ -2108,7 +2120,7 @@ async fn ws_rpc_runtime_lanes_reports_lane_queue_stats() {
     let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
     let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
     let tool_registry = Arc::new(ToolRegistry::new());
-    let lane_queue = Arc::new(LaneQueue::with_capacities(2, 3, 4));
+    let lane_queue = Arc::new(LaneQueue::with_limits(2, 3, 4, 20, 5));
     let turn_executor = Arc::new(
         TurnExecutor::new(
             session_repo.clone() as Arc<dyn SessionRepo>,
@@ -2192,6 +2204,9 @@ async fn ws_rpc_runtime_lanes_reports_lane_queue_stats() {
     assert_eq!(payload["lanes"]["subagent"]["capacity"], 3);
     assert_eq!(payload["lanes"]["cron"]["active"], 0);
     assert_eq!(payload["lanes"]["cron"]["capacity"], 4);
+    assert_eq!(payload["lanes"]["tools"]["active"], 0);
+    assert_eq!(payload["lanes"]["tools"]["capacity"], 20);
+    assert_eq!(payload["lanes"]["tools"]["per_project_capacity"], 5);
 
     drop(main_permit);
     drop(subagent_permit);


### PR DESCRIPTION
## Summary\n- thread global and per-project tool concurrency limits through runtime config\n- pass tool capacity limits into the lane queue from gateway startup\n- expose tool concurrency stats from the gateway RPC and route tests\n\n## Testing\n- cargo check