### PR TITLE
feat(comms): select transport via trait abstraction

### DIFF
--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -125,7 +125,14 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
             .comms_dir
             .clone()
             .unwrap_or_else(|| ".comms".to_string());
-        Some(Arc::new(CommsClient::new(
+        let transport = services
+            .config
+            .comms
+            .transport
+            .parse()
+            .map_err(GatewayError::BadRequest)?;
+        Some(Arc::new(CommsClient::with_transport_kind(
+            transport,
             comms_dir,
             services.config.comms.agent_id.clone(),
             services.config.comms.peer_id.clone(),

--- a/crates/rune-runtime/src/comms.rs
+++ b/crates/rune-runtime/src/comms.rs
@@ -4,6 +4,7 @@
 //! and archives processed messages. Implements the .comms/ protocol.
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -53,6 +54,31 @@ pub trait CommsTransport: Send + Sync {
     async fn send(&self, message: CommsMessage) -> Result<(), String>;
     async fn receive(&self, agent_id: &str) -> Result<Vec<(PathBuf, CommsMessage)>, String>;
     async fn ack(&self, path: &Path) -> Result<(), String>;
+}
+
+/// Built-in transport kinds for native inter-agent comms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommsTransportKind {
+    Filesystem,
+}
+
+impl CommsTransportKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Filesystem => "filesystem",
+        }
+    }
+}
+
+impl FromStr for CommsTransportKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "filesystem" | "fs" => Ok(Self::Filesystem),
+            other => Err(format!("unsupported comms transport: {other}")),
+        }
+    }
 }
 
 /// Filesystem-backed transport for the `.comms/` mailbox protocol.
@@ -155,6 +181,16 @@ impl CommsTransport for FsCommsTransport {
     }
 }
 
+
+pub fn build_comms_transport(
+    transport: CommsTransportKind,
+    comms_dir: impl Into<PathBuf>,
+) -> Arc<dyn CommsTransport> {
+    match transport {
+        CommsTransportKind::Filesystem => Arc::new(FsCommsTransport::new(comms_dir)),
+    }
+}
+
 /// The comms client — reads/writes messages using a configurable transport.
 #[derive(Clone)]
 pub struct CommsClient {
@@ -169,11 +205,16 @@ impl CommsClient {
         agent_id: impl Into<String>,
         peer_id: impl Into<String>,
     ) -> Self {
-        Self::with_transport(
-            Arc::new(FsCommsTransport::new(comms_dir)),
-            agent_id,
-            peer_id,
-        )
+        Self::with_transport_kind(CommsTransportKind::Filesystem, comms_dir, agent_id, peer_id)
+    }
+
+    pub fn with_transport_kind(
+        transport: CommsTransportKind,
+        comms_dir: impl Into<PathBuf>,
+        agent_id: impl Into<String>,
+        peer_id: impl Into<String>,
+    ) -> Self {
+        Self::with_transport(build_comms_transport(transport, comms_dir), agent_id, peer_id)
     }
 
     pub fn with_transport(
@@ -366,6 +407,13 @@ mod tests {
         let client = CommsClient::new(tmp.path(), "rune", "horizon-ai");
         let messages = client.read_inbox().await;
         assert!(messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parse_transport_kind_aliases() {
+        assert_eq!(CommsTransportKind::from_str("filesystem").unwrap(), CommsTransportKind::Filesystem);
+        assert_eq!(CommsTransportKind::from_str("FS").unwrap(), CommsTransportKind::Filesystem);
+        assert!(CommsTransportKind::from_str("http").is_err());
     }
 
     #[tokio::test]

--- a/crates/rune-runtime/src/lib.rs
+++ b/crates/rune-runtime/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc = "Session engine, turn loop, context assembly, and tool orchestration for Rune."]
 
 pub mod comms;
-pub use comms::{CommsClient, CommsMessageSummary, CommsTransport, FsCommsTransport};
+pub use comms::{
+    CommsClient, CommsMessageSummary, CommsTransport, CommsTransportKind, FsCommsTransport,
+    build_comms_transport,
+};
 
 pub mod agent_registry;
 pub mod claude_plugin;


### PR DESCRIPTION
## Summary\n- add a concrete  selector plus builder around the existing  trait\n- construct comms clients through the configured transport instead of hard-wiring filesystem transport in gateway startup\n- keep filesystem behavior as the default and add regression coverage for transport parsing\n\n## Testing\n- cargo test -p rune-runtime comms -- --nocapture\n- cargo test -p rune-gateway native_comms_send_inbox_and_ack_flow -- --nocapture\n- cargo check\n\nCloses #410