### PR TITLE
test(gateway): fix storage path check count (#429)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -6562,7 +6562,7 @@ mod tests {
             ..Default::default()
         };
         let checks = storage_path_checks(&config);
-        assert_eq!(checks.len(), 13);
+        assert_eq!(checks.len(), 14);
         for c in &checks {
             assert_eq!(
                 c.status, "pass",


### PR DESCRIPTION
## Summary\n- update the storage path doctor test to match the 14 configured persistent paths\n- keep the context budget enforcement branch green after data_dir was added to path checks\n\n## Testing\n- cargo test -p rune-gateway routes::tests::storage_checks_pass_for_writable_dirs -- --nocapture\n- cargo test -p rune-tools comms -- --nocapture\n- cargo check