### PR TITLE
feat(runtime): enforce tool permits during execution (#417)

### DIFF
--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -1008,6 +1008,11 @@ impl TurnExecutor {
                         arguments: args,
                     };
 
+                    let _tool_permit = match &self.lane_queue {
+                        Some(queue) => Some(queue.acquire_tool(call.project_key()).await),
+                        None => None,
+                    };
+
                     let tool_result = match self.tool_executor.execute(call.clone()).await {
                         Ok(result) => result,
                         Err(rune_tools::ToolError::ApprovalRequired { tool, details }) => {
@@ -1086,6 +1091,13 @@ impl TurnExecutor {
                                     tool_call_id: call.tool_call_id.clone(),
                                     tool_name: call.tool_name.clone(),
                                     arguments: auto_args,
+                                };
+
+                                let _tool_permit = match &self.lane_queue {
+                                    Some(queue) => {
+                                        Some(queue.acquire_tool(auto_call.project_key()).await)
+                                    }
+                                    None => None,
                                 };
 
                                 match self.tool_executor.execute(auto_call).await {


### PR DESCRIPTION
## Summary\n- acquire per-project tool permits before executing tool calls in the turn loop\n- apply the same permit gating to auto-approved replays\n- wire existing  metadata into runtime enforcement\n\n## Validation\n- cargo test -q -p rune-runtime lane_queue -- --nocapture\n- cargo check -q\n