### PR TITLE
feat(gateway): align session status card fields

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -2199,6 +2199,34 @@ fn render_session_status_card(
     let reasoning = metadata_string(metadata, "reasoning").unwrap_or_else(|| "off".to_string());
     let verbose = metadata_bool(metadata, "verbose").unwrap_or(false);
     let elevated = metadata_bool(metadata, "elevated").unwrap_or(false);
+    let parent_session_id = row.requester_session_id.map(|id| id.to_string());
+    let session_mode = metadata_string(metadata, "mode");
+    let orchestration_status = metadata_string(metadata, "orchestration_status")
+        .or_else(|| metadata_string(metadata, "subagent_lifecycle"));
+    let delegation_roles = metadata
+        .get("delegation_roles")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let delegation_depth = if parent_session_id.is_some() {
+        Some(
+            metadata
+                .get("delegation_depth")
+                .and_then(|value| value.as_u64())
+                .map(|value| value as u32)
+                .unwrap_or(1),
+        )
+    } else {
+        metadata
+            .get("delegation_depth")
+            .and_then(|value| value.as_u64())
+            .map(|value| value as u32)
+    };
     let subagent_lifecycle = metadata_string(metadata, "subagent_lifecycle");
     let subagent_runtime_status = metadata_string(metadata, "subagent_runtime_status");
     let subagent_runtime_attached = metadata_bool(metadata, "subagent_runtime_attached");
@@ -2208,9 +2236,7 @@ fn render_session_status_card(
     let mut unresolved =
         vec!["cost posture is estimate-only; provider pricing is not wired yet".to_string()];
     if approval_mode == "on-miss" {
-        unresolved.push(
-            "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable".to_string(),
-        );
+        unresolved.push(rune_runtime::restart_continuity::RESTART_CONTINUITY_SUMMARY.to_string());
     }
     if security_mode == "allowlist" {
         unresolved.push(
@@ -2232,6 +2258,13 @@ fn render_session_status_card(
             row.status,
         ),
         "status": row.status,
+        "kind": row.kind,
+        "channel_ref": row.channel_ref,
+        "parent_session_id": parent_session_id,
+        "session_mode": session_mode,
+        "orchestration_status": orchestration_status,
+        "delegation_roles": delegation_roles,
+        "delegation_depth": delegation_depth,
         "current_model": current_model,
         "model_override": model_override,
         "prompt_tokens": aggregate.usage_prompt_tokens,


### PR DESCRIPTION
## Summary
- extend session_status card output with parent/orchestration/delegation fields tracked by the roadmap parity work
- reuse the shared restart continuity summary constant instead of duplicating unresolved approval wording
- keep existing runtime and subagent fields intact while exposing extra parity metadata in one response

## Testing
- cargo check

Closes #406