### PR TITLE
fix(cli): remove duplicate dashboard session field (#402)

### DIFF
--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -6272,7 +6272,6 @@ mod tests {
                     channel: Some("telegram".into()),
                     project_id: None,
                     requester_session_id: None,
-                    project_id: None,
                     created_at: None,
                     turn_count: Some(1),
                     usage_prompt_tokens: Some(10),


### PR DESCRIPTION
## Summary
- remove the duplicate  field from the dashboard session sample in 
- restore  test compilation for the output test target

## Verification
- cargo check
- cargo test -p rune-cli output