### PR TITLE
fix(cli): remove duplicate session test field (#501)

### DIFF
--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -6272,7 +6272,6 @@ mod tests {
                     channel: Some("telegram".into()),
                     project_id: None,
                     requester_session_id: None,
-                    project_id: None,
                     created_at: None,
                     turn_count: Some(1),
                     usage_prompt_tokens: Some(10),


### PR DESCRIPTION
## Summary
- remove the duplicate `project_id` field from the dashboard output test fixture
- restore `rune-cli` test compilation so project registry/remove tests run again

## Verification
- cargo test -p rune-cli projects_remove -- --nocapture
- cargo check
