### PR TITLE
feat(core): retain provider attachment ids

### DIFF
--- a/crates/rune-channels/src/discord.rs
+++ b/crates/rune-channels/src/discord.rs
@@ -224,6 +224,7 @@ impl DiscordAdapter {
                         mime_type: a.content_type.clone(),
                         size_bytes: Some(a.size),
                         url: Some(a.url.clone()),
+                        provider_file_id: None,
                     })
                     .collect(),
                 timestamp,

--- a/crates/rune-channels/src/signal.rs
+++ b/crates/rune-channels/src/signal.rs
@@ -168,6 +168,7 @@ impl SignalAdapter {
                     mime_type: a.content_type.clone(),
                     size_bytes: a.size.map(|s| s as u64),
                     url: None,
+                    provider_file_id: None,
                 })
                 .collect();
 
@@ -491,6 +492,7 @@ mod tests {
                     group_id: Some("abc123group".into()),
                     group_type: Some("DELIVER".into()),
                 }),
+                provider_file_id: None,
             }),
             receipt_message: None,
             typing_message: None,

--- a/crates/rune-channels/src/slack.rs
+++ b/crates/rune-channels/src/slack.rs
@@ -353,6 +353,7 @@ impl SlackAdapter {
                     mime_type: mime,
                     size_bytes: size,
                     url,
+                    provider_file_id: None,
                 }
             })
             .collect()

--- a/crates/rune-channels/src/teams.rs
+++ b/crates/rune-channels/src/teams.rs
@@ -125,6 +125,7 @@ impl TeamsAdapter {
                         .as_ref()
                         .map(|_| "teams-inline:adaptive-card".into())
                 }),
+                provider_file_id: None,
             })
             .collect()
     }

--- a/crates/rune-channels/src/telegram.rs
+++ b/crates/rune-channels/src/telegram.rs
@@ -189,6 +189,7 @@ impl TelegramAdapter {
                 mime_type: doc.mime_type.clone(),
                 size_bytes: doc.file_size.map(|s| s as u64),
                 url: Some(format!("telegram-file:{}", doc.file_id)),
+                provider_file_id: Some(doc.file_id.clone()),
             });
         }
 
@@ -199,6 +200,7 @@ impl TelegramAdapter {
                     mime_type: Some("image/jpeg".into()),
                     size_bytes: largest.file_size.map(|s| s as u64),
                     url: Some(format!("telegram-file:{}", largest.file_id)),
+                    provider_file_id: Some(largest.file_id.clone()),
                 });
             }
         }
@@ -214,6 +216,7 @@ impl TelegramAdapter {
                 ),
                 size_bytes: voice.file_size.map(|s| s as u64),
                 url: Some(format!("telegram-file:{}", voice.file_id)),
+                provider_file_id: Some(voice.file_id.clone()),
             });
         }
 
@@ -228,6 +231,7 @@ impl TelegramAdapter {
                 ),
                 size_bytes: audio.file_size.map(|s| s as u64),
                 url: Some(format!("telegram-file:{}", audio.file_id)),
+                provider_file_id: Some(audio.file_id.clone()),
             });
         }
 
@@ -237,6 +241,7 @@ impl TelegramAdapter {
                 mime_type: Some("video/mp4".into()),
                 size_bytes: video_note.file_size.map(|s| s as u64),
                 url: Some(format!("telegram-file:{}", video_note.file_id)),
+                provider_file_id: Some(video_note.file_id.clone()),
             });
         }
 
@@ -251,6 +256,7 @@ impl TelegramAdapter {
                 ),
                 size_bytes: video.file_size.map(|s| s as u64),
                 url: Some(format!("telegram-file:{}", video.file_id)),
+                provider_file_id: Some(video.file_id.clone()),
             });
         }
 

--- a/crates/rune-channels/src/whatsapp.rs
+++ b/crates/rune-channels/src/whatsapp.rs
@@ -465,6 +465,7 @@ impl WhatsAppAdapter {
                     mime_type: mime,
                     size_bytes: None,
                     url: None, // Media URLs require a separate download call.
+                    provider_file_id: Some(media_id.clone()),
                 };
 
                 Some(InboundEvent::Message(ChannelMessage {

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -246,6 +246,8 @@ pub struct AttachmentRef {
     pub mime_type: Option<String>,
     pub size_bytes: Option<u64>,
     pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_file_id: Option<String>,
 }
 
 /// Transcript entries persisted during session execution.
@@ -859,6 +861,22 @@ mod tests {
         assert!(message.channel_id.is_none());
         assert!(message.attachments.is_empty());
         assert_eq!(message.metadata, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn attachment_ref_serde_backfills_provider_file_id_for_legacy_payloads() {
+        let attachment: AttachmentRef = serde_json::from_value(serde_json::json!({
+            "name": "photo.jpg",
+            "mime_type": "image/jpeg",
+            "size_bytes": 42,
+            "url": "https://example.com/photo.jpg"
+        }))
+        .unwrap();
+
+        assert_eq!(attachment.provider_file_id, None);
+
+        let value = serde_json::to_value(&attachment).unwrap();
+        assert!(value.get("provider_file_id").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add optional provider_file_id to AttachmentRef with backward-compatible serde behavior
- preserve upstream attachment ids for Telegram and WhatsApp media while explicitly setting None for other adapters
- cover legacy deserialization with a rune-core serde regression test

## Testing
- cargo check

## Issue
- closes #436