### PR TITLE
fix(ci): align test doubles with project-scoped memory repo (#402)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -3268,6 +3268,7 @@ mod tests {
     impl MemoryEmbeddingRepo for MemMemoryEmbeddingRepo {
         async fn upsert_chunk(
             &self,
+            _project_id: Option<&str>,
             file_path: &str,
             chunk_index: i32,
             chunk_text: &str,
@@ -3288,7 +3289,11 @@ mod tests {
             Ok(())
         }
 
-        async fn delete_by_file(&self, file_path: &str) -> Result<usize, StoreError> {
+        async fn delete_by_file(
+            &self,
+            _project_id: Option<&str>,
+            file_path: &str,
+        ) -> Result<usize, StoreError> {
             self.deleted_files.lock().await.push(file_path.to_string());
             let mut existing = self.existing_files.lock().await;
             let before = existing.len();
@@ -3298,6 +3303,7 @@ mod tests {
 
         async fn delete_chunk(
             &self,
+            _project_id: Option<&str>,
             file_path: &str,
             _chunk_index: i32,
         ) -> Result<bool, StoreError> {
@@ -3305,7 +3311,7 @@ mod tests {
             Ok(true)
         }
 
-        async fn delete_all(&self) -> Result<usize, StoreError> {
+        async fn delete_all(&self, _project_id: Option<&str>) -> Result<usize, StoreError> {
             let mut existing = self.existing_files.lock().await;
             let count = existing.len();
             existing.clear();
@@ -3314,6 +3320,7 @@ mod tests {
 
         async fn keyword_search(
             &self,
+            _project_id: Option<&str>,
             _query: &str,
             _limit: i64,
         ) -> Result<Vec<KeywordSearchRow>, StoreError> {
@@ -3322,17 +3329,21 @@ mod tests {
 
         async fn vector_search(
             &self,
+            _project_id: Option<&str>,
             _embedding: &[f32],
             _limit: i64,
         ) -> Result<Vec<VectorSearchRow>, StoreError> {
             Ok(Vec::new())
         }
 
-        async fn count(&self) -> Result<i64, StoreError> {
+        async fn count(&self, _project_id: Option<&str>) -> Result<i64, StoreError> {
             Ok(self.existing_files.lock().await.len() as i64)
         }
 
-        async fn list_indexed_files(&self) -> Result<Vec<String>, StoreError> {
+        async fn list_indexed_files(
+            &self,
+            _project_id: Option<&str>,
+        ) -> Result<Vec<String>, StoreError> {
             Ok(self.existing_files.lock().await.clone())
         }
     }

--- a/crates/rune-channels/src/signal.rs
+++ b/crates/rune-channels/src/signal.rs
@@ -492,7 +492,6 @@ mod tests {
                     group_id: Some("abc123group".into()),
                     group_type: Some("DELIVER".into()),
                 }),
-                provider_file_id: None,
             }),
             receipt_message: None,
             typing_message: None,

--- a/crates/rune-store/tests/pg_integration.rs
+++ b/crates/rune-store/tests/pg_integration.rs
@@ -212,6 +212,7 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
     if has_pgvector {
         // Full test with vector embeddings.
         repo.upsert_chunk(
+            None,
             "memory/preferences.md",
             0,
             "Prefers dark mode and keyboard shortcuts.",
@@ -220,6 +221,7 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
         .await
         .unwrap();
         repo.upsert_chunk(
+            None,
             "memory/tasks.md",
             0,
             "Reviewed build pipeline rollout notes.",
@@ -228,33 +230,34 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
         .await
         .unwrap();
 
-        assert_eq!(repo.count().await.unwrap(), 2);
+        assert_eq!(repo.count(None).await.unwrap(), 2);
 
-        let keyword_hits = repo.keyword_search("dark mode", 5).await.unwrap();
+        let keyword_hits = repo.keyword_search(None, "dark mode", 5).await.unwrap();
         assert_eq!(keyword_hits.len(), 1);
         assert_eq!(keyword_hits[0].file_path, "memory/preferences.md");
         assert!(keyword_hits[0].score > 0.0);
 
         let vector_hits = repo
-            .vector_search(&[0.95, 0.05, 0.0, 0.0], 5)
+            .vector_search(None, &[0.95, 0.05, 0.0, 0.0], 5)
             .await
             .unwrap();
         assert!(!vector_hits.is_empty());
         assert_eq!(vector_hits[0].file_path, "memory/preferences.md");
 
-        let indexed_files = repo.list_indexed_files().await.unwrap();
+        let indexed_files = repo.list_indexed_files(None).await.unwrap();
         assert_eq!(
             indexed_files,
             vec!["memory/preferences.md", "memory/tasks.md"]
         );
 
-        let deleted = repo.delete_by_file("memory/preferences.md").await.unwrap();
+        let deleted = repo.delete_by_file(None, "memory/preferences.md").await.unwrap();
         assert_eq!(deleted, 1);
-        assert_eq!(repo.count().await.unwrap(), 1);
+        assert_eq!(repo.count(None).await.unwrap(), 1);
     } else {
         // pgvector unavailable — verify keyword-only path works.
         // Insert directly without embeddings for keyword search testing.
         repo.upsert_keyword_only(
+            None,
             "memory/preferences.md",
             0,
             "Prefers dark mode and keyboard shortcuts.",
@@ -262,13 +265,13 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
         .await
         .unwrap();
 
-        let keyword_hits = repo.keyword_search("dark mode", 5).await.unwrap();
+        let keyword_hits = repo.keyword_search(None, "dark mode", 5).await.unwrap();
         assert_eq!(keyword_hits.len(), 1);
         assert_eq!(keyword_hits[0].file_path, "memory/preferences.md");
 
-        let deleted = repo.delete_by_file("memory/preferences.md").await.unwrap();
+        let deleted = repo.delete_by_file(None, "memory/preferences.md").await.unwrap();
         assert_eq!(deleted, 1);
-        assert_eq!(repo.count().await.unwrap(), 0);
+        assert_eq!(repo.count(None).await.unwrap(), 0);
     }
 }
 


### PR DESCRIPTION
## Summary\n- update the in-memory gateway test repo to match the project-scoped MemoryEmbeddingRepo trait\n- fix pg integration tests to pass the new optional project_id argument\n- remove the stray Signal test field that broke all-targets builds\n\n## Verification\n- cargo check --workspace --all-targets\n- cargo test --workspace --all-targets --no-run\n