### PR TITLE
fix(gateway): honor sub-10s plugin scan intervals (#403)

### DIFF
--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -355,7 +355,11 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         event_tx: state.event_tx.clone(),
         operator_delivery,
         plugin_scanner: Some(plugin_scanner.clone()),
-        plugin_scan_interval_ticks: plugin_scan_interval_secs / 10,
+        plugin_scan_interval_ticks: if plugin_scan_interval_secs == 0 {
+            0
+        } else {
+            std::cmp::max(1, plugin_scan_interval_secs.div_ceil(10))
+        },
         comms: state.comms_client.clone(),
     };
 


### PR DESCRIPTION
## Summary
- fix supervisor plugin scan tick calculation so non-zero intervals under 10 seconds still run
- preserve disabled scanning when the configured interval is exactly 0
- prevent effective no-op plugin rescans from integer truncation

## Validation
- cargo check -p rune-gateway
- cargo test -p rune-gateway supervisor -- --nocapture