### PR TITLE
feat(gateway): expose diagnostics context budget payload (#434)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -568,6 +568,7 @@ pub struct DashboardDiagnosticItem {
 pub struct DashboardDiagnosticsResponse {
     pub structured_errors_available: bool,
     pub items: Vec<DashboardDiagnosticItem>,
+    pub context_budget: ContextBudgetDiagnostics,
 }
 
 #[derive(Serialize)]
@@ -837,6 +838,7 @@ pub async fn dashboard_diagnostics(
     Ok(Json(DashboardDiagnosticsResponse {
         structured_errors_available: false,
         items,
+        context_budget,
     }))
 }
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4298,6 +4298,15 @@ async fn dashboard_diagnostics_falls_back_to_status_notes() {
     assert_eq!(json["structured_errors_available"], false);
     let items = json["items"].as_array().unwrap();
     assert!(!items.is_empty());
+    let context_budget = &json["context_budget"];
+    assert_eq!(context_budget["max_tokens"], 128000);
+    assert_eq!(context_budget["warn_at_tokens"], 102400);
+    assert_eq!(context_budget["compress_after"], 50000);
+    assert_eq!(context_budget["reserved_system"], 5000);
+    assert_eq!(context_budget["reserved_task"], 10000);
+    assert_eq!(context_budget["usable_prompt_budget"], 113000);
+    assert_eq!(context_budget["auto_inject_project"], true);
+    assert_eq!(context_budget["memory_search_k"], 10);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n- add a structured context_budget object to the dashboard diagnostics response\n- keep the existing human-readable diagnostics item for parity\n- cover the new payload in gateway route tests\n\nCloses #434