### PR TITLE
feat(runtime): preserve provider image refs in multimodal parts (#529)

### DIFF
--- a/crates/rune-runtime/src/context.rs
+++ b/crates/rune-runtime/src/context.rs
@@ -309,17 +309,11 @@ fn build_user_message_parts(content: &str, attachments: &[AttachmentRef]) -> Opt
     }
 
     for attachment in attachments {
-        let Some(url) = attachment.url.as_deref() else {
+        let Some(image_ref) = attachment_image_ref(attachment) else {
             continue;
         };
-        let mime = attachment.mime_type.as_deref().unwrap_or("");
-        if !mime.starts_with("image/") {
-            continue;
-        }
         parts.push(MessagePart::ImageUrl {
-            image_url: ImageUrlPart {
-                url: url.to_string(),
-            },
+            image_url: ImageUrlPart { url: image_ref },
         });
     }
 
@@ -328,6 +322,22 @@ fn build_user_message_parts(content: &str, attachments: &[AttachmentRef]) -> Opt
     } else {
         Some(parts)
     }
+}
+
+fn attachment_image_ref(attachment: &AttachmentRef) -> Option<String> {
+    let mime = attachment.mime_type.as_deref().unwrap_or("");
+    if !mime.starts_with("image/") {
+        return None;
+    }
+
+    if let Some(url) = attachment.url.as_deref() {
+        return Some(url.to_string());
+    }
+
+    attachment
+        .provider_file_id
+        .as_ref()
+        .map(|file_id| format!("provider-file:{file_id}"))
 }
 
 fn render_user_message_content(content: &str, attachments: &[AttachmentRef]) -> String {
@@ -380,7 +390,7 @@ fn format_attachment_ref(attachment: &AttachmentRef) -> String {
 
 #[cfg(test)]
 mod attachment_prompt_tests {
-    use super::{build_user_message_parts, format_attachment_ref, render_user_message_content, ContextAssembler};
+    use super::{attachment_image_ref, build_user_message_parts, format_attachment_ref, render_user_message_content, ContextAssembler};
     use rune_core::{AttachmentRef, NormalizedMessage, TranscriptItem};
     use rune_models::{MessagePart, Role};
     use rune_store::models::TranscriptItemRow;
@@ -458,6 +468,38 @@ mod attachment_prompt_tests {
 
         assert_eq!(formatted, "photo.jpg (image/jpeg, 42 bytes, provider_file_id=abc)");
     }
+    #[test]
+    fn prefers_attachment_url_for_image_parts() {
+        let attachment = AttachmentRef {
+            name: "photo.jpg".into(),
+            mime_type: Some("image/jpeg".into()),
+            size_bytes: Some(42),
+            url: Some("telegram-file:file_123".into()),
+            provider_file_id: Some("file_123".into()),
+        };
+
+        assert_eq!(
+            attachment_image_ref(&attachment).as_deref(),
+            Some("telegram-file:file_123")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_provider_file_id_for_image_parts_when_url_missing() {
+        let attachment = AttachmentRef {
+            name: "photo.jpg".into(),
+            mime_type: Some("image/jpeg".into()),
+            size_bytes: Some(42),
+            url: None,
+            provider_file_id: Some("file_123".into()),
+        };
+
+        assert_eq!(
+            attachment_image_ref(&attachment).as_deref(),
+            Some("provider-file:file_123")
+        );
+    }
+
     #[test]
     fn builds_multimodal_parts_for_user_text_and_image_attachments() {
         let parts = build_user_message_parts(


### PR DESCRIPTION
## Summary\n- preserve image attachment refs in multimodal message parts even when only provider_file_id is available\n- prefer attachment URL when present and fall back to provider-file refs for image attachments\n- add runtime tests covering URL preference and provider file id fallback\n\n## Testing\n- cargo test -p rune-runtime attachment_prompt_tests -- --nocapture\n- cargo test -p rune-models openai_serializes_multimodal_user_content_parts -- --nocapture\n- cargo test -p rune-models azure_serializes_multimodal_user_content_parts -- --nocapture\n- cargo check