### PR TITLE
feat(ui): polish mobile approval and chat theming (#435)

### DIFF
--- a/apps/mobile/app/(tabs)/approvals.tsx
+++ b/apps/mobile/app/(tabs)/approvals.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { ActivityIndicator, Alert, FlatList, SafeAreaView, Text, View } from "react-native";
 import { ApprovalCard } from "../../src/components/approvals/ApprovalCard";
 import { useApprovals } from "../../src/hooks/use-approvals";
+import { useTheme } from "../../src/hooks/use-theme";
 
 export default function ApprovalsScreen() {
+  const colors = useTheme();
   const { approvals, loading, decidingId, decide } = useApprovals();
 
   const handleDecision = async (id: string, decision: "allow_once" | "deny") => {
@@ -15,15 +17,15 @@ export default function ApprovalsScreen() {
   };
 
   return (
-    <SafeAreaView style={{ backgroundColor: "#f9fafb", flex: 1 }}>
-      <View style={{ borderBottomWidth: 1, borderColor: "#e5e7eb", gap: 4, padding: 16 }}>
-        <Text style={{ fontSize: 24, fontWeight: "700" }}>Approvals</Text>
-        <Text style={{ color: "#6b7280" }}>Review and unblock pending tool calls.</Text>
+    <SafeAreaView style={{ backgroundColor: colors.background, flex: 1 }}>
+      <View style={{ borderBottomWidth: 1, borderColor: colors.border, gap: 4, padding: 16 }}>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: "700" }}>Approvals</Text>
+        <Text style={{ color: colors.textMuted }}>Review and unblock pending tool calls.</Text>
       </View>
 
       {loading ? (
         <View style={{ alignItems: "center", flex: 1, justifyContent: "center" }}>
-          <ActivityIndicator />
+          <ActivityIndicator color={colors.primary} />
         </View>
       ) : (
         <FlatList
@@ -32,8 +34,8 @@ export default function ApprovalsScreen() {
           keyExtractor={(item) => item.id}
           ListEmptyComponent={
             <View style={{ alignItems: "center", flex: 1, justifyContent: "center", padding: 24 }}>
-              <Text style={{ color: "#111827", fontSize: 18, fontWeight: "600" }}>No pending approvals</Text>
-              <Text style={{ color: "#6b7280", marginTop: 8, textAlign: "center" }}>
+              <Text style={{ color: colors.text, fontSize: 18, fontWeight: "600" }}>No pending approvals</Text>
+              <Text style={{ color: colors.textMuted, marginTop: 8, textAlign: "center" }}>
                 Approval requests will show up here when a tool call needs operator input.
               </Text>
             </View>

--- a/apps/mobile/src/components/approvals/ApprovalCard.tsx
+++ b/apps/mobile/src/components/approvals/ApprovalCard.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import type { ApprovalRequestResponse } from "../../api/api-types";
+import { useTheme } from "../../hooks/use-theme";
 
 interface ApprovalCardProps {
   approval: ApprovalRequestResponse;
@@ -25,9 +26,21 @@ function getSummary(approval: ApprovalRequestResponse): string {
   return approval.reason;
 }
 
+function getStatusLabel(approval: ApprovalRequestResponse): string {
+  if (approval.approval_status) {
+    return approval.approval_status.replace(/_/g, " ");
+  }
+  if (approval.decision) {
+    return approval.decision.replace(/_/g, " ");
+  }
+  return "pending";
+}
+
 export function ApprovalCard({ approval, busy = false, onApprove, onDeny }: ApprovalCardProps) {
+  const colors = useTheme();
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
   const summary = useMemo(() => getSummary(approval), [approval]);
+  const statusLabel = useMemo(() => getStatusLabel(approval), [approval]);
 
   return (
     <View
@@ -43,8 +56,8 @@ export function ApprovalCard({ approval, busy = false, onApprove, onDeny }: Appr
         }
       }}
       style={{
-        backgroundColor: "#fff",
-        borderColor: "#e5e7eb",
+        backgroundColor: colors.surface,
+        borderColor: colors.border,
         borderRadius: 16,
         borderWidth: 1,
         gap: 12,
@@ -52,14 +65,31 @@ export function ApprovalCard({ approval, busy = false, onApprove, onDeny }: Appr
       }}
     >
       <View style={{ gap: 6 }}>
-        <Text style={{ color: "#6b7280", fontSize: 12, fontWeight: "600", textTransform: "uppercase" }}>
-          {approval.subject_type.replace(/_/g, " ")}
-        </Text>
-        <Text style={{ color: "#111827", fontSize: 18, fontWeight: "700" }}>{approval.reason}</Text>
-        <Text style={{ color: "#374151", fontFamily: "monospace" }}>{summary}</Text>
+        <View style={{ alignItems: "center", flexDirection: "row", justifyContent: "space-between" }}>
+          <Text style={{ color: colors.textMuted, fontSize: 12, fontWeight: "600", textTransform: "uppercase" }}>
+            {approval.subject_type.replace(/_/g, " ")}
+          </Text>
+          <View
+            style={{
+              backgroundColor: colors.surfaceMuted,
+              borderRadius: 999,
+              paddingHorizontal: 10,
+              paddingVertical: 4,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: 12, fontWeight: "700", textTransform: "capitalize" }}>
+              {statusLabel}
+            </Text>
+          </View>
+        </View>
+        <Text style={{ color: colors.text, fontSize: 18, fontWeight: "700" }}>{approval.reason}</Text>
+        <Text style={{ color: colors.text, fontFamily: "monospace" }}>{summary}</Text>
+        {approval.resume_result_summary ? (
+          <Text style={{ color: colors.textMuted, fontSize: 12 }}>{approval.resume_result_summary}</Text>
+        ) : null}
       </View>
 
-      <Text style={{ color: "#9ca3af", fontSize: 12 }}>
+      <Text style={{ color: colors.textMuted, fontSize: 12 }}>
         Swipe right to approve • Swipe left to deny
       </Text>
 
@@ -69,26 +99,26 @@ export function ApprovalCard({ approval, busy = false, onApprove, onDeny }: Appr
           onPress={onDeny}
           style={{
             alignItems: "center",
-            backgroundColor: "#fee2e2",
+            backgroundColor: colors.surfaceMuted,
             borderRadius: 12,
             flex: 1,
             paddingVertical: 14,
           }}
         >
-          {busy ? <ActivityIndicator /> : <Text style={{ color: "#b91c1c", fontWeight: "700" }}>Deny</Text>}
+          {busy ? <ActivityIndicator color={colors.text} /> : <Text style={{ color: colors.danger, fontWeight: "700" }}>Deny</Text>}
         </Pressable>
         <Pressable
           disabled={busy}
           onPress={onApprove}
           style={{
             alignItems: "center",
-            backgroundColor: "#dcfce7",
+            backgroundColor: colors.primary,
             borderRadius: 12,
             flex: 1,
             paddingVertical: 14,
           }}
         >
-          {busy ? <ActivityIndicator /> : <Text style={{ color: "#15803d", fontWeight: "700" }}>Approve</Text>}
+          {busy ? <ActivityIndicator color={colors.onPrimary} /> : <Text style={{ color: colors.onPrimary, fontWeight: "700" }}>Approve</Text>}
         </Pressable>
       </View>
     </View>

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text, View } from "react-native";
+import { useTheme } from "../../hooks/use-theme";
 
 interface MessageBubbleProps {
   role: "user" | "assistant" | "system";
@@ -7,21 +8,39 @@ interface MessageBubbleProps {
 }
 
 export function MessageBubble({ role, text }: MessageBubbleProps) {
+  const colors = useTheme();
   const isUser = role === "user";
+  const isSystem = role === "system";
+  const backgroundColor = isUser ? colors.primary : isSystem ? colors.surface : colors.surfaceMuted;
+  const textColor = isUser ? colors.onPrimary : colors.text;
+  const alignSelf = isUser ? "flex-end" : "flex-start" as const;
 
   return (
     <View
       style={{
-        alignSelf: isUser ? "flex-end" : "flex-start",
-        backgroundColor: isUser ? "#2563eb" : "#e5e7eb",
+        alignSelf,
+        backgroundColor,
+        borderColor: isSystem ? colors.border : backgroundColor,
         borderRadius: 16,
+        borderWidth: isSystem ? 1 : 0,
         marginBottom: 8,
         maxWidth: "88%",
         paddingHorizontal: 12,
         paddingVertical: 10,
       }}
     >
-      <Text style={{ color: isUser ? "#fff" : "#111827" }}>{text}</Text>
+      <Text
+        style={{
+          color: colors.textMuted,
+          fontSize: 11,
+          fontWeight: "700",
+          marginBottom: 4,
+          textTransform: "uppercase",
+        }}
+      >
+        {role}
+      </Text>
+      <Text style={{ color: textColor }}>{text}</Text>
     </View>
   );
 }


### PR DESCRIPTION
Closes #435\n\n- theme mobile approval cards with the shared palette\n- surface approval status badges and resume summaries\n- align chat bubbles with light/dark theme colors and role labels