### PR TITLE
refactor(runtime): normalize formatting across shipped slices (#421)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -49,8 +49,7 @@ use rune_runtime::{
 };
 use rune_spells_code_review::{CodeReviewToolExecutor, code_review_tool_definition};
 use rune_spells_rust_patterns::{
-    RustPatternsToolExecutor, rust_patterns_tool_definition,
-    rust_patterns_validate_tool_definition,
+    RustPatternsToolExecutor, rust_patterns_tool_definition, rust_patterns_validate_tool_definition,
 };
 use rune_spells_security_audit::security_audit_tool_definition;
 use rune_store::models::{NewToolExecution, SessionRow, TurnRow};
@@ -1391,8 +1390,22 @@ impl CommsOps for CommsClientOps {
         self.client.send(msg_type, subject, body, priority).await
     }
 
-    async fn read_inbox(&self, mark_read: bool) -> Result<Vec<rune_tools::comms_tool::CommsMessageSummary>, String> {
-        self.client.read_inbox_summary(mark_read).await.map(|msgs| msgs.into_iter().map(|msg| rune_tools::comms_tool::CommsMessageSummary { id: msg.id, from: msg.from, subject: msg.subject, body: msg.body, priority: msg.priority, created_at: msg.created_at, }).collect())
+    async fn read_inbox(
+        &self,
+        mark_read: bool,
+    ) -> Result<Vec<rune_tools::comms_tool::CommsMessageSummary>, String> {
+        self.client.read_inbox_summary(mark_read).await.map(|msgs| {
+            msgs.into_iter()
+                .map(|msg| rune_tools::comms_tool::CommsMessageSummary {
+                    id: msg.id,
+                    from: msg.from,
+                    subject: msg.subject,
+                    body: msg.body,
+                    priority: msg.priority,
+                    created_at: msg.created_at,
+                })
+                .collect()
+        })
     }
 }
 

--- a/crates/rune-cli/src/doctor.rs
+++ b/crates/rune-cli/src/doctor.rs
@@ -15,13 +15,12 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::output::{
-    DoctorBackendMatrixEntry, DoctorCheck as OutputDoctorCheck, DoctorMemoryHierarchySummary, DoctorPathSummary, DoctorReport,
-    DoctorTopologySummary,
+    DoctorBackendMatrixEntry, DoctorCheck as OutputDoctorCheck, DoctorMemoryHierarchySummary,
+    DoctorPathSummary, DoctorReport, DoctorTopologySummary,
 };
 use rune_config::{AppConfig, RuntimeMode};
 use serde::Serialize;
 use std::collections::BTreeMap;
-
 
 /// Result of a single diagnostic check.
 #[derive(Clone, Debug, Serialize)]

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -4126,11 +4126,18 @@ mod tests {
         let registry = ProjectRegistry::new();
         registry.save(workspace).unwrap();
 
-        unsafe { std::env::set_var("RUNE_WORKSPACE", workspace); }
+        unsafe {
+            std::env::set_var("RUNE_WORKSPACE", workspace);
+        }
         let err = handle_projects_remove("missing".to_string()).unwrap_err();
-        unsafe { std::env::remove_var("RUNE_WORKSPACE"); }
+        unsafe {
+            std::env::remove_var("RUNE_WORKSPACE");
+        }
 
-        assert!(err.to_string().contains("project 'missing' is not registered"));
+        assert!(
+            err.to_string()
+                .contains("project 'missing' is not registered")
+        );
     }
 
     #[test]
@@ -4138,7 +4145,9 @@ mod tests {
         let cli = Cli::try_parse_from(["rune", "projects", "remove", "alpha"]).unwrap();
 
         match cli.command {
-            Command::Projects { action: ProjectsAction::Remove { name } } => {
+            Command::Projects {
+                action: ProjectsAction::Remove { name },
+            } => {
                 assert_eq!(name, "alpha");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -4167,9 +4176,13 @@ mod tests {
         registry.switch_active("alpha").unwrap();
         registry.save(workspace).unwrap();
 
-        unsafe { std::env::set_var("RUNE_WORKSPACE", workspace); }
+        unsafe {
+            std::env::set_var("RUNE_WORKSPACE", workspace);
+        }
         handle_projects_remove("alpha".to_string()).unwrap();
-        unsafe { std::env::remove_var("RUNE_WORKSPACE"); }
+        unsafe {
+            std::env::remove_var("RUNE_WORKSPACE");
+        }
 
         let updated = ProjectRegistry::load(workspace).unwrap();
         assert!(updated.is_empty());

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -141,15 +141,16 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
                 )
             }
             rune_runtime::CommsTransportKind::Http => {
-                let http = services
-                    .config
-                    .comms
-                    .http
-                    .clone()
-                    .ok_or_else(|| GatewayError::BadRequest("comms.http config is required for HTTP transport".to_string()))?;
-                let base_url = http
-                    .base_url
-                    .ok_or_else(|| GatewayError::BadRequest("comms.http.base_url is required for HTTP transport".to_string()))?;
+                let http = services.config.comms.http.clone().ok_or_else(|| {
+                    GatewayError::BadRequest(
+                        "comms.http config is required for HTTP transport".to_string(),
+                    )
+                })?;
+                let base_url = http.base_url.ok_or_else(|| {
+                    GatewayError::BadRequest(
+                        "comms.http.base_url is required for HTTP transport".to_string(),
+                    )
+                })?;
                 CommsClient::with_http_transport(
                     base_url,
                     http.auth_token,
@@ -664,7 +665,10 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/api/v1/memory/store", post(routes::v1_memory_store))
         .route("/api/v1/memory/list", get(routes::v1_memory_list))
         .route("/api/v1/memory/{id}", delete(routes::v1_memory_delete))
-        .route("/api/v1/memory/vault/sync", post(routes::v1_memory_vault_sync))
+        .route(
+            "/api/v1/memory/vault/sync",
+            post(routes::v1_memory_vault_sync),
+        )
         // Log routes
         .route("/api/logs", get(routes::query_logs))
         // Doctor routes

--- a/crates/rune-gateway/src/state.rs
+++ b/crates/rune-gateway/src/state.rs
@@ -134,7 +134,11 @@ impl TokenMetricsStore {
                 }
             })
             .collect::<Vec<_>>();
-        rows.sort_by(|a, b| a.provider.cmp(&b.provider).then_with(|| a.model.cmp(&b.model)));
+        rows.sort_by(|a, b| {
+            a.provider
+                .cmp(&b.provider)
+                .then_with(|| a.model.cmp(&b.model))
+        });
         rows
     }
 }

--- a/crates/rune-gateway/src/supervisor.rs
+++ b/crates/rune-gateway/src/supervisor.rs
@@ -844,7 +844,6 @@ mod tests {
     use rune_core::JobId;
     use rune_runtime::scheduler::{Job, JobPayload, JobRunStatus, Schedule, SessionTarget};
 
-
     #[tokio::test]
     async fn supervisor_starts_and_stops_cleanly() {
         let mut supervisor = BackgroundSupervisor::new();

--- a/crates/rune-gateway/src/ws.rs
+++ b/crates/rune-gateway/src/ws.rs
@@ -34,7 +34,6 @@ fn current_state_version(state_version: &AtomicU64) -> u64 {
     state_version.load(Ordering::Relaxed)
 }
 
-
 fn method_changes_state(method: &str) -> bool {
     matches!(
         method,
@@ -435,13 +434,7 @@ where
                             } else {
                                 current_state_version(state_version.as_ref())
                             };
-                            Some(encode_res(
-                                &id,
-                                true,
-                                Some(payload),
-                                None,
-                                next_version,
-                            ))
+                            Some(encode_res(&id, true, Some(payload), None, next_version))
                         }
                         Err(rpc_err) => Some(encode_res(
                             &id,

--- a/crates/rune-mcp/src/memory_server.rs
+++ b/crates/rune-mcp/src/memory_server.rs
@@ -28,11 +28,11 @@
 //! }
 //! ```
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{self, BufRead, Write};
 use tracing::{debug, error, info};
 
-use crate::protocol::{JsonRpcRequest, JsonRpcResponse, JsonRpcError, MCP_PROTOCOL_VERSION};
+use crate::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION};
 
 /// Default Rune gateway URL for the memory API.
 ///

--- a/crates/rune-models/src/provider/anthropic.rs
+++ b/crates/rune-models/src/provider/anthropic.rs
@@ -234,7 +234,6 @@ impl ModelProvider for AnthropicProvider {
                     cached_prompt_tokens: cached,
                     uncached_prompt_tokens: created
                         .or_else(|| cached.map(|c| input.saturating_sub(c))),
-
                 }
             },
             finish_reason,

--- a/crates/rune-models/src/provider/azure.rs
+++ b/crates/rune-models/src/provider/azure.rs
@@ -81,7 +81,11 @@ impl ModelProvider for AzureOpenAiProvider {
                 .collect(),
             temperature: request.temperature,
             max_tokens: request.max_tokens,
-            tools: &request.stable_prefix_tools.as_ref().or(request.tools.as_ref()).cloned(),
+            tools: &request
+                .stable_prefix_tools
+                .as_ref()
+                .or(request.tools.as_ref())
+                .cloned(),
         };
 
         debug!(url = %self.url, msg_count = body.messages.len(), "Azure OpenAI completion request");

--- a/crates/rune-models/src/provider/response.rs
+++ b/crates/rune-models/src/provider/response.rs
@@ -1,8 +1,8 @@
 //! Shared response parsing and error mapping for OpenAI-compatible APIs.
 
 use reqwest::Response;
-use std::time::{SystemTime, UNIX_EPOCH};
 use serde::Deserialize;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::ModelError;
 use crate::types::{CompletionResponse, FinishReason, ToolCallRequest, Usage};
@@ -103,7 +103,6 @@ pub(crate) async fn map_error_response(resp: Response) -> ModelError {
     }
 }
 
-
 fn parse_retry_after_header(value: &str) -> Option<u64> {
     let trimmed = value.trim();
     if let Ok(secs) = trimmed.parse::<u64>() {
@@ -112,11 +111,15 @@ fn parse_retry_after_header(value: &str) -> Option<u64> {
 
     let retry_at = httpdate::parse_http_date(trimmed).ok()?;
     let now = SystemTime::now();
-    retry_at.duration_since(now).ok().map(|d| d.as_secs()).or_else(|| {
-        let retry_epoch = retry_at.duration_since(UNIX_EPOCH).ok()?.as_secs();
-        let now_epoch = now.duration_since(UNIX_EPOCH).ok()?.as_secs();
-        Some(retry_epoch.saturating_sub(now_epoch))
-    })
+    retry_at
+        .duration_since(now)
+        .ok()
+        .map(|d| d.as_secs())
+        .or_else(|| {
+            let retry_epoch = retry_at.duration_since(UNIX_EPOCH).ok()?.as_secs();
+            let now_epoch = now.duration_since(UNIX_EPOCH).ok()?.as_secs();
+            Some(retry_epoch.saturating_sub(now_epoch))
+        })
 }
 
 /// Parse a successful API response body.

--- a/crates/rune-models/src/types.rs
+++ b/crates/rune-models/src/types.rs
@@ -4,12 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessagePart {
-    Text {
-        text: String,
-    },
-    ImageUrl {
-        image_url: ImageUrlPart,
-    },
+    Text { text: String },
+    ImageUrl { image_url: ImageUrlPart },
 }
 
 /// OpenAI-compatible image URL content block.
@@ -32,7 +28,10 @@ pub enum Role {
 #[derive(Clone, Debug, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "serialize_message_content")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_message_content"
+    )]
     pub content: Option<String>,
     #[serde(skip)]
     pub content_parts: Option<Vec<MessagePart>>,

--- a/crates/rune-models/tests/provider_tests.rs
+++ b/crates/rune-models/tests/provider_tests.rs
@@ -22,7 +22,7 @@ fn simple_request() -> CompletionRequest {
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
-                content_parts: None,
+            content_parts: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -322,7 +322,7 @@ async fn azure_request_golden_shape_full() {
         stable_prefix_messages: Some(vec![ChatMessage {
             role: Role::System,
             content: Some("You are helpful.".into()),
-                content_parts: None,
+            content_parts: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -2224,7 +2224,7 @@ fn claude_request() -> CompletionRequest {
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
-                content_parts: None,
+            content_parts: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -2547,7 +2547,7 @@ async fn azure_request_prepends_stable_prefix_messages() {
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
-                content_parts: None,
+            content_parts: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -2592,7 +2592,7 @@ async fn openai_request_prepends_stable_prefix_messages() {
         messages: vec![ChatMessage {
             role: Role::User,
             content: Some("Hello".into()),
-                content_parts: None,
+            content_parts: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -2708,10 +2708,13 @@ async fn openai_serializes_multimodal_user_content_parts() {
     let request = CompletionRequest {
         messages: vec![ChatMessage {
             role: Role::User,
-            content: Some("Describe this image
+            content: Some(
+                "Describe this image
 
 [Attachments]
-- photo.jpg (image/jpeg, url=https://example.test/photo.jpg)".into()),
+- photo.jpg (image/jpeg, url=https://example.test/photo.jpg)"
+                    .into(),
+            ),
             content_parts: Some(vec![
                 MessagePart::Text {
                     text: "Describe this image".into(),
@@ -2742,7 +2745,10 @@ async fn openai_serializes_multimodal_user_content_parts() {
     assert_eq!(content[0]["type"], "text");
     assert_eq!(content[0]["text"], "Describe this image");
     assert_eq!(content[1]["type"], "image_url");
-    assert_eq!(content[1]["image_url"]["url"], "https://example.test/photo.jpg");
+    assert_eq!(
+        content[1]["image_url"]["url"],
+        "https://example.test/photo.jpg"
+    );
 }
 
 #[tokio::test]
@@ -2759,10 +2765,13 @@ async fn azure_serializes_multimodal_user_content_parts() {
     let request = CompletionRequest {
         messages: vec![ChatMessage {
             role: Role::User,
-            content: Some("Describe this image
+            content: Some(
+                "Describe this image
 
 [Attachments]
-- photo.jpg (image/jpeg, url=https://example.test/photo.jpg)".into()),
+- photo.jpg (image/jpeg, url=https://example.test/photo.jpg)"
+                    .into(),
+            ),
             content_parts: Some(vec![
                 MessagePart::Text {
                     text: "Describe this image".into(),
@@ -2792,5 +2801,8 @@ async fn azure_serializes_multimodal_user_content_parts() {
     let content = body["messages"][0]["content"].as_array().unwrap();
     assert_eq!(content[0]["type"], "text");
     assert_eq!(content[1]["type"], "image_url");
-    assert_eq!(content[1]["image_url"]["url"], "https://example.test/photo.jpg");
+    assert_eq!(
+        content[1]["image_url"]["url"],
+        "https://example.test/photo.jpg"
+    );
 }

--- a/crates/rune-runtime/src/comms.rs
+++ b/crates/rune-runtime/src/comms.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -132,8 +132,8 @@ fn normalize_http_base_url(base_url: String) -> Result<String, String> {
     if trimmed.is_empty() {
         return Err("http comms base url cannot be empty".to_string());
     }
-    let url = reqwest::Url::parse(trimmed)
-        .map_err(|e| format!("invalid HTTP comms base url: {e}"))?;
+    let url =
+        reqwest::Url::parse(trimmed).map_err(|e| format!("invalid HTTP comms base url: {e}"))?;
     match url.scheme() {
         "http" | "https" => Ok(trimmed.to_string()),
         scheme => Err(format!("unsupported HTTP comms scheme: {scheme}")),
@@ -351,14 +351,15 @@ impl CommsTransport for FsCommsTransport {
     }
 }
 
-
 pub fn build_comms_transport(
     transport: CommsTransportKind,
     comms_dir: impl Into<PathBuf>,
 ) -> Arc<dyn CommsTransport> {
     match transport {
         CommsTransportKind::Filesystem => Arc::new(FsCommsTransport::new(comms_dir)),
-        CommsTransportKind::Http => panic!("http transport requires explicit HttpCommsTransport configuration"),
+        CommsTransportKind::Http => {
+            panic!("http transport requires explicit HttpCommsTransport configuration")
+        }
     }
 }
 
@@ -395,7 +396,11 @@ impl CommsClient {
         agent_id: impl Into<String>,
         peer_id: impl Into<String>,
     ) -> Self {
-        Self::with_transport(build_comms_transport(transport, comms_dir), agent_id, peer_id)
+        Self::with_transport(
+            build_comms_transport(transport, comms_dir),
+            agent_id,
+            peer_id,
+        )
     }
 
     pub fn with_transport(
@@ -594,10 +599,22 @@ mod tests {
 
     #[tokio::test]
     async fn parse_transport_kind_aliases() {
-        assert_eq!(CommsTransportKind::from_str("filesystem").unwrap(), CommsTransportKind::Filesystem);
-        assert_eq!(CommsTransportKind::from_str("FS").unwrap(), CommsTransportKind::Filesystem);
-        assert_eq!(CommsTransportKind::from_str("http").unwrap(), CommsTransportKind::Http);
-        assert_eq!(CommsTransportKind::from_str("HTTPS").unwrap(), CommsTransportKind::Http);
+        assert_eq!(
+            CommsTransportKind::from_str("filesystem").unwrap(),
+            CommsTransportKind::Filesystem
+        );
+        assert_eq!(
+            CommsTransportKind::from_str("FS").unwrap(),
+            CommsTransportKind::Filesystem
+        );
+        assert_eq!(
+            CommsTransportKind::from_str("http").unwrap(),
+            CommsTransportKind::Http
+        );
+        assert_eq!(
+            CommsTransportKind::from_str("HTTPS").unwrap(),
+            CommsTransportKind::Http
+        );
     }
 
     #[tokio::test]
@@ -631,7 +648,9 @@ mod tests {
                 "body": "done",
                 "priority": "p1"
             })))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id":"remote-send"})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id":"remote-send"})),
+            )
             .mount(&server)
             .await;
 
@@ -639,14 +658,16 @@ mod tests {
             .and(path("/api/comms/inbox"))
             .and(query_param("mark_read", "false"))
             .and(header("authorization", "Bearer shared-secret"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(vec![serde_json::json!({
-                "id": "msg-123",
-                "from": "openclaw",
-                "subject": "directive",
-                "body": "ship code",
-                "priority": "p0",
-                "created_at": "2026-03-28T07:00:00Z"
-            })]))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(vec![serde_json::json!({
+                    "id": "msg-123",
+                    "from": "openclaw",
+                    "subject": "directive",
+                    "body": "ship code",
+                    "priority": "p0",
+                    "created_at": "2026-03-28T07:00:00Z"
+                })]),
+            )
             .mount(&server)
             .await;
 
@@ -666,7 +687,10 @@ mod tests {
         )
         .unwrap();
 
-        client.send("status", "ship it", "done", "p1").await.unwrap();
+        client
+            .send("status", "ship it", "done", "p1")
+            .await
+            .unwrap();
 
         let messages = client.read_inbox().await;
         assert_eq!(messages.len(), 1);
@@ -696,14 +720,16 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/api/comms/inbox"))
             .and(query_param("mark_read", "false"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(vec![serde_json::json!({
-                "id": "msg-999",
-                "from": "openclaw",
-                "subject": "status",
-                "body": "merged",
-                "priority": "p2",
-                "created_at": null
-            })]))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(vec![serde_json::json!({
+                    "id": "msg-999",
+                    "from": "openclaw",
+                    "subject": "status",
+                    "body": "merged",
+                    "priority": "p2",
+                    "created_at": null
+                })]),
+            )
             .mount(&server)
             .await;
 
@@ -714,7 +740,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = CommsClient::with_http_transport(server.uri(), None, "rune", "horizon-ai").unwrap();
+        let client =
+            CommsClient::with_http_transport(server.uri(), None, "rune", "horizon-ai").unwrap();
         let summaries = client.read_inbox_summary(true).await.unwrap();
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].id, "msg-999");

--- a/crates/rune-runtime/src/context.rs
+++ b/crates/rune-runtime/src/context.rs
@@ -752,11 +752,26 @@ mod context_tier_tests {
         let assembler = ContextAssembler::new("You are Rune.");
         let specs = assembler.tier_specs();
         assert_eq!(specs.len(), 5);
-        assert_eq!(specs[0], ContextTierSpec::new(ContextTierKind::Identity, 1_000));
-        assert_eq!(specs[1], ContextTierSpec::new(ContextTierKind::ActiveTask, 10_000));
-        assert_eq!(specs[2], ContextTierSpec::new(ContextTierKind::Project, 20_000));
-        assert_eq!(specs[3], ContextTierSpec::new(ContextTierKind::Shared, 5_000));
-        assert_eq!(specs[4], ContextTierSpec::new(ContextTierKind::Historical, 0));
+        assert_eq!(
+            specs[0],
+            ContextTierSpec::new(ContextTierKind::Identity, 1_000)
+        );
+        assert_eq!(
+            specs[1],
+            ContextTierSpec::new(ContextTierKind::ActiveTask, 10_000)
+        );
+        assert_eq!(
+            specs[2],
+            ContextTierSpec::new(ContextTierKind::Project, 20_000)
+        );
+        assert_eq!(
+            specs[3],
+            ContextTierSpec::new(ContextTierKind::Shared, 5_000)
+        );
+        assert_eq!(
+            specs[4],
+            ContextTierSpec::new(ContextTierKind::Historical, 0)
+        );
     }
 
     #[test]
@@ -780,9 +795,11 @@ mod context_tier_tests {
         assert!(report.project_tokens() > 0);
         assert!(report.tokens_for(ContextTierKind::Shared) > 0);
         assert_eq!(report.tokens_for(ContextTierKind::Historical), 0);
-        assert!(report
-            .tiers
-            .iter()
-            .any(|tier| tier.kind == ContextTierKind::ActiveTask && tier.loaded));
+        assert!(
+            report
+                .tiers
+                .iter()
+                .any(|tier| tier.kind == ContextTierKind::ActiveTask && tier.loaded)
+        );
     }
 }

--- a/crates/rune-runtime/src/lane_queue.rs
+++ b/crates/rune-runtime/src/lane_queue.rs
@@ -103,13 +103,12 @@ impl LaneSemaphore {
         // back to a direct semaphore acquire.
         match rx.await {
             Ok(permit) => permit,
-            Err(_) => {
-                self.semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("semaphore should not be closed")
-            }
+            Err(_) => self
+                .semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("semaphore should not be closed"),
         }
     }
 
@@ -396,7 +395,10 @@ mod tests {
     fn lane_from_session_kind_mapping() {
         assert_eq!(Lane::from_session_kind(&SessionKind::Direct), Lane::Main);
         assert_eq!(Lane::from_session_kind(&SessionKind::Channel), Lane::Main);
-        assert_eq!(Lane::from_session_kind(&SessionKind::Subagent), Lane::Subagent);
+        assert_eq!(
+            Lane::from_session_kind(&SessionKind::Subagent),
+            Lane::Subagent
+        );
         assert_eq!(Lane::from_session_kind(&SessionKind::Scheduled), Lane::Cron);
     }
 
@@ -545,7 +547,10 @@ mod tests {
             queue_for_other.acquire_tool(Some("beta")),
         )
         .await;
-        assert!(other_project.is_ok(), "different project should not be blocked");
+        assert!(
+            other_project.is_ok(),
+            "different project should not be blocked"
+        );
     }
 
     #[tokio::test]

--- a/crates/rune-runtime/src/mem0.rs
+++ b/crates/rune-runtime/src/mem0.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::mem0_vault::{VaultSyncer, VaultSyncReport};
+use crate::mem0_vault::{VaultSyncReport, VaultSyncer};
 
 /// A single remembered fact.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/rune-runtime/src/mem0_vault.rs
+++ b/crates/rune-runtime/src/mem0_vault.rs
@@ -49,8 +49,8 @@ impl VaultIndex {
     async fn save(&self, vault_dir: &Path) -> Result<(), String> {
         let path = vault_dir.join(".vault-index.json");
         let tmp = vault_dir.join(".vault-index.json.tmp");
-        let data = serde_json::to_string_pretty(self)
-            .map_err(|e| format!("index serialize: {e}"))?;
+        let data =
+            serde_json::to_string_pretty(self).map_err(|e| format!("index serialize: {e}"))?;
         tokio::fs::write(&tmp, data)
             .await
             .map_err(|e| format!("index write: {e}"))?;
@@ -155,8 +155,14 @@ fn render_fact_md(memory: &Memory, related: &[(String, f64)]) -> String {
     md.push_str("---\n");
     md.push_str(&format!("id: \"{}\"\n", memory.id));
     md.push_str(&format!("category: \"{}\"\n", memory.category));
-    md.push_str(&format!("created_at: \"{}\"\n", memory.created_at.to_rfc3339()));
-    md.push_str(&format!("updated_at: \"{}\"\n", memory.updated_at.to_rfc3339()));
+    md.push_str(&format!(
+        "created_at: \"{}\"\n",
+        memory.created_at.to_rfc3339()
+    ));
+    md.push_str(&format!(
+        "updated_at: \"{}\"\n",
+        memory.updated_at.to_rfc3339()
+    ));
     md.push_str(&format!("access_count: {}\n", memory.access_count));
     if let Some(ref sid) = memory.source_session_id {
         md.push_str(&format!("source_session_id: \"{sid}\"\n"));
@@ -174,10 +180,7 @@ fn render_fact_md(memory: &Memory, related: &[(String, f64)]) -> String {
     if !related.is_empty() {
         md.push_str("\n## Related\n\n");
         for (slug, similarity) in related {
-            md.push_str(&format!(
-                "- [[{slug}]] ({:.0}%)\n",
-                similarity * 100.0
-            ));
+            md.push_str(&format!("- [[{slug}]] ({:.0}%)\n", similarity * 100.0));
         }
     }
 
@@ -339,7 +342,8 @@ impl VaultSyncer {
                             id_to_slug.get(target_id).map(|s| (s.clone(), *sim))
                         })
                         .collect();
-                    links.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                    links
+                        .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
                     links
                 })
                 .unwrap_or_default();
@@ -369,8 +373,7 @@ impl VaultSyncer {
         }
 
         // Prune orphaned files (in index but not in current memories).
-        let live_ids: std::collections::HashSet<Uuid> =
-            memories.iter().map(|m| m.id).collect();
+        let live_ids: std::collections::HashSet<Uuid> = memories.iter().map(|m| m.id).collect();
         let mut idx = self.index.write().await;
         let orphans: Vec<Uuid> = idx
             .entries
@@ -430,7 +433,10 @@ mod tests {
 
     #[test]
     fn slug_basic() {
-        assert_eq!(generate_slug("User prefers dark mode"), "user-prefers-dark-mode");
+        assert_eq!(
+            generate_slug("User prefers dark mode"),
+            "user-prefers-dark-mode"
+        );
     }
 
     #[test]
@@ -577,11 +583,9 @@ mod tests {
         assert_eq!(report.created, 2);
 
         // Check wikilinks are present.
-        let content_a = tokio::fs::read_to_string(
-            tmp.path().join("rune-is-written-in-rust.md"),
-        )
-        .await
-        .unwrap();
+        let content_a = tokio::fs::read_to_string(tmp.path().join("rune-is-written-in-rust.md"))
+            .await
+            .unwrap();
         assert!(content_a.contains("[[project-uses-tokio-for-async]]"));
         assert!(content_a.contains("72%"));
 

--- a/crates/rune-runtime/src/restart_continuity.rs
+++ b/crates/rune-runtime/src/restart_continuity.rs
@@ -2,8 +2,6 @@
 ///
 /// This is intentionally explicit and narrow: only behaviors that are
 /// implemented and covered by tests should be described here.
-pub const RESTART_CONTINUITY_SUMMARY: &str =
-    "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable";
+pub const RESTART_CONTINUITY_SUMMARY: &str = "approval requests, operator-triggered resume, and restart-safe mid-resume continuation are durable";
 
-pub const RESUMED_SESSION_NOTICE_TEMPLATE: &str =
-    "Resumed session `{session_id}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.";
+pub const RESUMED_SESSION_NOTICE_TEMPLATE: &str = "Resumed session `{session_id}` after restart. Transcript history plus durable approval/session state were restored from the last saved activity. In-flight turns, live process handles, and typing/progress UI do not resume in place; send your next message to continue.";

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -136,7 +136,10 @@ impl SessionLoop {
             }
         }
         if !sessions.is_empty() {
-            info!(count = sessions.len(), "restored active channel sessions from DB");
+            info!(
+                count = sessions.len(),
+                "restored active channel sessions from DB"
+            );
         }
         Ok(())
     }

--- a/crates/rune-runtime/src/session_metadata.rs
+++ b/crates/rune-runtime/src/session_metadata.rs
@@ -12,7 +12,6 @@ pub(crate) fn selected_model(session: &SessionRow) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
-
 pub(crate) fn set_selected_model(metadata: &Value, model: &str) -> Value {
     let mut next = metadata.as_object().cloned().unwrap_or_default();
     next.insert(SELECTED_MODEL_KEY.to_string(), json!(model));

--- a/crates/rune-runtime/src/skill.rs
+++ b/crates/rune-runtime/src/skill.rs
@@ -4,8 +4,6 @@
 //! Prefer importing from `crate::spell` directly in new code.
 
 pub use crate::spell::{
-    Spell as Skill,
-    SpellFrontmatter as SkillFrontmatter,
-    SpellRegistry as SkillRegistry,
+    Spell as Skill, SpellFrontmatter as SkillFrontmatter, SpellRegistry as SkillRegistry,
     parse_spell_frontmatter as parse_skill_frontmatter,
 };

--- a/crates/rune-runtime/src/skill_loader.rs
+++ b/crates/rune-runtime/src/skill_loader.rs
@@ -3,7 +3,4 @@
 //! The skill system has been renamed to "spells" (issue #299).
 //! Prefer importing from `crate::spell_loader` directly in new code.
 
-pub use crate::spell_loader::{
-    SpellLoader as SkillLoader,
-    SpellScanSummary as SkillScanSummary,
-};
+pub use crate::spell_loader::{SpellLoader as SkillLoader, SpellScanSummary as SkillScanSummary};

--- a/crates/rune-runtime/src/spell.rs
+++ b/crates/rune-runtime/src/spell.rs
@@ -60,7 +60,6 @@ pub struct Spell {
     pub user_invocable: bool,
 
     // ── #300 SPELL.md manifest fields ───────────────────────────────
-
     /// Dotted namespace, e.g. `"horizon.security-audit"`.
     #[serde(default)]
     pub namespace: Option<String>,

--- a/crates/rune-runtime/src/spell_loader.rs
+++ b/crates/rune-runtime/src/spell_loader.rs
@@ -69,7 +69,13 @@ impl SpellLoader {
         let mut loaded = 0;
         let mut seen_names = Vec::new();
 
-        self.scan_dir_recursive(&self.spells_dir.clone(), &mut discovered, &mut loaded, &mut seen_names).await;
+        self.scan_dir_recursive(
+            &self.spells_dir.clone(),
+            &mut discovered,
+            &mut loaded,
+            &mut seen_names,
+        )
+        .await;
 
         let removed = self.remove_missing_registry_entries(&seen_names).await;
         let elapsed = start.elapsed();
@@ -125,7 +131,8 @@ impl SpellLoader {
                     skill_md
                 } else {
                     // No manifest here — recurse deeper for namespace dirs
-                    self.scan_dir_recursive(&path, discovered, loaded, seen_names).await;
+                    self.scan_dir_recursive(&path, discovered, loaded, seen_names)
+                        .await;
                     continue;
                 };
 
@@ -293,7 +300,9 @@ async fn load_spell_from_path(path: &Path, dir_namespace: Option<&str>) -> Resul
         .unwrap_or_else(|| serde_json::json!({"type": "object", "properties": {}}));
 
     // Use frontmatter namespace or fall back to directory-derived namespace
-    let namespace = frontmatter.namespace.or_else(|| dir_namespace.map(String::from));
+    let namespace = frontmatter
+        .namespace
+        .or_else(|| dir_namespace.map(String::from));
 
     Ok(Spell {
         name,
@@ -316,7 +325,6 @@ async fn load_spell_from_path(path: &Path, dir_namespace: Option<&str>) -> Resul
         triggers: frontmatter.triggers,
     })
 }
-
 
 fn split_markdown_frontmatter(content: &str) -> Option<(&str, &str)> {
     let trimmed = content.trim();
@@ -545,13 +553,18 @@ Run shell commands carefully.
 
         let spell = registry.get("shell-runner").await.expect("spell loaded");
         assert_eq!(spell.model.as_deref(), Some("gpt-4.1-mini"));
-        assert_eq!(spell.allowed_tools, Some(vec!["exec".into(), "read".into()]));
+        assert_eq!(
+            spell.allowed_tools,
+            Some(vec!["exec".into(), "read".into()])
+        );
         assert!(spell.user_invocable);
-        assert!(spell
-            .prompt_body
-            .as_deref()
-            .unwrap_or_default()
-            .contains("Run shell commands carefully."));
+        assert!(
+            spell
+                .prompt_body
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Run shell commands carefully.")
+        );
     }
 
     #[tokio::test]
@@ -586,7 +599,6 @@ enabled: true
         assert_eq!(second.loaded, 1);
         assert!(!registry.get("sticky-spell").await.unwrap().enabled);
     }
-
 
     #[tokio::test]
     async fn scan_rejects_spell_missing_required_version() {

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2485,7 +2485,10 @@ async fn resumed_session_notice_skips_non_restored_sessions() {
         .await;
 
     let sent = sent.lock().await.clone();
-    assert!(sent.is_empty(), "notice should not be sent for sessions that were not restored during startup");
+    assert!(
+        sent.is_empty(),
+        "notice should not be sent for sessions that were not restored during startup"
+    );
 }
 
 #[tokio::test]
@@ -2568,7 +2571,10 @@ async fn create_session_full_persists_mode_in_metadata() {
         .unwrap();
 
     assert_eq!(
-        session.metadata.get("mode").and_then(|value| value.as_str()),
+        session
+            .metadata
+            .get("mode")
+            .and_then(|value| value.as_str()),
         Some("architect")
     );
 }
@@ -2618,7 +2624,10 @@ async fn prompt_prefix_is_stable_across_consecutive_turns() {
     );
 
     executor.execute(session.id, "hello", None).await.unwrap();
-    executor.execute(session.id, "follow-up", None).await.unwrap();
+    executor
+        .execute(session.id, "follow-up", None)
+        .await
+        .unwrap();
 
     let requests = model_handle.requests().await;
     assert!(requests.len() >= 2);

--- a/crates/rune-spells/code-review/src/lib.rs
+++ b/crates/rune-spells/code-review/src/lib.rs
@@ -31,7 +31,11 @@ pub enum CodeReviewError {
 pub enum ReviewTarget {
     File(PathBuf),
     Diff(String),
-    PullRequest { owner: String, repo: String, number: u64 },
+    PullRequest {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -278,7 +282,11 @@ fn parse_dimension(raw: &str) -> Option<Dimension> {
 
 fn parse_review_target(target_str: &str, workspace_root: &Path) -> Result<ReviewTarget, ToolError> {
     if let Some((owner, repo, number)) = parse_pr_target(target_str) {
-        return Ok(ReviewTarget::PullRequest { owner, repo, number });
+        return Ok(ReviewTarget::PullRequest {
+            owner,
+            repo,
+            number,
+        });
     }
 
     let candidate = Path::new(target_str);
@@ -290,9 +298,9 @@ fn parse_review_target(target_str: &str, workspace_root: &Path) -> Result<Review
             });
         }
 
-        let workspace_root = workspace_root.canonicalize().map_err(|e| {
-            ToolError::ExecutionFailed(format!("workspace root invalid: {e}"))
-        })?;
+        let workspace_root = workspace_root
+            .canonicalize()
+            .map_err(|e| ToolError::ExecutionFailed(format!("workspace root invalid: {e}")))?;
         let joined = workspace_root.join(candidate);
         if !joined.exists() {
             return Err(ToolError::InvalidArguments {
@@ -300,9 +308,9 @@ fn parse_review_target(target_str: &str, workspace_root: &Path) -> Result<Review
                 reason: "path does not exist".into(),
             });
         }
-        let resolved = joined.canonicalize().map_err(|e| {
-            ToolError::ExecutionFailed(format!("path resolution failed: {e}"))
-        })?;
+        let resolved = joined
+            .canonicalize()
+            .map_err(|e| ToolError::ExecutionFailed(format!("path resolution failed: {e}")))?;
         if !resolved.starts_with(&workspace_root) {
             return Err(ToolError::InvalidArguments {
                 tool: "code_review".to_string(),
@@ -330,7 +338,10 @@ fn parse_pr_target(raw: &str) -> Option<(String, String, u64)> {
     Some((owner.to_string(), repo.to_string(), number))
 }
 
-pub async fn code_review(target: &ReviewTarget, config: &ReviewConfig) -> Result<ReviewReport, CodeReviewError> {
+pub async fn code_review(
+    target: &ReviewTarget,
+    config: &ReviewConfig,
+) -> Result<ReviewReport, CodeReviewError> {
     let mut findings = Vec::new();
     let mut pass_results = Vec::new();
 
@@ -351,7 +362,10 @@ pub async fn code_review(target: &ReviewTarget, config: &ReviewConfig) -> Result
             }
 
             if config.enable_semantic {
-                info!("Semantic review stub: would call LLM on file {}", path.display());
+                info!(
+                    "Semantic review stub: would call LLM on file {}",
+                    path.display()
+                );
                 pass_results.push(PassResult {
                     pass: ReviewPass::Structure,
                     summary: "Semantic structure review placeholder".to_string(),
@@ -376,14 +390,24 @@ pub async fn code_review(target: &ReviewTarget, config: &ReviewConfig) -> Result
                 file: "<diff>".to_string(),
                 line: None,
                 title: "Diff review is currently semantic-only".to_string(),
-                explanation: "Mechanical AST checks require a file target in this initial implementation.".to_string(),
-                suggestion: Some("Review a workspace-relative file path for AST-backed checks.".to_string()),
+                explanation:
+                    "Mechanical AST checks require a file target in this initial implementation."
+                        .to_string(),
+                suggestion: Some(
+                    "Review a workspace-relative file path for AST-backed checks.".to_string(),
+                ),
             });
         }
-        ReviewTarget::PullRequest { owner, repo, number } => {
+        ReviewTarget::PullRequest {
+            owner,
+            repo,
+            number,
+        } => {
             pass_results.push(PassResult {
                 pass: ReviewPass::Structure,
-                summary: format!("PR target {owner}/{repo}#{number} queued for external diff fetch"),
+                summary: format!(
+                    "PR target {owner}/{repo}#{number} queued for external diff fetch"
+                ),
                 findings: 0,
             });
             findings.push(Finding {
@@ -424,7 +448,8 @@ fn mechanical_review(
     path: &Path,
     dimensions: &[Dimension],
 ) -> Result<Vec<Finding>, CodeReviewError> {
-    let syntax = syn::parse_file(content).map_err(|e| CodeReviewError::ParseError(e.to_string()))?;
+    let syntax =
+        syn::parse_file(content).map_err(|e| CodeReviewError::ParseError(e.to_string()))?;
     let review_file = path.display().to_string();
     let mut visitor = MechanicalVisitor::default();
     visitor.visit_file(&syntax);
@@ -439,8 +464,13 @@ fn mechanical_review(
                 file: review_file.clone(),
                 line: Some(line),
                 title: "unsafe block requires manual justification".to_string(),
-                explanation: "Unsafe Rust bypasses compiler guarantees and needs an explicit safety review.".to_string(),
-                suggestion: Some("Document the safety invariant and add focused tests around the unsafe block.".to_string()),
+                explanation:
+                    "Unsafe Rust bypasses compiler guarantees and needs an explicit safety review."
+                        .to_string(),
+                suggestion: Some(
+                    "Document the safety invariant and add focused tests around the unsafe block."
+                        .to_string(),
+                ),
             });
         }
     }
@@ -504,8 +534,13 @@ fn mechanical_review(
             file: review_file,
             line: None,
             title: "file has no inline test module".to_string(),
-            explanation: "The review engine did not detect a #[cfg(test)] mod tests block in this file.".to_string(),
-            suggestion: Some("Add focused unit tests for new logic or ensure coverage exists elsewhere.".to_string()),
+            explanation:
+                "The review engine did not detect a #[cfg(test)] mod tests block in this file."
+                    .to_string(),
+            suggestion: Some(
+                "Add focused unit tests for new logic or ensure coverage exists elsewhere."
+                    .to_string(),
+            ),
         });
     }
 
@@ -574,7 +609,10 @@ impl<'ast> Visit<'ast> for MechanicalVisitor {
                     .iter()
                     .map(|segment| segment.ident.to_string())
                     .collect::<Vec<_>>();
-                if segments == ["std", "thread", "sleep"] || segments == ["std", "fs", "read_to_string"] || segments == ["std", "fs", "read"] {
+                if segments == ["std", "thread", "sleep"]
+                    || segments == ["std", "fs", "read_to_string"]
+                    || segments == ["std", "fs", "read"]
+                {
                     self.blocking_async_lines.push(0);
                 }
             }
@@ -592,14 +630,15 @@ fn item_has_test_cfg(item: &syn::Item) -> bool {
 }
 
 fn attrs_have_test_cfg(attrs: &[syn::Attribute]) -> bool {
-    attrs.iter().any(|attr| attr.path().is_ident("test") || attr.path().is_ident("cfg"))
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("test") || attr.path().is_ident("cfg"))
 }
-
 
 #[cfg(test)]
 mod tests {
-    use rune_core::ToolCallId;
     use super::*;
+    use rune_core::ToolCallId;
     use tempfile::tempdir;
 
     fn tool_call(name: &str, arguments: serde_json::Value) -> ToolCall {
@@ -612,11 +651,15 @@ mod tests {
 
     #[test]
     fn parses_pr_target_with_owner_repo_number() {
-        let target = parse_review_target("ghostrider0470/rune#123", Path::new("."))
-            .expect("should parse");
+        let target =
+            parse_review_target("ghostrider0470/rune#123", Path::new(".")).expect("should parse");
 
         match target {
-            ReviewTarget::PullRequest { owner, repo, number } => {
+            ReviewTarget::PullRequest {
+                owner,
+                repo,
+                number,
+            } => {
                 assert_eq!(owner, "ghostrider0470");
                 assert_eq!(repo, "rune");
                 assert_eq!(number, 123);
@@ -669,7 +712,12 @@ async fn run(m: std::sync::Mutex<String>) {
 
         let target = ReviewTarget::File(file_path.clone());
         let config = ReviewConfig {
-            dimensions: vec![Dimension::Security, Dimension::Performance, Dimension::Correctness, Dimension::Maintainability],
+            dimensions: vec![
+                Dimension::Security,
+                Dimension::Performance,
+                Dimension::Correctness,
+                Dimension::Maintainability,
+            ],
             enable_mechanical: true,
             enable_semantic: false,
             ..ReviewConfig::default()
@@ -677,12 +725,42 @@ async fn run(m: std::sync::Mutex<String>) {
 
         let report = code_review(&target, &config).await.unwrap();
         assert!(report.blocks_merge);
-        assert!(report.findings.iter().any(|f| f.title.contains("unsafe block")));
-        assert!(report.findings.iter().any(|f| f.title.contains("unwrap() used")));
-        assert!(report.findings.iter().any(|f| f.title.contains("lock().unwrap()")));
-        assert!(report.findings.iter().any(|f| f.title.contains("blocking call inside async")));
-        assert!(report.findings.iter().any(|f| f.title.contains("clone() detected")));
-        assert!(report.pass_results.iter().any(|p| matches!(p.pass, ReviewPass::Detail)));
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("unsafe block"))
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("unwrap() used"))
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("lock().unwrap()"))
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("blocking call inside async"))
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("clone() detected"))
+        );
+        assert!(
+            report
+                .pass_results
+                .iter()
+                .any(|p| matches!(p.pass, ReviewPass::Detail))
+        );
     }
 
     #[tokio::test]
@@ -710,6 +788,11 @@ mod tests {
             ..ReviewConfig::default()
         };
         let report = code_review(&target, &config).await.unwrap();
-        assert!(!report.findings.iter().any(|f| f.title.contains("no inline test module")));
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|f| f.title.contains("no inline test module"))
+        );
     }
 }

--- a/crates/rune-spells/security-audit/src/lib.rs
+++ b/crates/rune-spells/security-audit/src/lib.rs
@@ -172,12 +172,11 @@ impl ToolExecutor for SecurityAuditToolExecutor {
             severity_threshold: Option<String>,
         }
 
-        let args: RawArgs = serde_json::from_value(call.arguments).map_err(|e| {
-            ToolError::InvalidArguments {
+        let args: RawArgs =
+            serde_json::from_value(call.arguments).map_err(|e| ToolError::InvalidArguments {
                 tool: call.tool_name.clone(),
                 reason: format!("invalid security_audit arguments: {e}"),
-            }
-        })?;
+            })?;
 
         let target = self.resolve_target(args.target.as_deref())?;
         let threshold = match args.severity_threshold.as_deref() {
@@ -188,7 +187,7 @@ impl ToolExecutor for SecurityAuditToolExecutor {
                 return Err(ToolError::InvalidArguments {
                     tool: call.tool_name.clone(),
                     reason: format!("unsupported severity_threshold: {other}"),
-                })
+                });
             }
         };
 
@@ -303,7 +302,10 @@ fn scan_open_ports() -> Vec<AuditFinding> {
                 check: "open_ports".into(),
                 severity,
                 status: "observed".into(),
-                summary: format!("Detected {} listening socket entries via {cmd}", ports.len()),
+                summary: format!(
+                    "Detected {} listening socket entries via {cmd}",
+                    ports.len()
+                ),
                 detail: if ports.is_empty() {
                     format!("{cmd} returned no listening sockets")
                 } else {
@@ -418,13 +420,21 @@ fn scan_ssh_config() -> Vec<AuditFinding> {
     if let Ok(meta) = fs::metadata(&ssh_dir) {
         let mode = meta.permissions().mode() & 0o777;
         if mode != 0o700 {
-            issues.push(format!("{} mode {:o}; expected 700", ssh_dir.display(), mode));
+            issues.push(format!(
+                "{} mode {:o}; expected 700",
+                ssh_dir.display(),
+                mode
+            ));
         }
     }
     if let Ok(meta) = fs::metadata(&config) {
         let mode = meta.permissions().mode() & 0o777;
         if mode & 0o077 != 0 {
-            issues.push(format!("{} mode {:o}; expected 600", config.display(), mode));
+            issues.push(format!(
+                "{} mode {:o}; expected 600",
+                config.display(),
+                mode
+            ));
         }
     }
     if let Ok(contents) = fs::read_to_string(&config) {
@@ -582,8 +592,7 @@ fn secret_patterns() -> Vec<SecretPattern> {
         SecretPattern {
             name: "slack_token",
             severity: Severity::Critical,
-            regex: Regex::new(r"xox[bpoas]-[A-Za-z0-9-]+")
-                .expect("valid slack regex"),
+            regex: Regex::new(r"xox[bpoas]-[A-Za-z0-9-]+").expect("valid slack regex"),
         },
         SecretPattern {
             name: "openai_key",
@@ -593,8 +602,7 @@ fn secret_patterns() -> Vec<SecretPattern> {
         SecretPattern {
             name: "jwt_token",
             severity: Severity::Warning,
-            regex: Regex::new(r"eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.")
-                .expect("valid jwt regex"),
+            regex: Regex::new(r"eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.").expect("valid jwt regex"),
         },
         SecretPattern {
             name: "private_key",
@@ -666,7 +674,9 @@ fn walk(path: &Path, exclude_patterns: &[String], out: &mut Vec<PathBuf>, sensit
 
 fn should_skip(path: &Path, exclude_patterns: &[String]) -> bool {
     let rendered = path.to_string_lossy();
-    exclude_patterns.iter().any(|pattern| rendered.contains(pattern))
+    exclude_patterns
+        .iter()
+        .any(|pattern| rendered.contains(pattern))
 }
 
 fn is_sensitive_path(path: &Path) -> bool {
@@ -758,7 +768,11 @@ mod tests {
         .unwrap();
 
         let findings = scan_secrets(dir.path(), &[]);
-        assert!(findings.iter().any(|f| f.summary.contains("aws_access_key")));
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.summary.contains("aws_access_key"))
+        );
         assert!(findings.iter().any(|f| f.summary.contains("openai_key")));
     }
 
@@ -794,7 +808,11 @@ mod tests {
     #[tokio::test]
     async fn tool_executor_runs_workspace_relative_scan() {
         let dir = tempdir().unwrap();
-        fs::write(dir.path().join("secrets.env"), "token=ghp_123456789012345678901234567890123456").unwrap();
+        fs::write(
+            dir.path().join("secrets.env"),
+            "token=ghp_123456789012345678901234567890123456",
+        )
+        .unwrap();
         let executor = SecurityAuditToolExecutor::new(dir.path());
 
         let result = executor

--- a/crates/rune-store/src/cosmos/approval.rs
+++ b/crates/rune-store/src/cosmos/approval.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, parse_doc, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, parse_doc};
 use crate::error::StoreError;
 use crate::models::{ApprovalRow, NewApproval};
 use crate::repos::ApprovalRepo;
@@ -118,7 +118,10 @@ impl ApprovalRepo for CosmosStore {
                     StoreError::Database(msg)
                 }
             })?;
-        let doc: ApprovalDoc = parse_doc(resp.into_model().map_err(|e| StoreError::Database(e.to_string()))?)?;
+        let doc: ApprovalDoc = parse_doc(
+            resp.into_model()
+                .map_err(|e| StoreError::Database(e.to_string()))?,
+        )?;
         Ok(ApprovalRow::from(doc))
     }
 

--- a/crates/rune-store/src/cosmos/device.rs
+++ b/crates/rune-store/src/cosmos/device.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, parse_doc, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, parse_doc};
 use crate::error::StoreError;
 use crate::models::{NewPairedDevice, NewPairingRequest, PairedDeviceRow, PairingRequestRow};
 use crate::repos::DeviceRepo;
@@ -162,8 +162,10 @@ impl DeviceRepo for CosmosStore {
                     StoreError::Database(msg)
                 }
             })?;
-        let doc: DeviceDoc =
-            parse_doc(resp.into_model().map_err(|e| StoreError::Database(e.to_string()))?)?;
+        let doc: DeviceDoc = parse_doc(
+            resp.into_model()
+                .map_err(|e| StoreError::Database(e.to_string()))?,
+        )?;
         Ok(PairedDeviceRow::from(doc))
     }
 

--- a/crates/rune-store/src/cosmos/job.rs
+++ b/crates/rune-store/src/cosmos/job.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{parse_doc, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, parse_doc, pk};
 use crate::error::StoreError;
 use crate::models::{JobRow, NewJob};
 use crate::repos::JobRepo;
@@ -114,7 +114,10 @@ async fn read_job(store: &CosmosStore, id: Uuid) -> Result<JobDoc, StoreError> {
                 StoreError::Database(msg)
             }
         })?;
-    parse_doc(resp.into_model().map_err(|e| StoreError::Database(e.to_string()))?)
+    parse_doc(
+        resp.into_model()
+            .map_err(|e| StoreError::Database(e.to_string()))?,
+    )
 }
 
 #[async_trait]

--- a/crates/rune-store/src/cosmos/job_run.rs
+++ b/crates/rune-store/src/cosmos/job_run.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, pk};
 use crate::error::StoreError;
 use crate::models::{JobRunRow, NewJobRun};
 use crate::repos::JobRunRepo;

--- a/crates/rune-store/src/cosmos/memory_fact.rs
+++ b/crates/rune-store/src/cosmos/memory_fact.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{pk, CosmosStore};
+use crate::cosmos::{CosmosStore, pk};
 use crate::error::StoreError;
 use crate::models::{MemoryFact, MemoryFactEdge};
 use crate::repos::MemoryFactRepo;
@@ -28,61 +28,155 @@ struct MemoryFactDoc {
 
 impl From<MemoryFactDoc> for MemoryFact {
     fn from(d: MemoryFactDoc) -> Self {
-        Self { id: d.fact_id, fact: d.fact, category: d.category, source_session_id: d.source_session_id, created_at: d.created_at, updated_at: d.updated_at, access_count: d.access_count }
+        Self {
+            id: d.fact_id,
+            fact: d.fact,
+            category: d.category,
+            source_session_id: d.source_session_id,
+            created_at: d.created_at,
+            updated_at: d.updated_at,
+            access_count: d.access_count,
+        }
     }
 }
 
 #[derive(Debug, Deserialize)]
-struct VectorHit { fact_id: Uuid, fact: String, category: String, source_session_id: Option<Uuid>, created_at: DateTime<Utc>, updated_at: DateTime<Utc>, access_count: i32, score: f64 }
+struct VectorHit {
+    fact_id: Uuid,
+    fact: String,
+    category: String,
+    source_session_id: Option<Uuid>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    access_count: i32,
+    score: f64,
+}
 
 #[derive(Debug, Deserialize)]
-struct DedupHit { fact_id: Uuid, fact: String, score: f64 }
+struct DedupHit {
+    fact_id: Uuid,
+    fact: String,
+    score: f64,
+}
 
 #[derive(Debug, Deserialize)]
-struct EmbeddingOnly { fact_id: Uuid, embedding: Vec<f32> }
+struct EmbeddingOnly {
+    fact_id: Uuid,
+    embedding: Vec<f32>,
+}
 
 #[async_trait]
 impl MemoryFactRepo for CosmosStore {
-    async fn recall(&self, embedding_str: &str, threshold: f64, limit: i64) -> Result<Vec<MemoryFact>, StoreError> {
-        let sql = format!("SELECT TOP {} c.fact_id, c.fact, c.category, c.source_session_id, c.created_at, c.updated_at, c.access_count, VectorDistance(c.embedding, {}) AS score FROM c WHERE c.type = 'memory_fact' ORDER BY VectorDistance(c.embedding, {})", limit, embedding_str, embedding_str);
+    async fn recall(
+        &self,
+        embedding_str: &str,
+        threshold: f64,
+        limit: i64,
+    ) -> Result<Vec<MemoryFact>, StoreError> {
+        let sql = format!(
+            "SELECT TOP {} c.fact_id, c.fact, c.category, c.source_session_id, c.created_at, c.updated_at, c.access_count, VectorDistance(c.embedding, {}) AS score FROM c WHERE c.type = 'memory_fact' ORDER BY VectorDistance(c.embedding, {})",
+            limit, embedding_str, embedding_str
+        );
         let hits: Vec<VectorHit> = self.query_cross_partition(&sql).await?;
-        Ok(hits.into_iter().filter(|h| h.score > threshold).map(|h| MemoryFact { id: h.fact_id, fact: h.fact, category: h.category, source_session_id: h.source_session_id, created_at: h.created_at, updated_at: h.updated_at, access_count: h.access_count }).collect())
+        Ok(hits
+            .into_iter()
+            .filter(|h| h.score > threshold)
+            .map(|h| MemoryFact {
+                id: h.fact_id,
+                fact: h.fact,
+                category: h.category,
+                source_session_id: h.source_session_id,
+                created_at: h.created_at,
+                updated_at: h.updated_at,
+                access_count: h.access_count,
+            })
+            .collect())
     }
 
     async fn increment_access(&self, ids: &[Uuid]) -> Result<(), StoreError> {
         for id in ids {
-            let query = format!("SELECT * FROM c WHERE c.type = 'memory_fact' AND c.fact_id = '{}'", id);
+            let query = format!(
+                "SELECT * FROM c WHERE c.type = 'memory_fact' AND c.fact_id = '{}'",
+                id
+            );
             let docs: Vec<MemoryFactDoc> = self.query_cross_partition(&query).await?;
             if let Some(mut doc) = docs.into_iter().next() {
                 doc.access_count += 1;
-                self.container().upsert_item(pk(&doc.pk), &doc, None).await?;
+                self.container()
+                    .upsert_item(pk(&doc.pk), &doc, None)
+                    .await?;
             }
         }
         Ok(())
     }
 
-    async fn dedup_check(&self, embedding_str: &str, threshold: f64) -> Result<Option<(Uuid, String, f64)>, StoreError> {
-        let sql = format!("SELECT TOP 1 c.fact_id, c.fact, VectorDistance(c.embedding, {}) AS score FROM c WHERE c.type = 'memory_fact' ORDER BY VectorDistance(c.embedding, {})", embedding_str, embedding_str);
+    async fn dedup_check(
+        &self,
+        embedding_str: &str,
+        threshold: f64,
+    ) -> Result<Option<(Uuid, String, f64)>, StoreError> {
+        let sql = format!(
+            "SELECT TOP 1 c.fact_id, c.fact, VectorDistance(c.embedding, {}) AS score FROM c WHERE c.type = 'memory_fact' ORDER BY VectorDistance(c.embedding, {})",
+            embedding_str, embedding_str
+        );
         let hits: Vec<DedupHit> = self.query_cross_partition(&sql).await?;
-        Ok(hits.into_iter().next().filter(|h| h.score > threshold).map(|h| (h.fact_id, h.fact, h.score)))
+        Ok(hits
+            .into_iter()
+            .next()
+            .filter(|h| h.score > threshold)
+            .map(|h| (h.fact_id, h.fact, h.score)))
     }
 
-    async fn insert(&self, id: Uuid, fact: &str, category: &str, embedding_str: &str, source_session_id: Option<Uuid>, now: DateTime<Utc>) -> Result<(), StoreError> {
+    async fn insert(
+        &self,
+        id: Uuid,
+        fact: &str,
+        category: &str,
+        embedding_str: &str,
+        source_session_id: Option<Uuid>,
+        now: DateTime<Utc>,
+    ) -> Result<(), StoreError> {
         let embedding = parse_embedding_str(embedding_str)?;
-        let doc = MemoryFactDoc { id: id.to_string(), pk: format!("fact:{}", id), doc_type: "memory_fact".to_string(), fact_id: id, fact: fact.to_string(), category: category.to_string(), embedding, source_session_id, created_at: now, updated_at: now, access_count: 0 };
-        self.container().upsert_item(pk(&doc.pk), &doc, None).await?;
+        let doc = MemoryFactDoc {
+            id: id.to_string(),
+            pk: format!("fact:{}", id),
+            doc_type: "memory_fact".to_string(),
+            fact_id: id,
+            fact: fact.to_string(),
+            category: category.to_string(),
+            embedding,
+            source_session_id,
+            created_at: now,
+            updated_at: now,
+            access_count: 0,
+        };
+        self.container()
+            .upsert_item(pk(&doc.pk), &doc, None)
+            .await?;
         Ok(())
     }
 
-    async fn update(&self, id: Uuid, fact: &str, category: &str, embedding_str: &str, now: DateTime<Utc>) -> Result<(), StoreError> {
-        let query = format!("SELECT * FROM c WHERE c.type = 'memory_fact' AND c.fact_id = '{}'", id);
+    async fn update(
+        &self,
+        id: Uuid,
+        fact: &str,
+        category: &str,
+        embedding_str: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), StoreError> {
+        let query = format!(
+            "SELECT * FROM c WHERE c.type = 'memory_fact' AND c.fact_id = '{}'",
+            id
+        );
         let docs: Vec<MemoryFactDoc> = self.query_cross_partition(&query).await?;
         if let Some(mut doc) = docs.into_iter().next() {
             doc.fact = fact.to_string();
             doc.category = category.to_string();
             doc.embedding = parse_embedding_str(embedding_str)?;
             doc.updated_at = now;
-            self.container().upsert_item(pk(&doc.pk), &doc, None).await?;
+            self.container()
+                .upsert_item(pk(&doc.pk), &doc, None)
+                .await?;
         }
         Ok(())
     }
@@ -91,7 +185,14 @@ impl MemoryFactRepo for CosmosStore {
         let pk_val = format!("fact:{}", id);
         match self.container().delete_item(pk(&pk_val), id, None).await {
             Ok(_) => Ok(()),
-            Err(e) => { let msg = e.to_string(); if msg.contains("NotFound") || msg.contains("404") { Ok(()) } else { Err(StoreError::Database(msg)) } }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("NotFound") || msg.contains("404") {
+                    Ok(())
+                } else {
+                    Err(StoreError::Database(msg))
+                }
+            }
         }
     }
 
@@ -101,7 +202,11 @@ impl MemoryFactRepo for CosmosStore {
         Ok(docs.into_iter().map(MemoryFact::from).collect())
     }
 
-    async fn graph_edges(&self, threshold: f64, neighbors_k: i64) -> Result<Vec<MemoryFactEdge>, StoreError> {
+    async fn graph_edges(
+        &self,
+        threshold: f64,
+        neighbors_k: i64,
+    ) -> Result<Vec<MemoryFactEdge>, StoreError> {
         let sql = "SELECT c.fact_id, c.embedding FROM c WHERE c.type = 'memory_fact'";
         let docs: Vec<EmbeddingOnly> = self.query_cross_partition(sql).await?;
         let mut edges = Vec::new();
@@ -109,11 +214,17 @@ impl MemoryFactRepo for CosmosStore {
             let mut neighbors: Vec<(Uuid, f64)> = Vec::new();
             for b in docs.iter().skip(i + 1) {
                 let sim = cosine_similarity(&a.embedding, &b.embedding);
-                if sim > threshold { neighbors.push((b.fact_id, sim)); }
+                if sim > threshold {
+                    neighbors.push((b.fact_id, sim));
+                }
             }
             neighbors.sort_by(|x, y| y.1.partial_cmp(&x.1).unwrap_or(std::cmp::Ordering::Equal));
             for (target_id, sim) in neighbors.into_iter().take(neighbors_k as usize) {
-                edges.push(MemoryFactEdge { source: a.fact_id, target: target_id, similarity: sim });
+                edges.push(MemoryFactEdge {
+                    source: a.fact_id,
+                    target: target_id,
+                    similarity: sim,
+                });
             }
         }
         Ok(edges)
@@ -121,14 +232,25 @@ impl MemoryFactRepo for CosmosStore {
 }
 
 fn parse_embedding_str(s: &str) -> Result<Vec<f32>, StoreError> {
-    s.trim_start_matches('[').trim_end_matches(']').split(',')
-        .map(|v| v.trim().parse::<f32>().map_err(|e| StoreError::Serialization(format!("bad embedding float: {e}"))))
+    s.trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(',')
+        .map(|v| {
+            v.trim()
+                .parse::<f32>()
+                .map_err(|e| StoreError::Serialization(format!("bad embedding float: {e}")))
+        })
         .collect()
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     let (mut dot, mut na, mut nb) = (0.0f64, 0.0f64, 0.0f64);
-    for (x, y) in a.iter().zip(b.iter()) { let (x, y) = (*x as f64, *y as f64); dot += x * y; na += x * x; nb += y * y; }
+    for (x, y) in a.iter().zip(b.iter()) {
+        let (x, y) = (*x as f64, *y as f64);
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
     let d = na.sqrt() * nb.sqrt();
     if d == 0.0 { 0.0 } else { dot / d }
 }

--- a/crates/rune-store/src/cosmos/mod.rs
+++ b/crates/rune-store/src/cosmos/mod.rs
@@ -85,7 +85,9 @@ impl CosmosStore {
         let resource_link = "dbs/rune/colls/rune";
 
         // Step 1: get partition key ranges
-        let pk_ranges = self.get_partition_key_ranges(&client, resource_link).await?;
+        let pk_ranges = self
+            .get_partition_key_ranges(&client, resource_link)
+            .await?;
 
         // Step 2: query each range, paginating with continuation
         let url = format!("{}/{}/docs", self.endpoint, resource_link);
@@ -169,8 +171,7 @@ impl CosmosStore {
         let date = chrono::Utc::now()
             .format("%a, %d %b %Y %H:%M:%S GMT")
             .to_string();
-        let auth_token =
-            generate_auth_token(&self.key, "get", "pkranges", resource_link, &date)?;
+        let auth_token = generate_auth_token(&self.key, "get", "pkranges", resource_link, &date)?;
 
         let resp = client
             .get(&url)

--- a/crates/rune-store/src/cosmos/process.rs
+++ b/crates/rune-store/src/cosmos/process.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, pk};
 use crate::error::StoreError;
 use crate::models::{NewProcessHandle, ProcessHandleRow};
 use crate::repos::ProcessHandleRepo;
@@ -89,7 +89,10 @@ fn process_row_to_doc(row: &ProcessHandleRow) -> ProcessHandleDoc {
 }
 
 /// Read a process handle by ID. Cross-partition since we may not know session_id.
-async fn read_process(store: &CosmosStore, process_id: Uuid) -> Result<ProcessHandleDoc, StoreError> {
+async fn read_process(
+    store: &CosmosStore,
+    process_id: Uuid,
+) -> Result<ProcessHandleDoc, StoreError> {
     let query = format!(
         "SELECT * FROM c WHERE c.type = 'process_handle' AND c.process_id = '{}'",
         process_id
@@ -136,13 +139,9 @@ impl ProcessHandleRepo for CosmosStore {
         Ok(row)
     }
 
-    async fn list_by_session(
-        &self,
-        session_id: Uuid,
-    ) -> Result<Vec<ProcessHandleRow>, StoreError> {
+    async fn list_by_session(&self, session_id: Uuid) -> Result<Vec<ProcessHandleRow>, StoreError> {
         let pk_val = session_id.to_string();
-        let query =
-            "SELECT * FROM c WHERE c.type = 'process_handle' ORDER BY c.started_at DESC";
+        let query = "SELECT * FROM c WHERE c.type = 'process_handle' ORDER BY c.started_at DESC";
         let stream = self
             .container()
             .query_items::<serde_json::Value>(query, pk(&pk_val), None)
@@ -152,8 +151,7 @@ impl ProcessHandleRepo for CosmosStore {
     }
 
     async fn list_active(&self) -> Result<Vec<ProcessHandleRow>, StoreError> {
-        let query =
-            "SELECT * FROM c WHERE c.type = 'process_handle' \
+        let query = "SELECT * FROM c WHERE c.type = 'process_handle' \
              AND c.status IN ('running', 'backgrounded')";
         let docs: Vec<ProcessHandleDoc> = self.query_cross_partition(query).await?;
         Ok(docs.into_iter().map(ProcessHandleRow::from).collect())

--- a/crates/rune-store/src/cosmos/session.rs
+++ b/crates/rune-store/src/cosmos/session.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{parse_doc, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, parse_doc, pk};
 use crate::error::StoreError;
 use crate::models::{NewSession, SessionRow};
 use crate::repos::SessionRepo;
@@ -125,7 +125,10 @@ impl SessionRepo for CosmosStore {
                     StoreError::Database(msg)
                 }
             })?;
-        let doc: SessionDoc = parse_doc(resp.into_model().map_err(|e| StoreError::Database(e.to_string()))?)?;
+        let doc: SessionDoc = parse_doc(
+            resp.into_model()
+                .map_err(|e| StoreError::Database(e.to_string()))?,
+        )?;
         Ok(SessionRow::from(doc))
     }
 
@@ -226,11 +229,7 @@ impl SessionRepo for CosmosStore {
 
     async fn delete(&self, id: Uuid) -> Result<bool, StoreError> {
         let sid = id.to_string();
-        match self
-            .container()
-            .delete_item(pk(&sid), &sid, None)
-            .await
-        {
+        match self.container().delete_item(pk(&sid), &sid, None).await {
             Ok(_) => Ok(true),
             Err(e) => {
                 let msg = e.to_string();
@@ -244,8 +243,7 @@ impl SessionRepo for CosmosStore {
     }
 
     async fn list_active_channel_sessions(&self) -> Result<Vec<SessionRow>, StoreError> {
-        let query =
-            "SELECT * FROM c WHERE c.type = 'session' AND IS_DEFINED(c.channel_ref) \
+        let query = "SELECT * FROM c WHERE c.type = 'session' AND IS_DEFINED(c.channel_ref) \
              AND c.channel_ref != null \
              AND c.status NOT IN ('completed', 'failed', 'cancelled')";
         let docs: Vec<SessionDoc> = self.query_cross_partition(query).await?;

--- a/crates/rune-store/src/cosmos/tool_exec.rs
+++ b/crates/rune-store/src/cosmos/tool_exec.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{pk, CosmosStore};
+use crate::cosmos::{CosmosStore, pk};
 use crate::error::StoreError;
 use crate::models::{NewToolExecution, ToolExecutionRow};
 use crate::repos::ToolExecutionRepo;
@@ -97,7 +97,10 @@ fn tool_exec_row_to_doc(row: &ToolExecutionRow) -> ToolExecutionDoc {
 }
 
 /// Read a tool execution by ID. Cross-partition since we may not know session_id.
-async fn read_tool_execution(store: &CosmosStore, id: Uuid) -> Result<ToolExecutionDoc, StoreError> {
+async fn read_tool_execution(
+    store: &CosmosStore,
+    id: Uuid,
+) -> Result<ToolExecutionDoc, StoreError> {
     let query = format!(
         "SELECT * FROM c WHERE c.type = 'tool_execution' AND c.execution_id = '{}'",
         id

--- a/crates/rune-store/src/cosmos/tool_policy.rs
+++ b/crates/rune-store/src/cosmos/tool_policy.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::cosmos::{collect_query, parse_doc, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, parse_doc};
 use crate::error::StoreError;
 use crate::repos::{ToolApprovalPolicy, ToolApprovalPolicyRepo};
 use azure_data_cosmos::PartitionKey;
@@ -53,8 +53,10 @@ impl ToolApprovalPolicyRepo for CosmosStore {
             .await
         {
             Ok(resp) => {
-                let doc: ToolPolicyDoc =
-                    parse_doc(resp.into_model().map_err(|e| StoreError::Database(e.to_string()))?)?;
+                let doc: ToolPolicyDoc = parse_doc(
+                    resp.into_model()
+                        .map_err(|e| StoreError::Database(e.to_string()))?,
+                )?;
                 Ok(Some(ToolApprovalPolicy::from(doc)))
             }
             Err(e) => {

--- a/crates/rune-store/src/cosmos/transcript.rs
+++ b/crates/rune-store/src/cosmos/transcript.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, pk};
 use crate::error::StoreError;
 use crate::models::{NewTranscriptItem, TranscriptItemRow};
 use crate::repos::TranscriptRepo;
@@ -72,8 +72,7 @@ impl TranscriptRepo for CosmosStore {
         session_id: Uuid,
     ) -> Result<Vec<TranscriptItemRow>, StoreError> {
         let pk_val = session_id.to_string();
-        let query =
-            "SELECT * FROM c WHERE c.type = 'transcript_item' ORDER BY c.seq ASC";
+        let query = "SELECT * FROM c WHERE c.type = 'transcript_item' ORDER BY c.seq ASC";
         let stream = self
             .container()
             .query_items::<serde_json::Value>(query, pk(&pk_val), None)
@@ -84,8 +83,7 @@ impl TranscriptRepo for CosmosStore {
 
     async fn delete_by_session(&self, session_id: Uuid) -> Result<usize, StoreError> {
         let pk_val = session_id.to_string();
-        let query =
-            "SELECT c.id FROM c WHERE c.type = 'transcript_item'";
+        let query = "SELECT c.id FROM c WHERE c.type = 'transcript_item'";
         let stream = self
             .container()
             .query_items::<serde_json::Value>(query, pk(&pk_val), None)

--- a/crates/rune-store/src/cosmos/turn.rs
+++ b/crates/rune-store/src/cosmos/turn.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cosmos::{collect_query, pk, CosmosStore};
+use crate::cosmos::{CosmosStore, collect_query, pk};
 use crate::error::StoreError;
 use crate::models::{NewTurn, TurnRow};
 use crate::repos::TurnRepo;

--- a/crates/rune-store/src/pool.rs
+++ b/crates/rune-store/src/pool.rs
@@ -63,9 +63,12 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), StoreError> {
         .is_some();
 
     if diesel_exists {
-        warn!("detected old Diesel schema — dropping all tables for clean tokio-postgres migration");
-        client.batch_execute(
-            "DROP TABLE IF EXISTS __diesel_schema_migrations CASCADE;
+        warn!(
+            "detected old Diesel schema — dropping all tables for clean tokio-postgres migration"
+        );
+        client
+            .batch_execute(
+                "DROP TABLE IF EXISTS __diesel_schema_migrations CASCADE;
              DROP TABLE IF EXISTS _rune_pg_migrations CASCADE;
              DROP TABLE IF EXISTS transcript_items CASCADE;
              DROP TABLE IF EXISTS tool_executions CASCADE;
@@ -78,8 +81,10 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), StoreError> {
              DROP TABLE IF EXISTS jobs CASCADE;
              DROP TABLE IF EXISTS paired_devices CASCADE;
              DROP TABLE IF EXISTS pairing_requests CASCADE;
-             DROP TABLE IF EXISTS memory_embeddings CASCADE;"
-        ).await.map_err(|e| StoreError::Migration(format!("failed to drop old tables: {e}")))?;
+             DROP TABLE IF EXISTS memory_embeddings CASCADE;",
+            )
+            .await
+            .map_err(|e| StoreError::Migration(format!("failed to drop old tables: {e}")))?;
         info!("old tables dropped — clean slate for migration");
     }
 
@@ -116,7 +121,10 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), StoreError> {
             .collect();
 
         if !diesel_versions.is_empty() {
-            info!(count = diesel_versions.len(), "detected prior Diesel migrations, seeding tracker");
+            info!(
+                count = diesel_versions.len(),
+                "detected prior Diesel migrations, seeding tracker"
+            );
             for version in &diesel_versions {
                 let _ = client
                     .execute(
@@ -130,10 +138,7 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), StoreError> {
 
     // Get already-applied migrations
     let applied: Vec<String> = client
-        .query(
-            "SELECT name FROM _rune_pg_migrations ORDER BY name",
-            &[],
-        )
+        .query("SELECT name FROM _rune_pg_migrations ORDER BY name", &[])
         .await
         .map_err(|e| StoreError::Migration(format!("failed to read applied migrations: {e}")))?
         .iter()

--- a/crates/rune-store/tests/embedded_fallback.rs
+++ b/crates/rune-store/tests/embedded_fallback.rs
@@ -23,9 +23,13 @@ async fn embedded_pg_bootstrap_runs_migrations_and_accepts_connections() {
     let pool = create_pool(embedded.database_url(), 2).expect("pool should be created");
 
     // Verifies migration runner works against embedded fallback.
-    run_migrations(&pool).await.expect("migrations should run on embedded postgres");
+    run_migrations(&pool)
+        .await
+        .expect("migrations should run on embedded postgres");
     // Idempotence check: second run should be a no-op and still succeed.
-    run_migrations(&pool).await.expect("second migration run should be idempotent");
+    run_migrations(&pool)
+        .await
+        .expect("second migration run should be idempotent");
     let conn = pool.get().await.expect("connection should be acquired");
 
     // Ensure database is queryable after bootstrap + migrations.

--- a/crates/rune-store/tests/pg_device_pairing_integration.rs
+++ b/crates/rune-store/tests/pg_device_pairing_integration.rs
@@ -81,11 +81,12 @@ async fn setup() -> Option<PgPool> {
         }
     };
 
-    if let Err(err) = conn.batch_execute(
-        "TRUNCATE sessions, turns, transcript_items, jobs, approvals, \
+    if let Err(err) = conn
+        .batch_execute(
+            "TRUNCATE sessions, turns, transcript_items, jobs, approvals, \
          tool_executions, channel_deliveries, paired_devices, pairing_requests CASCADE",
-    )
-    .await
+        )
+        .await
     {
         eprintln!("skipping rune-store device pairing integration tests: truncate failed: {err}");
         return None;

--- a/crates/rune-store/tests/pg_integration.rs
+++ b/crates/rune-store/tests/pg_integration.rs
@@ -87,12 +87,13 @@ async fn setup() -> Option<(PgPool, PgVectorStatus)> {
         }
     };
 
-    if let Err(err) = conn.batch_execute(
-        "TRUNCATE sessions, turns, transcript_items, jobs, approvals, \
+    if let Err(err) = conn
+        .batch_execute(
+            "TRUNCATE sessions, turns, transcript_items, jobs, approvals, \
          tool_executions, channel_deliveries, paired_devices, pairing_requests, \
          memory_embeddings CASCADE",
-    )
-    .await
+        )
+        .await
     {
         eprintln!("skipping rune-store pg integration tests: truncate failed: {err}");
         return None;
@@ -250,7 +251,10 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
             vec!["memory/preferences.md", "memory/tasks.md"]
         );
 
-        let deleted = repo.delete_by_file(None, "memory/preferences.md").await.unwrap();
+        let deleted = repo
+            .delete_by_file(None, "memory/preferences.md")
+            .await
+            .unwrap();
         assert_eq!(deleted, 1);
         assert_eq!(repo.count(None).await.unwrap(), 1);
     } else {
@@ -269,7 +273,10 @@ async fn memory_embedding_repo_round_trip_search_and_cleanup() {
         assert_eq!(keyword_hits.len(), 1);
         assert_eq!(keyword_hits[0].file_path, "memory/preferences.md");
 
-        let deleted = repo.delete_by_file(None, "memory/preferences.md").await.unwrap();
+        let deleted = repo
+            .delete_by_file(None, "memory/preferences.md")
+            .await
+            .unwrap();
         assert_eq!(deleted, 1);
         assert_eq!(repo.count(None).await.unwrap(), 0);
     }

--- a/crates/rune-tools/src/document_tools.rs
+++ b/crates/rune-tools/src/document_tools.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use quick_xml::events::Event;
 use quick_xml::Reader;
+use quick_xml::events::Event;
 use tracing::instrument;
 use zip::ZipArchive;
 
@@ -20,32 +20,51 @@ pub struct DocumentToolExecutor {
 
 impl DocumentToolExecutor {
     pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
-        Self { workspace_root: workspace_root.into() }
+        Self {
+            workspace_root: workspace_root.into(),
+        }
     }
 
     fn resolve_path(&self, tool: &str, raw: &str) -> Result<PathBuf, ToolError> {
         let candidate = Path::new(raw);
         if candidate.is_absolute() {
-            return Err(ToolError::InvalidArguments { tool: tool.to_string(), reason: "absolute paths are not allowed".into() });
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "absolute paths are not allowed".into(),
+            });
         }
-        let workspace_root = self.workspace_root.canonicalize().map_err(|e| ToolError::ExecutionFailed(format!("workspace root invalid: {e}")))?;
+        let workspace_root = self
+            .workspace_root
+            .canonicalize()
+            .map_err(|e| ToolError::ExecutionFailed(format!("workspace root invalid: {e}")))?;
         let joined = workspace_root.join(candidate);
         let canonical = if joined.exists() {
-            joined.canonicalize().map_err(|e| ToolError::ExecutionFailed(format!("path resolution failed: {e}")))?
+            joined
+                .canonicalize()
+                .map_err(|e| ToolError::ExecutionFailed(format!("path resolution failed: {e}")))?
         } else {
-            return Err(ToolError::InvalidArguments { tool: tool.to_string(), reason: "path does not exist".into() });
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "path does not exist".into(),
+            });
         };
         if !canonical.starts_with(&workspace_root) {
-            return Err(ToolError::InvalidArguments { tool: tool.to_string(), reason: "path escapes workspace boundary".into() });
+            return Err(ToolError::InvalidArguments {
+                tool: tool.to_string(),
+                reason: "path escapes workspace boundary".into(),
+            });
         }
         Ok(canonical)
     }
 
     fn required_str<'a>(call: &'a ToolCall, key: &str) -> Result<&'a str, ToolError> {
-        call.arguments.get(key).and_then(|v| v.as_str()).ok_or_else(|| ToolError::InvalidArguments {
-            tool: call.tool_name.clone(),
-            reason: format!("missing required parameter: {key}"),
-        })
+        call.arguments
+            .get(key)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidArguments {
+                tool: call.tool_name.clone(),
+                reason: format!("missing required parameter: {key}"),
+            })
     }
 
     fn optional_u64(call: &ToolCall, key: &str) -> Option<u64> {
@@ -59,34 +78,50 @@ impl DocumentToolExecutor {
     }
 
     async fn extract_pdf(&self, path: &Path) -> Result<String, ToolError> {
-        pdf_extract::extract_text(path).map_err(|e| ToolError::ExecutionFailed(format!("failed to extract PDF text: {e}")))
+        pdf_extract::extract_text(path)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to extract PDF text: {e}")))
     }
 
     async fn extract_docx(&self, path: &Path) -> Result<String, ToolError> {
-        let file = std::fs::File::open(path).map_err(|e| ToolError::ExecutionFailed(format!("failed to open DOCX: {e}")))?;
-        let mut archive = ZipArchive::new(file).map_err(|e| ToolError::ExecutionFailed(format!("failed to read DOCX zip: {e}")))?;
+        let file = std::fs::File::open(path)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to open DOCX: {e}")))?;
+        let mut archive = ZipArchive::new(file)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to read DOCX zip: {e}")))?;
         let mut xml = String::new();
-        archive.by_name("word/document.xml").map_err(|e| ToolError::ExecutionFailed(format!("missing word/document.xml: {e}")))?
-            .read_to_string(&mut xml).map_err(|e| ToolError::ExecutionFailed(format!("failed to read DOCX xml: {e}")))?;
+        archive
+            .by_name("word/document.xml")
+            .map_err(|e| ToolError::ExecutionFailed(format!("missing word/document.xml: {e}")))?
+            .read_to_string(&mut xml)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to read DOCX xml: {e}")))?;
         Ok(extract_text_from_wordprocessing_xml(&xml))
     }
 
     async fn extract_xlsx(&self, path: &Path) -> Result<String, ToolError> {
-        let file = std::fs::File::open(path).map_err(|e| ToolError::ExecutionFailed(format!("failed to open XLSX: {e}")))?;
-        let mut archive = ZipArchive::new(file).map_err(|e| ToolError::ExecutionFailed(format!("failed to read XLSX zip: {e}")))?;
+        let file = std::fs::File::open(path)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to open XLSX: {e}")))?;
+        let mut archive = ZipArchive::new(file)
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to read XLSX zip: {e}")))?;
         let shared = read_zip_entry(&mut archive, "xl/sharedStrings.xml").ok();
-        let shared_strings = shared.as_deref().map(parse_shared_strings).unwrap_or_default();
+        let shared_strings = shared
+            .as_deref()
+            .map(parse_shared_strings)
+            .unwrap_or_default();
         let mut sheets = Vec::new();
         for i in 1..=32 {
             let name = format!("xl/worksheets/sheet{i}.xml");
             match read_zip_entry(&mut archive, &name) {
-                Ok(xml) => sheets.push(format!("# sheet{i}\n{}", extract_sheet_text(&xml, &shared_strings))),
+                Ok(xml) => sheets.push(format!(
+                    "# sheet{i}\n{}",
+                    extract_sheet_text(&xml, &shared_strings)
+                )),
                 Err(_) if i == 1 => continue,
                 Err(_) => break,
             }
         }
         if sheets.is_empty() {
-            return Err(ToolError::ExecutionFailed("no worksheets found in XLSX".into()));
+            return Err(ToolError::ExecutionFailed(
+                "no worksheets found in XLSX".into(),
+            ));
         }
         Ok(sheets.join("\n\n"))
     }
@@ -98,18 +133,32 @@ impl ToolExecutor for DocumentToolExecutor {
     async fn execute(&self, call: ToolCall) -> Result<ToolResult, ToolError> {
         let path_str = Self::required_str(&call, "path")?;
         let path = self.resolve_path(&call.tool_name, path_str)?;
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or_default().to_ascii_lowercase();
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         let (from_page, to_page) = Self::page_window(&call);
         let mut output = match ext.as_str() {
             "pdf" => self.extract_pdf(&path).await?,
             "docx" => self.extract_docx(&path).await?,
             "xlsx" => self.extract_xlsx(&path).await?,
-            _ => return Err(ToolError::InvalidArguments { tool: call.tool_name.clone(), reason: format!("unsupported document format: {ext}") }),
+            _ => {
+                return Err(ToolError::InvalidArguments {
+                    tool: call.tool_name.clone(),
+                    reason: format!("unsupported document format: {ext}"),
+                });
+            }
         };
         if ext == "pdf" {
             output = slice_pdf_pages(&output, from_page, to_page);
         }
-        Ok(ToolResult { tool_call_id: call.tool_call_id.clone(), output, is_error: false, tool_execution_id: None })
+        Ok(ToolResult {
+            tool_call_id: call.tool_call_id.clone(),
+            output,
+            is_error: false,
+            tool_execution_id: None,
+        })
     }
 }
 
@@ -131,10 +180,16 @@ pub fn document_extract_tool_definition() -> crate::ToolDefinition {
     }
 }
 
-fn read_zip_entry<R: Read + std::io::Seek>(archive: &mut ZipArchive<R>, name: &str) -> Result<String, ToolError> {
+fn read_zip_entry<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+    name: &str,
+) -> Result<String, ToolError> {
     let mut s = String::new();
-    archive.by_name(name).map_err(|e| ToolError::ExecutionFailed(format!("missing {name}: {e}")))?
-        .read_to_string(&mut s).map_err(|e| ToolError::ExecutionFailed(format!("failed reading {name}: {e}")))?;
+    archive
+        .by_name(name)
+        .map_err(|e| ToolError::ExecutionFailed(format!("missing {name}: {e}")))?
+        .read_to_string(&mut s)
+        .map_err(|e| ToolError::ExecutionFailed(format!("failed reading {name}: {e}")))?;
     Ok(s)
 }
 
@@ -147,11 +202,15 @@ fn extract_text_from_wordprocessing_xml(xml: &str) -> String {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name().as_ref() == b"w:p" => {
-                if !out.is_empty() { out.push('\n'); }
+                if !out.is_empty() {
+                    out.push('\n');
+                }
                 in_paragraph = true;
             }
             Ok(Event::Text(t)) if in_paragraph => {
-                if let Ok(text) = std::str::from_utf8(t.as_ref()) { out.push_str(text); }
+                if let Ok(text) = std::str::from_utf8(t.as_ref()) {
+                    out.push_str(text);
+                }
             }
             Ok(Event::Eof) => break,
             Ok(_) => {}
@@ -172,11 +231,18 @@ fn parse_shared_strings(xml: &str) -> Vec<String> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name().as_ref() == b"t" => in_text = true,
-            Ok(Event::End(e)) if e.name().as_ref() == b"si" => { out.push(current.clone()); current.clear(); },
-            Ok(Event::Text(t)) if in_text => if let Ok(text) = std::str::from_utf8(t.as_ref()) { current.push_str(text); },
+            Ok(Event::End(e)) if e.name().as_ref() == b"si" => {
+                out.push(current.clone());
+                current.clear();
+            }
+            Ok(Event::Text(t)) if in_text => {
+                if let Ok(text) = std::str::from_utf8(t.as_ref()) {
+                    current.push_str(text);
+                }
+            }
             Ok(Event::End(e)) if e.name().as_ref() == b"t" => in_text = false,
             Ok(Event::Eof) => break,
-            Ok(_) => {},
+            Ok(_) => {}
             Err(_) => break,
         }
         buf.clear();
@@ -194,21 +260,32 @@ fn extract_sheet_text(xml: &str, shared_strings: &[String]) -> String {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name().as_ref() == b"c" => {
-                current_type = e.attributes().flatten().find(|a| a.key.as_ref() == b"t").and_then(|a| String::from_utf8(a.value.into_owned()).ok());
+                current_type = e
+                    .attributes()
+                    .flatten()
+                    .find(|a| a.key.as_ref() == b"t")
+                    .and_then(|a| String::from_utf8(a.value.into_owned()).ok());
             }
             Ok(Event::Start(e)) if e.name().as_ref() == b"v" => in_value = true,
             Ok(Event::Text(t)) if in_value => {
                 if let Ok(v) = std::str::from_utf8(t.as_ref()) {
                     let text = if current_type.as_deref() == Some("s") {
-                        v.parse::<usize>().ok().and_then(|i| shared_strings.get(i).cloned()).unwrap_or_else(|| v.to_string())
-                    } else { v.to_string() };
-                    if !out.is_empty() { out.push('\n'); }
+                        v.parse::<usize>()
+                            .ok()
+                            .and_then(|i| shared_strings.get(i).cloned())
+                            .unwrap_or_else(|| v.to_string())
+                    } else {
+                        v.to_string()
+                    };
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
                     out.push_str(&text);
                 }
             }
             Ok(Event::End(e)) if e.name().as_ref() == b"v" => in_value = false,
             Ok(Event::Eof) => break,
-            Ok(_) => {},
+            Ok(_) => {}
             Err(_) => break,
         }
         buf.clear();

--- a/crates/rune-tools/src/memory_index.rs
+++ b/crates/rune-tools/src/memory_index.rs
@@ -1287,7 +1287,11 @@ Delta echo foxtrot.
             Ok(())
         }
 
-        async fn delete_by_file(&self, _project_id: Option<&str>, file_path: &str) -> Result<usize, StoreError> {
+        async fn delete_by_file(
+            &self,
+            _project_id: Option<&str>,
+            file_path: &str,
+        ) -> Result<usize, StoreError> {
             self.deleted_files
                 .lock()
                 .unwrap()
@@ -1317,7 +1321,10 @@ Delta echo foxtrot.
             Ok(0)
         }
 
-        async fn list_indexed_files(&self, _project_id: Option<&str>) -> Result<Vec<String>, StoreError> {
+        async fn list_indexed_files(
+            &self,
+            _project_id: Option<&str>,
+        ) -> Result<Vec<String>, StoreError> {
             Ok(Vec::new())
         }
 

--- a/crates/rune-tools/src/memory_tool.rs
+++ b/crates/rune-tools/src/memory_tool.rs
@@ -569,7 +569,11 @@ mod tests {
             unreachable!()
         }
 
-        async fn delete_by_file(&self, _project_id: Option<&str>, _file_path: &str) -> Result<usize, StoreError> {
+        async fn delete_by_file(
+            &self,
+            _project_id: Option<&str>,
+            _file_path: &str,
+        ) -> Result<usize, StoreError> {
             unreachable!()
         }
 
@@ -595,7 +599,10 @@ mod tests {
             Ok((self.keyword_hits.len().max(self.vector_hits.len())) as i64)
         }
 
-        async fn list_indexed_files(&self, _project_id: Option<&str>) -> Result<Vec<String>, StoreError> {
+        async fn list_indexed_files(
+            &self,
+            _project_id: Option<&str>,
+        ) -> Result<Vec<String>, StoreError> {
             Ok(Vec::new())
         }
 
@@ -762,11 +769,16 @@ mod tests {
     #[tokio::test]
     async fn evergreen_memory_file_outranks_equally_matching_daily_note() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(tmp.path().join("MEMORY.md"), "- prefers rust and dark mode
-")
+        tokio::fs::write(
+            tmp.path().join("MEMORY.md"),
+            "- prefers rust and dark mode
+",
+        )
+        .await
+        .unwrap();
+        tokio::fs::create_dir_all(tmp.path().join("memory"))
             .await
             .unwrap();
-        tokio::fs::create_dir_all(tmp.path().join("memory")).await.unwrap();
         tokio::fs::write(
             tmp.path().join("memory/2026-03-13.md"),
             "- prefers rust and dark mode
@@ -782,7 +794,11 @@ mod tests {
         );
         let result = exec.execute(call).await.unwrap();
 
-        assert!(result.output.contains("Source: MEMORY.md#1"), "{0}", result.output);
+        assert!(
+            result.output.contains("Source: MEMORY.md#1"),
+            "{0}",
+            result.output
+        );
     }
 
     #[tokio::test]

--- a/crates/rune-tools/src/stubs.rs
+++ b/crates/rune-tools/src/stubs.rs
@@ -45,7 +45,9 @@ pub fn register_builtin_stubs(registry: &mut ToolRegistry) {
         },
         ToolDefinition {
             name: "extract_document".into(),
-            description: "Extract text content from PDF, DOCX, or XLSX files. Supports page ranges for PDFs.".into(),
+            description:
+                "Extract text content from PDF, DOCX, or XLSX files. Supports page ranges for PDFs."
+                    .into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/crates/rune-tts/src/lib.rs
+++ b/crates/rune-tts/src/lib.rs
@@ -183,7 +183,6 @@ mod tests {
         assert!(matches!(err, TtsError::Config(_)));
     }
 
-
     #[tokio::test]
     async fn convert_with_without_key_returns_config_error() {
         let config = TtsConfig {


### PR DESCRIPTION
## Summary
- apply rustfmt normalization to the current shipped runtime tree
- keep the branch buildable and verified after the broad in-flight edits already present in the workspace
- preserve the now-shipped multi-instance/comms test coverage while unblocking clean follow-up diffs

## Validation
- cargo fmt --all
- cargo check
- cargo test -p rune-runtime comms -- --nocapture