### PR TITLE
feat: expose instance health and delegation-plan CLI surfaces

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -1284,6 +1284,17 @@ pub enum GatewayAction {
     Probe,
     /// Discover operator-facing runtime URLs and config binding details.
     Discover,
+    /// Inspect instance identity, capabilities, load, and peer health.
+    InstanceHealth,
+    /// Compute a peer selection plan for cross-instance delegation.
+    DelegationPlan {
+        /// Selection strategy (`least_busy` or `named`).
+        #[arg(long, default_value = "least_busy")]
+        strategy: String,
+        /// Required when `--strategy named`.
+        #[arg(long)]
+        peer_id: Option<String>,
+    },
     /// Query structured gateway logs.
     Logs(LogsArgs),
     /// Run gateway-backed diagnostic checks and inspect recent results.
@@ -2794,6 +2805,40 @@ mod tests {
                 action: GatewayAction::Discover
             }
         ));
+    }
+
+    #[test]
+    fn parse_gateway_instance_health() {
+        let cli = Cli::try_parse_from(["rune", "gateway", "instance-health"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Gateway {
+                action: GatewayAction::InstanceHealth
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_gateway_delegation_plan_named() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "gateway",
+            "delegation-plan",
+            "--strategy",
+            "named",
+            "--peer-id",
+            "peer-a",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Gateway {
+                action: GatewayAction::DelegationPlan { strategy, peer_id },
+            } => {
+                assert_eq!(strategy, "named");
+                assert_eq!(peer_id.as_deref(), Some("peer-a"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -16,10 +16,11 @@ use crate::output::{
     ApprovalPoliciesResponse, ApprovalPolicySummary, ApprovalRequestSummary, ConfigFileResponse,
     ConfigGetResponse, ConfigMutationResponse, ConfigValidationResult, ConfigureResponse,
     CronJobDetailResponse, CronJobSummary, CronListResponse, CronRunSummary, CronRunsResponse,
-    CronStatusResponse, DoctorReport, GatewayCallResponse, GatewayConfigResponse,
-    GatewayDiscoverResponse, GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse,
-    HeartbeatStatusResponse, LogsQueryResponse, MessageSearchHit, MessageSearchResponse,
-    MessageSendResponse, ModelScanProviderResult, ModelScanResponse, ReminderSummary,
+    CronStatusResponse, DelegationPlanResponse, DoctorReport, GatewayCallResponse,
+    GatewayConfigResponse, GatewayDiscoverResponse, GatewayInstanceHealthResponse,
+    GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
+    InstanceLoadSummary, LogsQueryResponse, MessageSearchHit, MessageSearchResponse,
+    MessageSendResponse, ModelScanProviderResult, ModelScanResponse, PeerSummary, ReminderSummary,
     RemindersListResponse, SandboxExplainResponse, SandboxListResponse, SandboxRecreateResponse,
     ScannedModelDetail, SecretsApplyResponse, SecretsAuditResponse, SecretsConfigureResponse,
     SecretsReloadResponse, SecurityAuditResponse, SessionDetailResponse, SessionListResponse,
@@ -132,6 +133,114 @@ impl GatewayClient {
         }
     }
 
+    pub async fn gateway_instance_health(&self) -> Result<GatewayInstanceHealthResponse> {
+        let resp = self
+            .http
+            .get(self.url("/api/v1/instance/health"))
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if !resp.status().is_success() {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+
+        let body = resp
+            .json::<serde_json::Value>()
+            .await
+            .context("invalid JSON from /api/v1/instance/health")?;
+
+        Ok(GatewayInstanceHealthResponse {
+            status: body["status"].as_str().unwrap_or("unknown").to_string(),
+            version: body["version"].as_str().map(String::from),
+            uptime_seconds: body["uptime_seconds"].as_u64(),
+            instance_id: body["capabilities"]["identity"]["id"]
+                .as_str()
+                .map(String::from),
+            instance_name: body["capabilities"]["identity"]["name"]
+                .as_str()
+                .map(String::from),
+            advertised_addr: body["capabilities"]["identity"]["advertised_addr"]
+                .as_str()
+                .map(String::from),
+            instance_roles: body["capabilities"]["identity"]["roles"]
+                .as_array()
+                .map(|roles| {
+                    roles
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            capabilities_version: body["capabilities"]["identity"]["capabilities_version"]
+                .as_u64()
+                .and_then(|v| u32::try_from(v).ok()),
+            peer_count: body["capabilities"]["peer_count"]
+                .as_u64()
+                .and_then(|v| usize::try_from(v).ok())
+                .unwrap_or_else(|| body["peers"].as_array().map_or(0, |peers| peers.len())),
+            configured_models: body["capabilities"]["configured_models"]
+                .as_array()
+                .map(|models| {
+                    models
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            active_projects: body["capabilities"]["active_projects"]
+                .as_array()
+                .map(|projects| {
+                    projects
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            comms_transport: body["capabilities"]["comms_transport"]
+                .as_str()
+                .map(String::from),
+            load: parse_instance_load(&body["load"]),
+            peers: parse_peer_summaries(&body["peers"]),
+        })
+    }
+
+    pub async fn gateway_delegation_plan(
+        &self,
+        strategy: &str,
+        peer_id: Option<&str>,
+    ) -> Result<DelegationPlanResponse> {
+        let mut url = self.url(&format!(
+            "/api/v1/instance/delegation-plan?strategy={strategy}"
+        ));
+        if let Some(peer_id) = peer_id {
+            url.push_str("&peer_id=");
+            url.push_str(&urlencoding::encode(peer_id));
+        }
+
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .context("failed to reach gateway")?;
+
+        if !resp.status().is_success() {
+            bail!("Gateway returned HTTP {}", resp.status());
+        }
+
+        let body = resp
+            .json::<serde_json::Value>()
+            .await
+            .context("invalid JSON from /api/v1/instance/delegation-plan")?;
+
+        Ok(DelegationPlanResponse {
+            strategy: body["strategy"].as_str().unwrap_or("unknown").to_string(),
+            selected_peer: parse_peer_summary(&body["selected_peer"]),
+            candidates: parse_peer_summaries(&body["candidates"]),
+            detail: body["detail"].as_str().unwrap_or_default().to_string(),
+        })
+    }
     /// `GET /config`
     pub async fn gateway_config(&self) -> Result<GatewayConfigResponse> {
         let resp = self
@@ -6733,4 +6842,63 @@ impl GatewayClient {
             bail!("Gateway returned HTTP {}", resp.status());
         }
     }
+}
+
+fn parse_instance_load(value: &serde_json::Value) -> Option<InstanceLoadSummary> {
+    Some(InstanceLoadSummary {
+        session_count: usize::try_from(value["session_count"].as_u64()?).ok()?,
+        ws_subscribers: usize::try_from(value["ws_subscribers"].as_u64()?).ok()?,
+        ws_connections: usize::try_from(value["ws_connections"].as_u64()?).ok()?,
+    })
+}
+
+fn parse_peer_summary(value: &serde_json::Value) -> Option<PeerSummary> {
+    if value.is_null() {
+        return None;
+    }
+
+    Some(PeerSummary {
+        id: value["id"].as_str().unwrap_or_default().to_string(),
+        health_url: value["health_url"].as_str().unwrap_or_default().to_string(),
+        status: value["status"].as_str().unwrap_or("unknown").to_string(),
+        detail: value["detail"].as_str().unwrap_or_default().to_string(),
+        checked_at: value["checked_at"].as_str().map(String::from),
+        latency_ms: value["latency_ms"].as_u64().map(u128::from),
+        advertised_addr: value["advertised_addr"].as_str().map(String::from),
+        roles: value["roles"]
+            .as_array()
+            .map(|roles| {
+                roles
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        configured_models: value["configured_models"]
+            .as_array()
+            .map(|models| {
+                models
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        active_projects: value["active_projects"]
+            .as_array()
+            .map(|projects| {
+                projects
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        load: parse_instance_load(&value["load"]),
+    })
+}
+
+fn parse_peer_summaries(value: &serde_json::Value) -> Vec<PeerSummary> {
+    value
+        .as_array()
+        .map(|peers| peers.iter().filter_map(parse_peer_summary).collect())
+        .unwrap_or_default()
 }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -2102,6 +2102,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.gateway_discover().await?;
                 println!("{}", render(&result, format));
             }
+            GatewayAction::InstanceHealth => {
+                let result = client.gateway_instance_health().await?;
+                println!("{}", render(&result, format));
+            }
+            GatewayAction::DelegationPlan { strategy, peer_id } => {
+                let result = client
+                    .gateway_delegation_plan(&strategy, peer_id.as_deref())
+                    .await?;
+                println!("{}", render(&result, format));
+            }
             GatewayAction::Logs(LogsArgs {
                 level,
                 source,

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -78,6 +78,270 @@ pub struct HealthResponse {
     pub message: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceLoadSummary {
+    pub session_count: usize,
+    pub ws_subscribers: usize,
+    pub ws_connections: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerSummary {
+    pub id: String,
+    pub health_url: String,
+    pub status: String,
+    pub detail: String,
+    pub checked_at: Option<String>,
+    pub latency_ms: Option<u128>,
+    pub advertised_addr: Option<String>,
+    pub roles: Vec<String>,
+    pub configured_models: Vec<String>,
+    pub active_projects: Vec<String>,
+    pub load: Option<InstanceLoadSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayInstanceHealthResponse {
+    pub status: String,
+    pub version: Option<String>,
+    pub uptime_seconds: Option<u64>,
+    pub instance_id: Option<String>,
+    pub instance_name: Option<String>,
+    pub advertised_addr: Option<String>,
+    pub instance_roles: Vec<String>,
+    pub capabilities_version: Option<u32>,
+    pub peer_count: usize,
+    pub configured_models: Vec<String>,
+    pub active_projects: Vec<String>,
+    pub comms_transport: Option<String>,
+    pub load: Option<InstanceLoadSummary>,
+    pub peers: Vec<PeerSummary>,
+}
+
+impl fmt::Display for GatewayInstanceHealthResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Instance health: {}", self.status)?;
+        if let Some(ref version) = self.version {
+            write!(
+                f,
+                "
+Version: {version}"
+            )?;
+        }
+        if let Some(uptime) = self.uptime_seconds {
+            write!(
+                f,
+                "
+Uptime: {uptime}s"
+            )?;
+        }
+        if let Some(ref instance_id) = self.instance_id {
+            write!(
+                f,
+                "
+Instance ID: {instance_id}"
+            )?;
+        }
+        if let Some(ref instance_name) = self.instance_name {
+            write!(
+                f,
+                "
+Instance name: {instance_name}"
+            )?;
+        }
+        if let Some(version) = self.capabilities_version {
+            write!(
+                f,
+                "
+Capabilities version: {version}"
+            )?;
+        }
+        if let Some(ref advertised_addr) = self.advertised_addr {
+            write!(
+                f,
+                "
+Advertised address: {advertised_addr}"
+            )?;
+        }
+        if !self.instance_roles.is_empty() {
+            write!(
+                f,
+                "
+Roles: {}",
+                self.instance_roles.join(", ")
+            )?;
+        }
+        if let Some(ref comms_transport) = self.comms_transport {
+            write!(
+                f,
+                "
+Comms transport: {comms_transport}"
+            )?;
+        }
+        if !self.configured_models.is_empty() {
+            write!(
+                f,
+                "
+Configured models: {}",
+                self.configured_models.join(", ")
+            )?;
+        }
+        if !self.active_projects.is_empty() {
+            write!(
+                f,
+                "
+Active projects: {}",
+                self.active_projects.join(", ")
+            )?;
+        }
+        if let Some(ref load) = self.load {
+            write!(
+                f,
+                "
+Load: sessions={}, ws_subscribers={}, ws_connections={}",
+                load.session_count, load.ws_subscribers, load.ws_connections
+            )?;
+        }
+        write!(
+            f,
+            "
+Peers: {}",
+            self.peer_count
+        )?;
+        for peer in &self.peers {
+            write!(
+                f,
+                "
+  - {} [{}]",
+                peer.id, peer.status
+            )?;
+            write!(
+                f,
+                "
+    Health URL: {}",
+                peer.health_url
+            )?;
+            write!(
+                f,
+                "
+    Detail: {}",
+                peer.detail
+            )?;
+            if let Some(ref checked_at) = peer.checked_at {
+                write!(
+                    f,
+                    "
+    Checked at: {checked_at}"
+                )?;
+            }
+            if let Some(latency_ms) = peer.latency_ms {
+                write!(
+                    f,
+                    "
+    Latency: {latency_ms}ms"
+                )?;
+            }
+            if let Some(ref advertised_addr) = peer.advertised_addr {
+                write!(
+                    f,
+                    "
+    Advertised address: {advertised_addr}"
+                )?;
+            }
+            if !peer.roles.is_empty() {
+                write!(
+                    f,
+                    "
+    Roles: {}",
+                    peer.roles.join(", ")
+                )?;
+            }
+            if !peer.configured_models.is_empty() {
+                write!(
+                    f,
+                    "
+    Models: {}",
+                    peer.configured_models.join(", ")
+                )?;
+            }
+            if !peer.active_projects.is_empty() {
+                write!(
+                    f,
+                    "
+    Projects: {}",
+                    peer.active_projects.join(", ")
+                )?;
+            }
+            if let Some(ref load) = peer.load {
+                write!(
+                    f,
+                    "
+    Load: sessions={}, ws_subscribers={}, ws_connections={}",
+                    load.session_count, load.ws_subscribers, load.ws_connections
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationPlanResponse {
+    pub strategy: String,
+    pub selected_peer: Option<PeerSummary>,
+    pub candidates: Vec<PeerSummary>,
+    pub detail: String,
+}
+
+impl fmt::Display for DelegationPlanResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Delegation strategy: {}", self.strategy)?;
+        write!(
+            f,
+            "
+Detail: {}",
+            self.detail
+        )?;
+        match &self.selected_peer {
+            Some(peer) => write!(
+                f,
+                "
+Selected peer: {} [{}]",
+                peer.id, peer.status
+            )?,
+            None => write!(
+                f,
+                "
+Selected peer: none"
+            )?,
+        }
+        write!(
+            f,
+            "
+Candidates: {}",
+            self.candidates.len()
+        )?;
+        for peer in &self.candidates {
+            write!(
+                f,
+                "
+  - {} [{}]",
+                peer.id, peer.status
+            )?;
+            if let Some(ref load) = peer.load {
+                write!(
+                    f,
+                    " sessions={}, ws={}, latency={}ms",
+                    load.session_count,
+                    load.ws_connections,
+                    peer.latency_ms.unwrap_or_default()
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for HealthResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let icon = if self.healthy { "✓" } else { "✗" };
@@ -5957,6 +6221,79 @@ mod tests {
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Gateway discovery"));
         assert!(out.contains("WebSocket URL: ws://127.0.0.1:8787/ws"));
+    }
+
+    #[test]
+    fn render_instance_health() {
+        let response = GatewayInstanceHealthResponse {
+            status: "ok".into(),
+            version: Some("0.1.0".into()),
+            uptime_seconds: Some(12),
+            instance_id: Some("inst-a".into()),
+            instance_name: Some("desktop".into()),
+            advertised_addr: Some("http://127.0.0.1:8787".into()),
+            instance_roles: vec!["gateway".into(), "scheduler".into()],
+            capabilities_version: Some(1),
+            peer_count: 1,
+            configured_models: vec!["gpt-4.1".into()],
+            active_projects: vec!["/workspace/rune".into()],
+            comms_transport: Some("filesystem".into()),
+            load: Some(InstanceLoadSummary {
+                session_count: 3,
+                ws_subscribers: 1,
+                ws_connections: 2,
+            }),
+            peers: vec![PeerSummary {
+                id: "peer-a".into(),
+                health_url: "http://peer-a:8787/api/v1/instance/health".into(),
+                status: "healthy".into(),
+                detail: "200 OK".into(),
+                checked_at: Some("2026-03-29T03:00:00Z".into()),
+                latency_ms: Some(15),
+                advertised_addr: Some("http://peer-a:8787".into()),
+                roles: vec!["gateway".into()],
+                configured_models: vec!["claude-3-7-sonnet".into()],
+                active_projects: vec!["/workspace/peer".into()],
+                load: Some(InstanceLoadSummary {
+                    session_count: 1,
+                    ws_subscribers: 0,
+                    ws_connections: 1,
+                }),
+            }],
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Instance health: ok"));
+        assert!(out.contains("Peers: 1"));
+        assert!(out.contains("peer-a [healthy]"));
+    }
+
+    #[test]
+    fn render_delegation_plan() {
+        let response = DelegationPlanResponse {
+            strategy: "least_busy".into(),
+            selected_peer: Some(PeerSummary {
+                id: "peer-a".into(),
+                health_url: "http://peer-a:8787/api/v1/instance/health".into(),
+                status: "healthy".into(),
+                detail: "200 OK".into(),
+                checked_at: Some("2026-03-29T03:00:00Z".into()),
+                latency_ms: Some(10),
+                advertised_addr: None,
+                roles: vec!["gateway".into()],
+                configured_models: vec![],
+                active_projects: vec![],
+                load: Some(InstanceLoadSummary {
+                    session_count: 1,
+                    ws_subscribers: 0,
+                    ws_connections: 1,
+                }),
+            }),
+            candidates: vec![],
+            detail: "selected least-busy healthy peer 'peer-a'".into(),
+        };
+        let out = render(&response, OutputFormat::Human);
+        assert!(out.contains("Delegation strategy: least_busy"));
+        assert!(out.contains("Selected peer: peer-a [healthy]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add CLI subcommands for instance health and delegation planning
- add gateway client methods and output renderers for multi-instance operator inspection
- add parser/render tests for the new surfaces

## Testing
- cargo check
- cargo test -p rune-cli parse_gateway_ -- --nocapture
- cargo test -p rune-cli render_instance_health -- --nocapture
- cargo test -p rune-cli render_delegation_plan -- --nocapture