### PR TITLE
fix(cli): parse delegation plan contract fields

### DIFF
--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -16,7 +16,9 @@ use crate::output::{
     ApprovalPoliciesResponse, ApprovalPolicySummary, ApprovalRequestSummary, ConfigFileResponse,
     ConfigGetResponse, ConfigMutationResponse, ConfigValidationResult, ConfigureResponse,
     CronJobDetailResponse, CronJobSummary, CronListResponse, CronRunSummary, CronRunsResponse,
-    CronStatusResponse, DelegationPlanResponse, DelegationTaskContract, DoctorReport, GatewayCallResponse,
+    CronStatusResponse, DelegationConflictCapabilitySummary, DelegationEndpointSummary,
+    DelegationPlanResponse, DelegationResultContractSummary, DelegationRoutingSummary,
+    DelegationTaskContract, DelegationTaskStatusSummary, DoctorReport, GatewayCallResponse,
     GatewayConfigResponse, GatewayDiscoverResponse, GatewayInstanceHealthResponse,
     GatewayProbeResponse, GatewayUsageCostResponse, HealthResponse, HeartbeatStatusResponse,
     InstanceLoadSummary, LogsQueryResponse, MessageSearchHit, MessageSearchResponse,
@@ -246,6 +248,13 @@ impl GatewayClient {
             candidates: parse_peer_summaries(&body["candidates"]),
             detail: body["detail"].as_str().unwrap_or_default().to_string(),
             task_contract: parse_delegation_task_contract(&body["task_contract"]),
+            sender: parse_delegation_endpoint(&body["sender"]),
+            receiver: parse_delegation_endpoint(&body["receiver"]),
+            routing: parse_delegation_routing(&body["routing"]),
+            branch_reservation: parse_delegation_conflict_capability(&body["branch_reservation"]),
+            file_locks: parse_delegation_conflict_capability(&body["file_locks"]),
+            task_status: parse_delegation_task_status(&body["task_status"]),
+            result: parse_delegation_result_contract(&body["result"]),
         })
     }
     /// `GET /config`
@@ -6924,6 +6933,122 @@ fn parse_string_array(value: &serde_json::Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn parse_delegation_endpoint(value: &serde_json::Value) -> Option<DelegationEndpointSummary> {
+    if !value.is_object() {
+        return None;
+    }
+
+    Some(DelegationEndpointSummary {
+        instance_id: value["instance_id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        instance_name: value["instance_name"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        transport: value["transport"].as_str().unwrap_or_default().to_string(),
+        health_url: value["health_url"].as_str().map(str::to_string),
+    })
+}
+
+fn parse_delegation_routing(value: &serde_json::Value) -> Option<DelegationRoutingSummary> {
+    if !value.is_object() {
+        return None;
+    }
+
+    Some(DelegationRoutingSummary {
+        mode: value["mode"].as_str().unwrap_or_default().to_string(),
+        detail: value["detail"].as_str().unwrap_or_default().to_string(),
+        peer_count: value["peer_count"]
+            .as_u64()
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_delegation_conflict_capability(
+    value: &serde_json::Value,
+) -> Option<DelegationConflictCapabilitySummary> {
+    if !value.is_object() {
+        return None;
+    }
+
+    Some(DelegationConflictCapabilitySummary {
+        required: value["required"].as_bool().unwrap_or(false),
+        mechanism: value["mechanism"].as_str().unwrap_or_default().to_string(),
+        enforced_by: value["enforced_by"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        detail: value["detail"].as_str().unwrap_or_default().to_string(),
+    })
+}
+
+fn parse_delegation_task_status(value: &serde_json::Value) -> Option<DelegationTaskStatusSummary> {
+    if !value.is_object() {
+        return None;
+    }
+
+    Some(DelegationTaskStatusSummary {
+        states: value["states"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|entry| entry.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        terminal_states: value["terminal_states"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|entry| entry.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        sender_visibility: value["sender_visibility"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        timeout_behavior: value["timeout_behavior"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        failure_behavior: value["failure_behavior"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+fn parse_delegation_result_contract(
+    value: &serde_json::Value,
+) -> Option<DelegationResultContractSummary> {
+    if !value.is_object() {
+        return None;
+    }
+
+    Some(DelegationResultContractSummary {
+        status_field: value["status_field"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        artifact_field: value["artifact_field"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        error_field: value["error_field"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        finished_at_field: value["finished_at_field"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
 fn parse_delegation_task_contract(value: &serde_json::Value) -> DelegationTaskContract {
     DelegationTaskContract {
         protocol_version: value["protocol_version"]
@@ -6937,5 +7062,118 @@ fn parse_delegation_task_contract(value: &serde_json::Value) -> DelegationTaskCo
         required_fields: parse_string_array(&value["required_fields"]),
         optional_fields: parse_string_array(&value["optional_fields"]),
         result_fields: parse_string_array(&value["result_fields"]),
+    }
+}
+
+#[cfg(test)]
+mod delegation_plan_parse_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_extended_delegation_plan_fields() {
+        let body = json!({
+            "strategy": "least_busy",
+            "selected_peer": {
+                "id": "peer-b",
+                "health_url": "http://peer-b/health",
+                "status": "healthy",
+                "detail": "ok",
+                "checked_at": "2026-03-29T00:00:00Z",
+                "latency_ms": 12,
+                "advertised_addr": "http://peer-b:8787",
+                "roles": ["gateway", "coder"],
+                "configured_models": ["gpt-4.1"],
+                "active_projects": ["rune"],
+                "load": {
+                    "session_count": 2,
+                    "ws_subscribers": 0,
+                    "ws_connections": 1
+                }
+            },
+            "candidates": [],
+            "detail": "selected least-busy healthy peer 'peer-b'",
+            "task_contract": {
+                "protocol_version": 1,
+                "submission_modes": ["named", "least_busy"],
+                "lifecycle": ["submitted", "accepted", "running", "completed", "failed", "timeout"],
+                "timeout_handling": ["sender supplies timeout_secs per task"],
+                "conflict_prevention": ["agents must reserve branch names before execution"],
+                "required_fields": ["task"],
+                "optional_fields": ["target_peer_id"],
+                "result_fields": ["status"]
+            },
+            "sender": {
+                "instance_id": "sender-a",
+                "instance_name": "Sender A",
+                "transport": "filesystem",
+                "health_url": "http://sender-a/api/v1/instance/health"
+            },
+            "receiver": {
+                "instance_id": "peer-b",
+                "instance_name": "Peer B",
+                "transport": "http",
+                "health_url": "http://peer-b/api/v1/instance/health"
+            },
+            "routing": {
+                "mode": "least_busy",
+                "detail": "selected least-busy healthy peer 'peer-b'",
+                "peer_count": 3
+            },
+            "branch_reservation": {
+                "required": true,
+                "mechanism": "branch_reservation",
+                "enforced_by": "orchestrator",
+                "detail": "reserve branch names"
+            },
+            "file_locks": {
+                "required": true,
+                "mechanism": "file_locks",
+                "enforced_by": "orchestrator",
+                "detail": "lock files"
+            },
+            "task_status": {
+                "states": ["submitted", "accepted", "running", "completed", "failed", "timeout"],
+                "terminal_states": ["completed", "failed", "timeout"],
+                "sender_visibility": "tracked",
+                "timeout_behavior": "timeout",
+                "failure_behavior": "failed"
+            },
+            "result": {
+                "status_field": "status",
+                "artifact_field": "artifacts",
+                "error_field": "error",
+                "finished_at_field": "finished_at"
+            }
+        });
+
+        let parsed = DelegationPlanResponse {
+            strategy: body["strategy"].as_str().unwrap().to_string(),
+            selected_peer: parse_peer_summary(&body["selected_peer"]),
+            candidates: parse_peer_summaries(&body["candidates"]),
+            detail: body["detail"].as_str().unwrap().to_string(),
+            task_contract: parse_delegation_task_contract(&body["task_contract"]),
+            sender: parse_delegation_endpoint(&body["sender"]),
+            receiver: parse_delegation_endpoint(&body["receiver"]),
+            routing: parse_delegation_routing(&body["routing"]),
+            branch_reservation: parse_delegation_conflict_capability(&body["branch_reservation"]),
+            file_locks: parse_delegation_conflict_capability(&body["file_locks"]),
+            task_status: parse_delegation_task_status(&body["task_status"]),
+            result: parse_delegation_result_contract(&body["result"]),
+        };
+
+        assert_eq!(parsed.sender.as_ref().unwrap().instance_id, "sender-a");
+        assert_eq!(parsed.receiver.as_ref().unwrap().transport, "http");
+        assert_eq!(parsed.routing.as_ref().unwrap().peer_count, 3);
+        assert_eq!(
+            parsed.branch_reservation.as_ref().unwrap().mechanism,
+            "branch_reservation"
+        );
+        assert_eq!(parsed.file_locks.as_ref().unwrap().mechanism, "file_locks");
+        assert_eq!(
+            parsed.task_status.as_ref().unwrap().terminal_states,
+            vec!["completed", "failed", "timeout"]
+        );
+        assert_eq!(parsed.result.as_ref().unwrap().artifact_field, "artifacts");
     }
 }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -310,12 +310,59 @@ pub struct DelegationTaskContract {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationEndpointSummary {
+    pub instance_id: String,
+    pub instance_name: String,
+    pub transport: String,
+    pub health_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationRoutingSummary {
+    pub mode: String,
+    pub detail: String,
+    pub peer_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationConflictCapabilitySummary {
+    pub required: bool,
+    pub mechanism: String,
+    pub enforced_by: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationTaskStatusSummary {
+    pub states: Vec<String>,
+    pub terminal_states: Vec<String>,
+    pub sender_visibility: String,
+    pub timeout_behavior: String,
+    pub failure_behavior: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationResultContractSummary {
+    pub status_field: String,
+    pub artifact_field: String,
+    pub error_field: String,
+    pub finished_at_field: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationPlanResponse {
     pub strategy: String,
     pub selected_peer: Option<PeerSummary>,
     pub candidates: Vec<PeerSummary>,
     pub detail: String,
     pub task_contract: DelegationTaskContract,
+    pub sender: Option<DelegationEndpointSummary>,
+    pub receiver: Option<DelegationEndpointSummary>,
+    pub routing: Option<DelegationRoutingSummary>,
+    pub branch_reservation: Option<DelegationConflictCapabilitySummary>,
+    pub file_locks: Option<DelegationConflictCapabilitySummary>,
+    pub task_status: Option<DelegationTaskStatusSummary>,
+    pub result: Option<DelegationResultContractSummary>,
 }
 
 impl fmt::Display for DelegationPlanResponse {
@@ -6391,6 +6438,55 @@ mod tests {
                 optional_fields: vec!["target_peer_id".into()],
                 result_fields: vec!["status".into()],
             },
+            sender: Some(DelegationEndpointSummary {
+                instance_id: "sender-a".into(),
+                instance_name: "Sender A".into(),
+                transport: "filesystem".into(),
+                health_url: Some("http://sender-a/api/v1/instance/health".into()),
+            }),
+            receiver: Some(DelegationEndpointSummary {
+                instance_id: "peer-a".into(),
+                instance_name: "Peer A".into(),
+                transport: "http".into(),
+                health_url: Some("http://peer-a/api/v1/instance/health".into()),
+            }),
+            routing: Some(DelegationRoutingSummary {
+                mode: "least_busy".into(),
+                detail: "selected least-busy healthy peer 'peer-a'".into(),
+                peer_count: 1,
+            }),
+            branch_reservation: Some(DelegationConflictCapabilitySummary {
+                required: true,
+                mechanism: "branch_reservation".into(),
+                enforced_by: "orchestrator".into(),
+                detail: "reserve branch names".into(),
+            }),
+            file_locks: Some(DelegationConflictCapabilitySummary {
+                required: true,
+                mechanism: "file_locks".into(),
+                enforced_by: "orchestrator".into(),
+                detail: "acquire file locks".into(),
+            }),
+            task_status: Some(DelegationTaskStatusSummary {
+                states: vec![
+                    "submitted".into(),
+                    "accepted".into(),
+                    "running".into(),
+                    "completed".into(),
+                    "failed".into(),
+                    "timeout".into(),
+                ],
+                terminal_states: vec!["completed".into(), "failed".into(), "timeout".into()],
+                sender_visibility: "tracked".into(),
+                timeout_behavior: "timeout".into(),
+                failure_behavior: "failed".into(),
+            }),
+            result: Some(DelegationResultContractSummary {
+                status_field: "status".into(),
+                artifact_field: "artifacts".into(),
+                error_field: "error".into(),
+                finished_at_field: "finished_at".into(),
+            }),
         };
         let out = render(&response, OutputFormat::Human);
         assert!(out.contains("Delegation strategy: least_busy"));


### PR DESCRIPTION
## Summary\n- parse the full delegation plan payload exposed by the gateway\n- add typed CLI output structs for sender/receiver/routing/conflict/task-status/result metadata\n- cover parsing with a focused unit test and keep render tests compiling\n\n## Testing\n- cargo test -p rune-cli delegation_plan -- --nocapture\n- cargo test -p rune-gateway delegation_plan_ -- --nocapture\n- cargo check\n\nCloses #421