### PR TITLE
feat(runtime): preload subagent delegation context

### DIFF
--- a/crates/rune-runtime/src/engine.rs
+++ b/crates/rune-runtime/src/engine.rs
@@ -95,6 +95,44 @@ impl SessionEngine {
         Ok(row)
     }
 
+
+    /// Create a subagent session preloaded with delegation context and scratchpad metadata.
+    ///
+    /// The context payload is stored in session metadata under `delegation_context` so an
+    /// orchestrator can inject an objective/history/background slice without forcing the
+    /// subagent to rediscover the same files. An optional `shared_scratchpad_path` gives both
+    /// orchestrator and subagent a stable handoff location for incremental findings.
+    pub async fn create_subagent_session_with_context(
+        &self,
+        workspace_root: Option<String>,
+        requester_session_id: Option<Uuid>,
+        channel_ref: Option<String>,
+        mode: Option<String>,
+        delegation_context: serde_json::Value,
+        shared_scratchpad_path: Option<String>,
+    ) -> Result<SessionRow, RuntimeError> {
+        let session = self
+            .create_session_full(
+                SessionKind::Subagent,
+                workspace_root,
+                requester_session_id,
+                channel_ref,
+                mode,
+            )
+            .await?;
+
+        let mut patch = serde_json::json!({
+            "delegation_context": delegation_context,
+        });
+        if let Some(path) = shared_scratchpad_path {
+            patch["shared_scratchpad"] = serde_json::json!({
+                "path": path,
+            });
+        }
+
+        self.patch_metadata(session.id, patch).await
+    }
+
     /// Transition a session to Ready status. Idempotent: if already ready, returns Ok.
     pub async fn mark_ready(&self, session_id: Uuid) -> Result<SessionRow, RuntimeError> {
         let row = self.session_repo.find_by_id(session_id).await?;

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2647,3 +2647,59 @@ async fn prompt_prefix_is_stable_across_consecutive_turns() {
     assert_eq!(first_system, second_system);
     assert!(first_system.contains("## Prompt Cache Padding"));
 }
+
+
+#[tokio::test]
+async fn create_subagent_session_with_context_persists_delegation_slice_and_scratchpad() {
+    let h = TestHarness::new();
+    let engine = h.session_engine();
+    let parent = engine
+        .create_session(
+            SessionKind::Direct,
+            Some(h.workspace_root.to_string_lossy().to_string()),
+        )
+        .await
+        .unwrap();
+
+    let session = engine
+        .create_subagent_session_with_context(
+            Some(h.workspace_root.to_string_lossy().to_string()),
+            Some(parent.id),
+            Some("orchestrator:acme".to_string()),
+            Some("isolated".to_string()),
+            serde_json::json!({
+                "task": "Fix auth timeout regression",
+                "budget": {
+                    "token_budget": 2048,
+                    "partitions": [
+                        {"id": "objective", "partition": "objective", "token_count": 180},
+                        {"id": "history-1", "partition": "history", "token_count": 420},
+                        {"id": "background-1", "partition": "background", "token_count": 260}
+                    ]
+                },
+                "file_summaries": [
+                    {"path": "src/auth.rs", "summary": "timeout logic and retry budget"}
+                ],
+                "memories": ["customer escalated timeout failures after retry patch"]
+            }),
+            Some("agents/acme/scratchpads/subagent-1.md".to_string()),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(session.kind, "subagent");
+    assert_eq!(session.status, "ready");
+    assert_eq!(session.requester_session_id, Some(parent.id));
+    assert_eq!(session.channel_ref.as_deref(), Some("orchestrator:acme"));
+    assert_eq!(session.metadata["mode"], "isolated");
+    assert_eq!(session.metadata["delegation_context"]["task"], "Fix auth timeout regression");
+    assert_eq!(session.metadata["delegation_context"]["budget"]["token_budget"], 2048);
+    assert_eq!(
+        session.metadata["delegation_context"]["file_summaries"][0]["path"],
+        "src/auth.rs"
+    );
+    assert_eq!(
+        session.metadata["shared_scratchpad"]["path"],
+        "agents/acme/scratchpads/subagent-1.md"
+    );
+}


### PR DESCRIPTION
## Summary\n- add a SessionEngine helper to create subagent sessions with preloaded delegation context metadata\n- persist an optional shared scratchpad path alongside the context slice for bidirectional handoff\n- cover the new subagent bootstrap path with a runtime test\n\n## Testing\n- cargo test -p rune-runtime create_subagent_session_with_context_persists_delegation_slice_and_scratchpad\n- cargo check\n