### PR TITLE
feat(gateway): enrich delegation peer metadata (#421)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -147,6 +147,7 @@ pub struct DelegationResultContractResponse {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PeerHealthResponse {
     pub id: String,
+    pub name: String,
     pub health_url: String,
     pub status: String,
     pub detail: String,
@@ -155,6 +156,9 @@ pub struct PeerHealthResponse {
     pub load: Option<InstanceLoadResponse>,
     pub advertised_addr: Option<String>,
     pub roles: Vec<String>,
+    pub capability_hash: Option<String>,
+    pub capabilities_version: Option<u32>,
+    pub comms_transport: Option<String>,
     pub configured_models: Vec<String>,
     pub active_projects: Vec<String>,
 }
@@ -295,7 +299,7 @@ pub async fn delegation_plan(
         .as_ref()
         .map(|peer| DelegationEndpointResponse {
             instance_id: peer.id.clone(),
-            instance_name: peer.id.clone(),
+            instance_name: peer.name.clone(),
             transport: "http".to_string(),
             health_url: Some(peer.health_url.clone()),
             submit_url: Some(format!(
@@ -461,7 +465,8 @@ async fn collect_peer_health(
             return peers
                 .into_iter()
                 .map(|peer| PeerHealthResponse {
-                    id: peer.id,
+                    id: peer.id.clone(),
+                    name: peer.id,
                     health_url: peer.health_url,
                     status: "degraded".to_string(),
                     detail: format!("client init failed: {error}"),
@@ -470,6 +475,9 @@ async fn collect_peer_health(
                     load: None,
                     advertised_addr: None,
                     roles: Vec::new(),
+                    capability_hash: None,
+                    capabilities_version: None,
+                    comms_transport: None,
                     configured_models: Vec::new(),
                     active_projects: Vec::new(),
                 })
@@ -489,6 +497,7 @@ async fn collect_peer_health(
                 match payload {
                     Ok(payload) => PeerHealthResponse {
                         id: peer.id,
+                        name: payload.capabilities.identity.name.clone(),
                         health_url: peer.health_url,
                         status: if status_code.is_success() {
                             "healthy".to_string()
@@ -501,11 +510,15 @@ async fn collect_peer_health(
                         load: Some(payload.load),
                         advertised_addr: payload.capabilities.identity.advertised_addr,
                         roles: payload.capabilities.identity.roles,
+                        capability_hash: Some(payload.capabilities.identity.capability_hash),
+                        capabilities_version: Some(payload.capabilities.identity.capabilities_version),
+                        comms_transport: Some(payload.capabilities.comms_transport),
                         configured_models: payload.capabilities.configured_models,
                         active_projects: payload.capabilities.active_projects,
                     },
                     Err(error) => PeerHealthResponse {
-                        id: peer.id,
+                        id: peer.id.clone(),
+                        name: peer.id,
                         health_url: peer.health_url,
                         status: "degraded".to_string(),
                         detail: format!("{} (invalid health payload: {error})", status_code),
@@ -514,13 +527,17 @@ async fn collect_peer_health(
                         load: None,
                         advertised_addr: None,
                         roles: Vec::new(),
+                        capability_hash: None,
+                        capabilities_version: None,
+                        comms_transport: None,
                         configured_models: Vec::new(),
                         active_projects: Vec::new(),
                     },
                 }
             }
             Err(error) => PeerHealthResponse {
-                id: peer.id,
+                id: peer.id.clone(),
+                name: peer.id,
                 health_url: peer.health_url,
                 status: "unreachable".to_string(),
                 detail: error.to_string(),
@@ -529,6 +546,9 @@ async fn collect_peer_health(
                 load: None,
                 advertised_addr: None,
                 roles: Vec::new(),
+                capability_hash: None,
+                capabilities_version: None,
+                comms_transport: None,
                 configured_models: Vec::new(),
                 active_projects: Vec::new(),
             },

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4278,9 +4278,13 @@ async fn instance_health_reports_peer_metadata_from_health_payload() {
     let json = body_json(response).await;
     let peer = json["peers"].as_array().unwrap().first().unwrap();
     assert_eq!(peer["status"], "healthy");
+    assert_eq!(peer["name"], "peer-a");
     assert_eq!(peer["load"]["session_count"], 3);
     assert_eq!(peer["advertised_addr"], "http://peer-a:8787");
     assert_eq!(peer["roles"], serde_json::json!(["gateway", "coder"]));
+    assert_eq!(peer["capability_hash"], "cap-peer-a");
+    assert_eq!(peer["capabilities_version"], 1);
+    assert_eq!(peer["comms_transport"], "filesystem");
     assert_eq!(peer["configured_models"], serde_json::json!(["gpt-4.1"]));
     assert_eq!(peer["active_projects"], serde_json::json!(["rune"]));
 }
@@ -4379,6 +4383,7 @@ async fn delegation_plan_selects_least_busy_healthy_peer() {
     assert_eq!(json["strategy"], "least_busy");
     assert_eq!(json["selected_peer"]["id"], "peer-b");
     assert_eq!(json["receiver"]["instance_id"], "peer-b");
+    assert_eq!(json["receiver"]["instance_name"], "peer-b");
     assert_eq!(json["receiver"]["transport"], "http");
     assert_eq!(
         json["receiver"]["submit_url"],
@@ -4549,6 +4554,87 @@ async fn delegation_plan_named_strategy_exposes_sender_health_url_when_advertise
         "http://127.0.0.1:8787/api/v1/instance/delegations/{task_id}"
     );
     assert_eq!(json["routing"]["mode"], "named");
+}
+
+#[tokio::test]
+async fn delegation_plan_named_strategy_uses_peer_identity_name_for_receiver() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let payload = serde_json::json!({
+            "status": "ok",
+            "service": "rune-gateway",
+            "version": "0.1.0",
+            "uptime_seconds": 12,
+            "load": {
+                "session_count": 1,
+                "ws_subscribers": 0,
+                "ws_connections": 0
+            },
+            "capabilities": {
+                "mode": "standalone",
+                "updated_at": "2026-03-29T00:00:00Z",
+                "storage_backend": "sqlite",
+                "pgvector": false,
+                "memory_mode": "semantic",
+                "browser": false,
+                "mcp_servers": 0,
+                "tts": false,
+                "stt": false,
+                "channels": [],
+                "approval_mode": "manual",
+                "security_posture": "standard",
+                "identity": {
+                    "id": "peer-a",
+                    "name": "Peer Alpha",
+                    "advertised_addr": "http://peer-a:8787",
+                    "roles": ["gateway", "coder"],
+                    "capabilities_version": 7,
+                    "capability_hash": "cap-peer-alpha"
+                },
+                "instance_id": "peer-a",
+                "instance_name": "Peer Alpha",
+                "peer_count": 0,
+                "configured_models": ["gpt-4.1"],
+                "active_projects": ["rune", "phoenix"],
+                "comms_transport": "http"
+            },
+            "peers": []
+        });
+        let app = axum::Router::new().route(
+            "/api/v1/instance/health",
+            axum::routing::get(move || {
+                let payload = payload.clone();
+                async move { axum::Json(payload) }
+            }),
+        );
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let mut config = AppConfig::default();
+    config.instance.peers = vec![rune_config::PeerConfig {
+        id: "peer-a".to_string(),
+        health_url: format!("http://{addr}/api/v1/instance/health"),
+    }];
+
+    let (app, _state) = build_test_app_parts(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/v1/instance/delegation-plan?strategy=named&peer_id=peer-a")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["receiver"]["instance_id"], "peer-a");
+    assert_eq!(json["receiver"]["instance_name"], "Peer Alpha");
+    assert_eq!(json["selected_peer"]["name"], "Peer Alpha");
+    assert_eq!(json["selected_peer"]["capability_hash"], "cap-peer-alpha");
+    assert_eq!(json["selected_peer"]["capabilities_version"], 7);
+    assert_eq!(json["selected_peer"]["comms_transport"], "http");
 }
 
 #[tokio::test]
@@ -4940,6 +5026,7 @@ async fn context_assembly_report_flags_compaction_when_budget_is_exceeded() {
             "Additional task context to force both tier and compaction thresholds.".into(),
         ],
         8,
+        false,
     );
 
     assert!(report.over_budget);


### PR DESCRIPTION
## Summary
- enrich instance health peer entries with peer identity name, capability hash/version, and comms transport
- use advertised peer identity name in delegation-plan receiver metadata
- add route coverage for peer metadata exposure and receiver naming behavior

## Validation
- cargo check
- cargo test -p rune-gateway instance_health_reports_peer_metadata_from_health_payload -- --nocapture
- cargo test -p rune-gateway delegation_plan_named_strategy_uses_peer_identity_name_for_receiver -- --nocapture
- cargo test -p rune-gateway delegation_plan_selects_least_busy_healthy_peer -- --nocapture