### PR TITLE
feat(gateway): expose memory hierarchy diagnostics

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -1072,6 +1072,7 @@ pub struct DashboardDiagnosticsResponse {
     pub items: Vec<DashboardDiagnosticItem>,
     pub context_budget: ContextBudgetDiagnostics,
     pub context_tiers: ContextTierDiagnostics,
+    pub memory_hierarchy: DashboardMemoryHierarchyDiagnostics,
 }
 
 #[derive(Serialize)]
@@ -1094,6 +1095,24 @@ pub struct ContextTierDiagnostics {
     pub task: usize,
     pub project: usize,
     pub shared: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DashboardMemoryHierarchyDiagnostics {
+    pub prompt_cache_rows: u64,
+    pub cached_tokens: u64,
+    pub total_input_tokens: u64,
+    pub cache_hit_ratio_percent: f64,
+    pub l2_recall_hits: u64,
+    pub l2_hot_memories: u64,
+    pub l2_total_memories: u64,
+    pub context_total_budget: u64,
+    pub context_total_estimated_tokens: u64,
+    pub context_compaction_trigger_tokens: u64,
+    pub context_over_budget: bool,
+    pub context_over_compaction_threshold: bool,
+    pub context_compaction_required: bool,
+    pub loaded_tier_count: u64,
 }
 
 // SPA serving - runtime UI dist lookup so cargo check works even when ui/dist is absent.
@@ -1335,6 +1354,27 @@ pub async fn dashboard_diagnostics(
         shared: config.context.shared,
     };
 
+    let memory_hierarchy_summary =
+        doctor_memory_hierarchy(&state, &config, &state.capabilities, &state.token_metrics).await;
+    let memory_hierarchy = DashboardMemoryHierarchyDiagnostics {
+        prompt_cache_rows: memory_hierarchy_summary.prompt_cache_rows,
+        cached_tokens: memory_hierarchy_summary.cached_tokens,
+        total_input_tokens: memory_hierarchy_summary.total_input_tokens,
+        cache_hit_ratio_percent: memory_hierarchy_summary.cache_hit_ratio_percent,
+        l2_recall_hits: memory_hierarchy_summary.l2_recall_hits,
+        l2_hot_memories: memory_hierarchy_summary.l2_hot_memories,
+        l2_total_memories: memory_hierarchy_summary.l2_total_memories,
+        context_total_budget: memory_hierarchy_summary.context_total_budget,
+        context_total_estimated_tokens: memory_hierarchy_summary.context_total_estimated_tokens,
+        context_compaction_trigger_tokens: memory_hierarchy_summary
+            .context_compaction_trigger_tokens,
+        context_over_budget: memory_hierarchy_summary.context_over_budget,
+        context_over_compaction_threshold: memory_hierarchy_summary
+            .context_over_compaction_threshold,
+        context_compaction_required: memory_hierarchy_summary.context_compaction_required,
+        loaded_tier_count: memory_hierarchy_summary.loaded_tier_count,
+    };
+
     items.push(DashboardDiagnosticItem {
         level: "info",
         source: "context",
@@ -1350,6 +1390,25 @@ pub async fn dashboard_diagnostics(
             context_budget.memory_search_k,
             context_budget.total_tier_budget,
             context_budget.exceeds_usable_budget,
+        ),
+        observed_at: now.clone(),
+    });
+
+    items.push(DashboardDiagnosticItem {
+        level: if memory_hierarchy.context_compaction_required { "warn" } else { "info" },
+        source: "memory_hierarchy",
+        message: format!(
+            "Memory hierarchy: prompt_cache_rows={} cache_hit_ratio_percent={:.1} l2_recall_hits={} l2_hot_memories={} l2_total_memories={} loaded_tiers={} context_estimated_tokens={} compaction_trigger={} over_budget={} compaction_required={}",
+            memory_hierarchy.prompt_cache_rows,
+            memory_hierarchy.cache_hit_ratio_percent,
+            memory_hierarchy.l2_recall_hits,
+            memory_hierarchy.l2_hot_memories,
+            memory_hierarchy.l2_total_memories,
+            memory_hierarchy.loaded_tier_count,
+            memory_hierarchy.context_total_estimated_tokens,
+            memory_hierarchy.context_compaction_trigger_tokens,
+            memory_hierarchy.context_over_budget,
+            memory_hierarchy.context_compaction_required,
         ),
         observed_at: now.clone(),
     });
@@ -1370,6 +1429,7 @@ pub async fn dashboard_diagnostics(
         items,
         context_budget,
         context_tiers,
+        memory_hierarchy,
     }))
 }
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -5033,6 +5033,25 @@ async fn dashboard_diagnostics_falls_back_to_status_notes() {
     assert_eq!(context_tiers["task"], 10000);
     assert_eq!(context_tiers["project"], 20000);
     assert_eq!(context_tiers["shared"], 5000);
+    let memory_hierarchy = &json["memory_hierarchy"];
+    assert_eq!(memory_hierarchy["prompt_cache_rows"], 0);
+    assert_eq!(memory_hierarchy["cached_tokens"], 0);
+    assert_eq!(memory_hierarchy["total_input_tokens"], 0);
+    assert_eq!(memory_hierarchy["cache_hit_ratio_percent"], 0.0);
+    assert_eq!(memory_hierarchy["l2_recall_hits"], 0);
+    assert_eq!(memory_hierarchy["l2_hot_memories"], 0);
+    assert_eq!(memory_hierarchy["l2_total_memories"], 0);
+    assert_eq!(memory_hierarchy["context_total_budget"], 36000);
+    assert_eq!(memory_hierarchy["context_compaction_trigger_tokens"], 50000);
+    assert_eq!(memory_hierarchy["context_over_budget"], false);
+    assert_eq!(memory_hierarchy["context_over_compaction_threshold"], false);
+    assert_eq!(memory_hierarchy["context_compaction_required"], false);
+    assert_eq!(memory_hierarchy["loaded_tier_count"], 5);
+    assert!(
+        items
+            .iter()
+            .any(|item| item["source"] == "memory_hierarchy")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n- expose structured memory hierarchy metrics on \n- add a dashboard diagnostic note for hierarchy/compaction pressure\n- cover the new response shape in route tests\n\n## Testing\n- cargo test -p rune-gateway dashboard_diagnostics_falls_back_to_status_notes -- --nocapture\n- cargo check\n\nCloses #426