### PR TITLE
feat(context): wire historical tier budget (#405)

### DIFF
--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -859,6 +859,8 @@ pub struct ContextConfig {
     pub project: usize,
     #[serde(default = "default_context_shared_tokens")]
     pub shared: usize,
+    #[serde(default = "default_context_historical_tokens")]
+    pub historical: usize,
 }
 
 fn default_context_identity_tokens() -> usize {
@@ -873,6 +875,9 @@ fn default_context_project_tokens() -> usize {
 fn default_context_shared_tokens() -> usize {
     5_000
 }
+fn default_context_historical_tokens() -> usize {
+    0
+}
 
 impl Default for ContextConfig {
     fn default() -> Self {
@@ -881,6 +886,7 @@ impl Default for ContextConfig {
             task: default_context_task_tokens(),
             project: default_context_project_tokens(),
             shared: default_context_shared_tokens(),
+            historical: default_context_historical_tokens(),
         }
     }
 }
@@ -896,6 +902,7 @@ mod context_config_tests {
         assert_eq!(cfg.task, 10_000);
         assert_eq!(cfg.project, 20_000);
         assert_eq!(cfg.shared, 5_000);
+        assert_eq!(cfg.historical, 0);
     }
 }
 

--- a/crates/rune-runtime/src/context.rs
+++ b/crates/rune-runtime/src/context.rs
@@ -280,7 +280,7 @@ impl ContextAssembler {
             ContextTierSpec::new(ContextTierKind::ActiveTask, config.task),
             ContextTierSpec::new(ContextTierKind::Project, config.project),
             ContextTierSpec::new(ContextTierKind::Shared, config.shared),
-            ContextTierSpec::new(ContextTierKind::Historical, 0),
+            ContextTierSpec::new(ContextTierKind::Historical, config.historical),
         ];
         self
     }
@@ -965,6 +965,7 @@ mod context_tier_tests {
             task: 222,
             project: 333,
             shared: 444,
+            historical: 555,
         };
 
         let assembler = ContextAssembler::new("Identity instructions").with_context_config(&config);
@@ -975,7 +976,7 @@ mod context_tier_tests {
         assert_eq!(specs[1].token_budget, 222);
         assert_eq!(specs[2].token_budget, 333);
         assert_eq!(specs[3].token_budget, 444);
-        assert_eq!(specs[4].token_budget, 0);
+        assert_eq!(specs[4].token_budget, 555);
     }
 
     #[test]


### PR DESCRIPTION
## Parent\nPart of #405 (Multi-Instance Federation)\n\n## Summary\n- add a configurable historical context tier budget to rune-config\n- pass the runtime context config historical budget through ContextAssembler\n- extend tests to cover the new default and runtime override\n\n## Verification\n- cargo test -p rune-runtime context_tier_tests -- --nocapture\n- cargo check