### PR TITLE
feat: add delegation protocol endpoints

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -632,6 +632,107 @@ fn delegation_task_contract() -> DelegationTaskContractResponse {
     }
 }
 
+pub async fn submit_delegation_task(
+    State(state): State<AppState>,
+    Json(payload): Json<DelegationTaskRequest>,
+) -> Result<(StatusCode, Json<DelegationTaskStatusEnvelope>), GatewayError> {
+    let accepted_at = Utc::now().to_rfc3339();
+    let result = DelegationTaskResultResponse {
+        task_id: payload.task_id,
+        status: "accepted".to_string(),
+        accepted_at,
+        started_at: None,
+        output: None,
+        artifacts: Vec::new(),
+        error: None,
+        finished_at: None,
+    };
+
+    let receiver = DelegationEndpointResponse {
+        instance_id: state.capabilities.identity.id.clone(),
+        instance_name: state.capabilities.identity.name.clone(),
+        transport: state.capabilities.comms_transport.clone(),
+        health_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| format!("{}/api/v1/instance/health", addr.trim_end_matches('/'))),
+        submit_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| format!("{}/api/v1/instance/delegations", addr.trim_end_matches('/'))),
+        result_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| {
+                format!(
+                    "{}/api/v1/instance/delegations/{{task_id}}",
+                    addr.trim_end_matches('/')
+                )
+            }),
+    };
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(DelegationTaskStatusEnvelope { receiver, result }),
+    ))
+}
+
+pub async fn delegation_task_status(
+    State(state): State<AppState>,
+    Path(task_id): Path<String>,
+) -> Result<Json<DelegationTaskStatusEnvelope>, GatewayError> {
+    let result = DelegationTaskResultResponse {
+        task_id: task_id.clone(),
+        status: "failed".to_string(),
+        accepted_at: Utc::now().to_rfc3339(),
+        started_at: None,
+        output: None,
+        artifacts: Vec::new(),
+        error: Some(DelegationErrorResponse {
+            code: "not_implemented".to_string(),
+            message: "delegation execution is not implemented yet; only the protocol surface is available".to_string(),
+        }),
+        finished_at: Some(Utc::now().to_rfc3339()),
+    };
+
+    let receiver = DelegationEndpointResponse {
+        instance_id: state.capabilities.identity.id.clone(),
+        instance_name: state.capabilities.identity.name.clone(),
+        transport: state.capabilities.comms_transport.clone(),
+        health_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| format!("{}/api/v1/instance/health", addr.trim_end_matches('/'))),
+        submit_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| format!("{}/api/v1/instance/delegations", addr.trim_end_matches('/'))),
+        result_url: state
+            .capabilities
+            .identity
+            .advertised_addr
+            .as_ref()
+            .map(|addr| {
+                format!(
+                    "{}/api/v1/instance/delegations/{task_id}",
+                    addr.trim_end_matches('/')
+                )
+            }),
+    };
+
+    Ok(Json(DelegationTaskStatusEnvelope { receiver, result }))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct DelegationPlanQuery {
     pub strategy: Option<String>,

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -433,6 +433,14 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
             "/api/v1/instance/delegation-plan",
             get(routes::delegation_plan),
         )
+        .route(
+            "/api/v1/instance/delegations",
+            post(routes::submit_delegation_task),
+        )
+        .route(
+            "/api/v1/instance/delegations/{task_id}",
+            get(routes::delegation_task_status),
+        )
         .route("/chat", get(webchat::legacy_chat_redirect))
         .route("/webchat", get(webchat::webchat_handler))
         .route("/assets/{path}", get(routes::branded_asset))

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -13302,3 +13302,101 @@ async fn doctor_run_reports_instance_topology_summary() {
     assert_eq!(body["topology"]["models"], "azure");
     assert_eq!(body["topology"]["search"], "semantic-hybrid");
 }
+
+#[tokio::test]
+async fn delegation_submission_accepts_task_and_returns_receiver_metadata() {
+    let mut config = AppConfig::default();
+    config.instance.id = "sender-a".to_string();
+    config.instance.name = "Sender A".to_string();
+    config.instance.advertised_addr = Some("http://127.0.0.1:8787/".to_string());
+
+    let (app, _state) = build_test_app_parts(config, None);
+    let response = app
+        .oneshot(
+            Request::post("/api/v1/instance/delegations")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "task_id": "delegation-123",
+                        "protocol_version": 1,
+                        "submitted_at": "2026-03-29T00:00:00Z",
+                        "sender": {
+                            "instance_id": "origin-a",
+                            "instance_name": "Origin A",
+                            "transport": "http",
+                            "health_url": "http://origin-a/api/v1/instance/health",
+                            "submit_url": "http://origin-a/api/v1/instance/delegations",
+                            "result_url": "http://origin-a/api/v1/instance/delegations/{task_id}"
+                        },
+                        "task": {
+                            "task": "Implement issue #421 receiver stub",
+                            "constraints": ["Run cargo check"],
+                            "expected_output": "Structured accepted response",
+                            "timeout_secs": 600,
+                            "target_peer_id": "sender-a",
+                            "branch_reservation": "agent/rune/issue-421",
+                            "file_locks": ["crates/rune-gateway/src/routes.rs"],
+                            "artifacts": []
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let json = body_json(response).await;
+    assert_eq!(json["receiver"]["instance_id"], "sender-a");
+    assert_eq!(json["receiver"]["instance_name"], "Sender A");
+    assert_eq!(json["receiver"]["transport"], "filesystem");
+    assert_eq!(
+        json["receiver"]["health_url"],
+        "http://127.0.0.1:8787/api/v1/instance/health"
+    );
+    assert_eq!(
+        json["receiver"]["submit_url"],
+        "http://127.0.0.1:8787/api/v1/instance/delegations"
+    );
+    assert_eq!(
+        json["receiver"]["result_url"],
+        "http://127.0.0.1:8787/api/v1/instance/delegations/{task_id}"
+    );
+    assert_eq!(json["result"]["task_id"], "delegation-123");
+    assert_eq!(json["result"]["status"], "accepted");
+    assert_eq!(json["result"]["started_at"], serde_json::Value::Null);
+    assert_eq!(json["result"]["error"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn delegation_status_returns_not_implemented_failure_envelope() {
+    let mut config = AppConfig::default();
+    config.instance.id = "receiver-a".to_string();
+    config.instance.name = "Receiver A".to_string();
+
+    let (app, _state) = build_test_app_parts(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/v1/instance/delegations/delegation-404")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    assert_eq!(json["receiver"]["instance_id"], "receiver-a");
+    assert_eq!(json["receiver"]["instance_name"], "Receiver A");
+    assert_eq!(json["result"]["task_id"], "delegation-404");
+    assert_eq!(json["result"]["status"], "failed");
+    assert_eq!(json["result"]["error"]["code"], "not_implemented");
+    assert!(
+        json["result"]["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("protocol surface")
+    );
+    assert!(json["result"]["finished_at"].is_string());
+}


### PR DESCRIPTION
## Summary
- add public receiver endpoints for cross-instance delegation submission and task status lookup
- return structured protocol envelopes with receiver metadata and lifecycle fields
- cover the new protocol surface with gateway route tests

## Verification
- cargo test -p rune-gateway delegation_ -- --nocapture
- cargo check

Closes #421