### PR TITLE
fix(gateway): restrict agent controls to subagent sessions (#658)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2845,6 +2845,13 @@ pub async fn agent_steer(
         .await
         .map_err(|_| GatewayError::SessionNotFound(format!("agent session {id} not found")))?;
 
+    if session.kind != "subagent" {
+        return Err(GatewayError::BadRequest(format!(
+            "agent controls require a subagent session; found kind {}",
+            session.kind
+        )));
+    }
+
     let now = chrono::Utc::now();
     let note = format!("[steer] operator instruction injected: {}", body.message);
 
@@ -2905,6 +2912,13 @@ pub async fn agent_kill(
         .find_by_id(id)
         .await
         .map_err(|_| GatewayError::SessionNotFound(format!("agent session {id} not found")))?;
+
+    if session.kind != "subagent" {
+        return Err(GatewayError::BadRequest(format!(
+            "agent controls require a subagent session; found kind {}",
+            session.kind
+        )));
+    }
 
     let now = chrono::Utc::now();
     let reason = body.reason.as_deref().unwrap_or("operator-initiated");


### PR DESCRIPTION
## Summary\n- reject HTTP agent steer/kill requests for non-subagent sessions\n- keep the bad-request response explicit about the found session kind\n\n## Testing\n- cargo check\n\nCloses #658