### PR TITLE
feat: expose peer failure counts in instance health

### DIFF
--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -6878,11 +6878,15 @@ fn parse_peer_summary(value: &serde_json::Value) -> Option<PeerSummary> {
 
     Some(PeerSummary {
         id: value["id"].as_str().unwrap_or_default().to_string(),
+        name: value["name"].as_str().map(String::from),
         health_url: value["health_url"].as_str().unwrap_or_default().to_string(),
         status: value["status"].as_str().unwrap_or("unknown").to_string(),
         detail: value["detail"].as_str().unwrap_or_default().to_string(),
         checked_at: value["checked_at"].as_str().map(String::from),
         latency_ms: value["latency_ms"].as_u64().map(u128::from),
+        consecutive_failures: value["consecutive_failures"]
+            .as_u64()
+            .and_then(|v| u32::try_from(v).ok()),
         advertised_addr: value["advertised_addr"].as_str().map(String::from),
         roles: value["roles"]
             .as_array()

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -92,11 +92,13 @@ pub struct InstanceLoadSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerSummary {
     pub id: String,
+    pub name: Option<String>,
     pub health_url: String,
     pub status: String,
     pub detail: String,
     pub checked_at: Option<String>,
     pub latency_ms: Option<u128>,
+    pub consecutive_failures: Option<u32>,
     pub advertised_addr: Option<String>,
     pub roles: Vec<String>,
     pub configured_models: Vec<String>,
@@ -228,7 +230,8 @@ Peers: {}",
                 f,
                 "
   - {} [{}]",
-                peer.id, peer.status
+                peer.name.as_deref().unwrap_or(&peer.id),
+                peer.status
             )?;
             write!(
                 f,
@@ -254,6 +257,13 @@ Peers: {}",
                     f,
                     "
     Latency: {latency_ms}ms"
+                )?;
+            }
+            if let Some(consecutive_failures) = peer.consecutive_failures {
+                write!(
+                    f,
+                    "
+    Consecutive failures: {consecutive_failures}"
                 )?;
             }
             if let Some(ref advertised_addr) = peer.advertised_addr {
@@ -688,7 +698,8 @@ Result timestamps: accepted={}, started={}, finished={}",
                 f,
                 "
   - {} [{}]",
-                peer.id, peer.status
+                peer.name.as_deref().unwrap_or(&peer.id),
+                peer.status
             )?;
             if let Some(ref load) = peer.load {
                 write!(

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -225,6 +225,7 @@ pub struct PeerHealthResponse {
     pub detail: String,
     pub checked_at: String,
     pub latency_ms: Option<u128>,
+    pub consecutive_failures: u32,
     pub load: Option<InstanceLoadResponse>,
     pub advertised_addr: Option<String>,
     pub roles: Vec<String>,
@@ -358,7 +359,11 @@ pub async fn delegation_plan(
 
     let capability_match = evaluate_capability_match(&state.capabilities, selected_peer.as_ref());
 
-    let detail = match (&selected_peer, strategy.as_str(), capability_match.compatible) {
+    let detail = match (
+        &selected_peer,
+        strategy.as_str(),
+        capability_match.compatible,
+    ) {
         (Some(peer), "named", true) => format!("selected named peer '{}'", peer.id),
         (Some(peer), "named", false) => format!(
             "selected named peer '{}' with capability mismatch: {}",
@@ -699,6 +704,7 @@ async fn collect_peer_health(
                     detail: format!("client init failed: {error}"),
                     checked_at: checked_at.clone(),
                     latency_ms: None,
+                    consecutive_failures: 0,
                     load: None,
                     advertised_addr: None,
                     roles: Vec::new(),
@@ -734,6 +740,7 @@ async fn collect_peer_health(
                         detail: status_code.to_string(),
                         checked_at,
                         latency_ms,
+                        consecutive_failures: if status_code.is_success() { 0 } else { 1 },
                         load: Some(payload.load),
                         advertised_addr: payload.capabilities.identity.advertised_addr,
                         roles: payload.capabilities.identity.roles,
@@ -753,6 +760,7 @@ async fn collect_peer_health(
                         detail: format!("{} (invalid health payload: {error})", status_code),
                         checked_at,
                         latency_ms,
+                        consecutive_failures: 1,
                         load: None,
                         advertised_addr: None,
                         roles: Vec::new(),
@@ -772,6 +780,7 @@ async fn collect_peer_health(
                 detail: error.to_string(),
                 checked_at,
                 latency_ms: None,
+                consecutive_failures: 1,
                 load: None,
                 advertised_addr: None,
                 roles: Vec::new(),
@@ -5958,7 +5967,6 @@ pub fn parse_memory_search_output(output: &str) -> Vec<MemorySearchResult> {
         })
         .collect()
 }
-
 
 #[derive(Serialize, Deserialize)]
 struct RemoteMemorySearchResponse {

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4886,7 +4886,6 @@ async fn delegation_plan_named_strategy_uses_peer_identity_name_for_receiver() {
     assert_eq!(json["selected_peer"]["comms_transport"], "http");
 }
 
-
 #[tokio::test]
 async fn delegation_plan_rejects_named_strategy_when_peer_has_capability_mismatch() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -4972,8 +4971,14 @@ async fn delegation_plan_rejects_named_strategy_when_peer_has_capability_mismatc
     let json = body_json(response).await;
     assert_eq!(json["selected_peer"]["id"], "peer-b");
     assert_eq!(json["capability_match"]["compatible"], false);
-    assert_eq!(json["capability_match"]["missing_roles"], serde_json::json!(["coder"]));
-    assert_eq!(json["capability_match"]["missing_projects"], serde_json::json!(["rune"]));
+    assert_eq!(
+        json["capability_match"]["missing_roles"],
+        serde_json::json!(["coder"])
+    );
+    assert_eq!(
+        json["capability_match"]["missing_projects"],
+        serde_json::json!(["rune"])
+    );
 }
 
 #[tokio::test]
@@ -13707,4 +13712,30 @@ async fn delegation_status_route_returns_trackable_task_status() {
         json["receiver"]["result_url"],
         "/api/v1/instance/delegations/delegation-421"
     );
+}
+
+#[tokio::test]
+async fn instance_health_marks_unreachable_peer_and_reports_failure_count() {
+    let mut config = AppConfig::default();
+    config.instance.peers = vec![rune_config::PeerConfig {
+        id: "peer-down".to_string(),
+        health_url: "http://127.0.0.1:9/api/v1/instance/health".to_string(),
+    }];
+
+    let (app, _state) = build_test_app_parts(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/v1/instance/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    let peer = json["peers"].as_array().unwrap().first().unwrap();
+    assert_eq!(peer["status"], "unreachable");
+    assert_eq!(peer["consecutive_failures"], 1);
+    assert!(!peer["detail"].as_str().unwrap().is_empty());
 }


### PR DESCRIPTION
## Summary
- add `consecutive_failures` to instance-health peer payloads
- surface peer display names and failure counts in CLI instance-health output
- add regression coverage for unreachable peers

## Testing
- cargo test -p rune-gateway instance_health_ -- --nocapture
- cargo check