### PR TITLE
feat(gateway): expose session tree parent ids (#410)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2637,6 +2637,8 @@ pub struct SessionTreeNode {
     pub kind: String,
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
@@ -2759,6 +2761,7 @@ pub async fn get_session_tree(
             id: row.id.to_string(),
             kind: row.kind.clone(),
             status: row.status.clone(),
+            parent_session_id: row.requester_session_id.map(|id| id.to_string()),
             mode: metadata_string(&row.metadata, "mode"),
             channel: row.channel_ref.clone(),
             orchestration_status,

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -14561,6 +14561,7 @@ async fn get_session_tree_surfaces_subagent_audit_metadata() {
     let child = &json["children"][0];
     assert_eq!(child["id"], child_id.to_string());
     assert_eq!(child["kind"], "subagent");
+    assert_eq!(child["parent_session_id"], root_id.to_string());
     assert_eq!(child["mode"], "architect");
     assert_eq!(child["orchestration_status"], "delegated");
     assert_eq!(child["delegation_roles"], serde_json::json!(["architect", "coder"]));


### PR DESCRIPTION
## Summary\n- expose parent_session_id in the gateway session tree response\n- cover the new field in gateway route tests\n\nCloses #410\n