### PR TITLE
feat(ui): add markdown code highlighting

### DIFF
--- a/ui/src/components/chat/MarkdownRenderer.tsx
+++ b/ui/src/components/chat/MarkdownRenderer.tsx
@@ -1,6 +1,20 @@
 import { useMemo } from "react";
 import { Marked } from "marked";
 import DOMPurify from "dompurify";
+import Prism from "prismjs";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-css";
+import "prismjs/components/prism-diff";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-markdown";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-toml";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-yaml";
 import { cn } from "@/lib/utils";
 
 interface MarkdownRendererProps {
@@ -47,6 +61,40 @@ function sanitizeUrl(rawHref: string | null | undefined, allowedProtocols?: stri
   }
 }
 
+function normalizeLanguage(rawLanguage?: string | null): string {
+  const language = rawLanguage?.trim().toLowerCase();
+  if (!language) {
+    return "plain";
+  }
+
+  const aliases: Record<string, string> = {
+    shell: "bash",
+    sh: "bash",
+    zsh: "bash",
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    yml: "yaml",
+    md: "markdown",
+    rs: "rust",
+  };
+
+  return aliases[language] ?? language;
+}
+
+function highlightCode(code: string, rawLanguage?: string | null) {
+  const language = normalizeLanguage(rawLanguage);
+  const grammar = Prism.languages[language];
+  const highlighted = grammar ? Prism.highlight(code, grammar, language) : escapeHtml(code);
+
+  return {
+    language,
+    highlighted,
+    supported: Boolean(grammar),
+  };
+}
+
 function renderTableCell(
   parser: Marked["Renderer"]["prototype"]["parser"],
   cell: { tokens: unknown[]; header: boolean; align: "center" | "left" | "right" | null },
@@ -69,6 +117,21 @@ const marked = new Marked({
 
 marked.use({
   renderer: {
+    code(token) {
+      const code = token.text ?? "";
+      const { language, highlighted, supported } = highlightCode(code, token.lang);
+      const label = supported ? language : token.lang?.trim() || "text";
+
+      return `
+        <div class="my-4 overflow-hidden rounded-2xl border border-border/70 bg-zinc-950/95 shadow-sm">
+          <div class="flex items-center justify-between border-b border-zinc-800/80 bg-zinc-900/90 px-4 py-2 text-[11px] uppercase tracking-[0.2em] text-zinc-400">
+            <span>${escapeHtml(label)}</span>
+            <span>${supported ? "highlighted" : "plain text"}</span>
+          </div>
+          <pre class="language-${escapeHtml(language)} overflow-x-auto px-4 py-3 text-xs leading-6 text-zinc-100"><code class="language-${escapeHtml(language)}">${highlighted}</code></pre>
+        </div>
+      `;
+    },
     link({ href, title, tokens }) {
       const safeHref = sanitizeUrl(href, ["http:", "https:", "mailto:", "tel:"]);
       const text = this.parser.parseInline(tokens);
@@ -98,7 +161,7 @@ marked.use({
         <figure class="my-4">
           <img
             src="${escapeHtml(safeSrc)}"
-            alt="${escapeHtml(altText || "Image") }"
+            alt="${escapeHtml(altText || "Image")}"
             loading="lazy"
             decoding="async"
           />
@@ -162,9 +225,38 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
         "[&_strong]:font-semibold",
         "[&_em]:italic",
         "[&_a]:break-words [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-primary/80",
-        "[&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-2xl [&_pre]:border [&_pre]:border-border/70 [&_pre]:bg-zinc-950/95 [&_pre]:px-4 [&_pre]:py-3 [&_pre]:text-xs [&_pre]:leading-6 [&_pre]:text-zinc-100",
-        "[&_pre>code]:block [&_pre>code]:bg-transparent [&_pre>code]:p-0 [&_pre>code]:text-inherit",
+        "[&_pre]:m-0 [&_pre]:bg-transparent [&_pre]:text-inherit",
+        "[&_pre>code]:block [&_pre>code]:bg-transparent [&_pre>code]:p-0",
         "[&_code]:rounded-md [&_code]:bg-muted/80 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em]",
+        "[&_pre_code]:rounded-none [&_pre_code]:bg-transparent [&_pre_code]:px-0 [&_pre_code]:py-0",
+        "[&_code[class*='language-']_.token.comment]:text-zinc-500",
+        "[&_code[class*='language-']_.token.prolog]:text-zinc-500",
+        "[&_code[class*='language-']_.token.doctype]:text-zinc-500",
+        "[&_code[class*='language-']_.token.cdata]:text-zinc-500",
+        "[&_code[class*='language-']_.token.punctuation]:text-zinc-300",
+        "[&_code[class*='language-']_.token.property]:text-sky-300",
+        "[&_code[class*='language-']_.token.tag]:text-sky-300",
+        "[&_code[class*='language-']_.token.boolean]:text-orange-300",
+        "[&_code[class*='language-']_.token.number]:text-orange-300",
+        "[&_code[class*='language-']_.token.constant]:text-orange-300",
+        "[&_code[class*='language-']_.token.symbol]:text-orange-300",
+        "[&_code[class*='language-']_.token.deleted]:text-rose-300",
+        "[&_code[class*='language-']_.token.selector]:text-emerald-300",
+        "[&_code[class*='language-']_.token.attr-name]:text-emerald-300",
+        "[&_code[class*='language-']_.token.string]:text-emerald-300",
+        "[&_code[class*='language-']_.token.char]:text-emerald-300",
+        "[&_code[class*='language-']_.token.builtin]:text-cyan-300",
+        "[&_code[class*='language-']_.token.inserted]:text-cyan-300",
+        "[&_code[class*='language-']_.token.operator]:text-violet-200",
+        "[&_code[class*='language-']_.token.entity]:text-violet-200",
+        "[&_code[class*='language-']_.token.url]:text-violet-200",
+        "[&_code[class*='language-']_.token.atrule]:text-fuchsia-300",
+        "[&_code[class*='language-']_.token.attr-value]:text-fuchsia-300",
+        "[&_code[class*='language-']_.token.keyword]:text-fuchsia-300",
+        "[&_code[class*='language-']_.token.function]:text-amber-200",
+        "[&_code[class*='language-']_.token.class-name]:text-amber-200",
+        "[&_code[class*='language-']_.token.regex]:text-yellow-200",
+        "[&_code[class*='language-']_.token.important]:text-yellow-200",
         "[&_img]:max-h-[28rem] [&_img]:max-w-full [&_img]:rounded-2xl [&_img]:border [&_img]:border-border/70 [&_img]:bg-background/80 [&_img]:shadow-sm",
         "[&_figure]:overflow-hidden",
         "[&_figcaption]:px-1",


### PR DESCRIPTION
Closes #431\n\n## Summary\n- add Prism-based syntax highlighting for markdown code fences\n- normalize common language aliases and fall back to plain text when unsupported\n- style fenced blocks separately from inline code\n