### PR TITLE
fix: include historical tier in offline doctor budget

### DIFF
--- a/crates/rune-cli/src/doctor.rs
+++ b/crates/rune-cli/src/doctor.rs
@@ -1356,14 +1356,22 @@ pub fn build_doctor_report(results: &[CheckResult], config: &AppConfig) -> Docto
             metrics: if config.mem0.enabled {
                 format!(
                     "offline doctor has no live cache metrics; Mem0 access_count persists hot-memory reuse. Context tiers ship static budgets: loaded_tiers=5, total_budget={}, estimated_tokens=0, compaction_trigger_tokens={}, over_budget=false, over_compaction_threshold=false, compaction_required=false, l3_cold_storage_enabled={}; gateway doctor exposes prompt_cache_rows/cached_tokens totals",
-                    config.context.identity + config.context.task + config.context.project + config.context.shared,
+                    config.context.identity
+                        + config.context.task
+                        + config.context.project
+                        + config.context.shared
+                        + config.context.historical,
                     config.runtime.compaction.compress_after,
                     l3_ready
                 )
             } else {
                 format!(
                     "offline doctor has no live cache metrics; run doctor against the gateway for prompt_cache_rows/cached_tokens totals. Context tiers ship static budgets: loaded_tiers=5, total_budget={}, estimated_tokens=0, compaction_trigger_tokens={}, over_budget=false, over_compaction_threshold=false, compaction_required=false, l3_cold_storage_enabled={}",
-                    config.context.identity + config.context.task + config.context.project + config.context.shared,
+                    config.context.identity
+                        + config.context.task
+                        + config.context.project
+                        + config.context.shared
+                        + config.context.historical,
                     config.runtime.compaction.compress_after,
                     l3_ready
                 )
@@ -1378,7 +1386,11 @@ pub fn build_doctor_report(results: &[CheckResult], config: &AppConfig) -> Docto
             l2_hot_memories: 0,
             l2_cold_memories: 0,
             l2_total_memories: 0,
-            context_total_budget: (config.context.identity + config.context.task + config.context.project + config.context.shared) as u64,
+            context_total_budget: (config.context.identity
+                + config.context.task
+                + config.context.project
+                + config.context.shared
+                + config.context.historical) as u64,
             context_total_estimated_tokens: 0,
             context_compaction_trigger_tokens: config.runtime.compaction.compress_after as u64,
             context_over_budget: false,


### PR DESCRIPTION
Closes #426\n\n## Summary\n- include the historical context tier in offline doctor budget reporting\n- keep offline metrics string aligned with the shipped 5-tier memory hierarchy\n\n## Verification\n- cargo test -p rune-cli doctor_memory_hierarchy -- --nocapture\n- cargo test -p rune-gateway doctor_memory_hierarchy -- --nocapture\n- cargo check