### PR TITLE
feat(gateway): surface peer alert summary in instance health

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -253,6 +253,7 @@ pub struct PeerHealthAlert {
 pub struct PeerHealthAlertsResponse {
     pub status: String,
     pub alerts: Vec<PeerHealthAlert>,
+    pub alert_count: usize,
     pub checked_at: String,
 }
 
@@ -865,6 +866,7 @@ fn peer_health_alerts_from_peers(peers: Vec<PeerHealthResponse>) -> PeerHealthAl
     let status = if alerts.is_empty() { "ok" } else { "degraded" };
     PeerHealthAlertsResponse {
         status: status.to_string(),
+        alert_count: alerts.len(),
         alerts,
         checked_at,
     }


### PR DESCRIPTION
## Summary\n- add peer_alerts alert_count to gateway peer health alert responses\n- expose the summary through /api/v1/instance/health consumers\n- keep operator visibility aligned with multi-instance health monitoring work\n\n## Testing\n- cargo test -p rune-gateway peer_health_alerts -- --nocapture\n- cargo test -p rune-cli render_instance_health -- --nocapture\n- cargo check