### PR TITLE
feat(gateway): surface subagent result audit in session status (#658)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2439,8 +2439,12 @@ pub async fn create_session(
 pub struct SessionAuditSummary {
     pub transcript_items: u32,
     pub status_notes: u32,
+    pub subagent_results: u32,
     pub last_transcript_at: Option<String>,
     pub last_operator_note: Option<String>,
+    pub last_subagent_result_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_subagent_result_summary: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -2610,6 +2614,10 @@ pub async fn get_session_status(
         .iter()
         .filter(|item| item.kind == "status_note")
         .count() as u32;
+    let subagent_results = transcript_items
+        .iter()
+        .filter(|item| item.kind == "subagent_result")
+        .count() as u32;
     let last_transcript_at = transcript_items
         .last()
         .map(|item| item.created_at.to_rfc3339());
@@ -2620,12 +2628,38 @@ pub async fn get_session_status(
         .and_then(|item| item.payload.get("content"))
         .and_then(|value| value.as_str())
         .map(ToOwned::to_owned);
+    let last_subagent_result = transcript_items
+        .iter()
+        .rev()
+        .find(|item| item.kind == "subagent_result");
+    let last_subagent_result_at = last_subagent_result.map(|item| item.created_at.to_rfc3339());
+    let last_subagent_result_summary = last_subagent_result.and_then(|item| {
+        item.payload
+            .get("summary")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                item.payload
+                    .get("result")
+                    .and_then(|value| value.as_str())
+                    .map(ToOwned::to_owned)
+            })
+            .or_else(|| {
+                item.payload
+                    .get("content")
+                    .and_then(|value| value.as_str())
+                    .map(ToOwned::to_owned)
+            })
+    });
     let audit = if row.kind == "subagent" {
         Some(SessionAuditSummary {
             transcript_items: transcript_items.len() as u32,
             status_notes,
+            subagent_results,
             last_transcript_at,
             last_operator_note,
+            last_subagent_result_at,
+            last_subagent_result_summary,
         })
     } else {
         None

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -14857,3 +14857,165 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
         "Operator asked for a tighter review pass"
     );
 }
+
+#[tokio::test]
+async fn get_session_status_surfaces_subagent_result_audit_summary() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+
+    let session_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let parent_id = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
+    let now = chrono::Utc::now();
+    session_repo
+        .create(NewSession {
+            id: session_id,
+            kind: "subagent".into(),
+            status: "completed".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: Some(parent_id),
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "subagent_lifecycle": "completed",
+                "subagent_runtime_status": "stopped",
+                "subagent_runtime_attached": false,
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    transcript_repo
+        .append(NewTranscriptItem {
+            id: Uuid::now_v7(),
+            session_id,
+            turn_id: None,
+            seq: 1,
+            kind: "subagent_result".into(),
+            payload: serde_json::json!({
+                "summary": "completed lint and fixed two route tests",
+                "result": "success"
+            }),
+            created_at: now + chrono::TimeDelta::seconds(1),
+        })
+        .await
+        .unwrap();
+    transcript_repo
+        .append(NewTranscriptItem {
+            id: Uuid::now_v7(),
+            session_id,
+            turn_id: None,
+            seq: 2,
+            kind: "status_note".into(),
+            payload: serde_json::json!({
+                "content": "Operator reviewed delegated result"
+            }),
+            created_at: now + chrono::TimeDelta::seconds(2),
+        })
+        .await
+        .unwrap();
+
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics: TokenMetricsStore::new(),
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["audit"]["transcript_items"], 2);
+    assert_eq!(json["audit"]["status_notes"], 1);
+    assert_eq!(json["audit"]["subagent_results"], 1);
+    assert_eq!(
+        json["audit"]["last_subagent_result_summary"],
+        "completed lint and fixed two route tests"
+    );
+    assert!(json["audit"]["last_subagent_result_at"].is_string());
+    assert_eq!(
+        json["audit"]["last_operator_note"],
+        "Operator reviewed delegated result"
+    );
+}


### PR DESCRIPTION
## Summary
- expose subagent_result counts and latest result details in session status audit output
- keep operator-facing subagent audit data focused on delegated result routing visibility
- add route coverage for the new audit fields

## Testing
- cargo check
- cargo test -p rune-gateway --test route_tests get_session_status_surfaces_orchestration_metadata -- --nocapture
- cargo test -p rune-gateway --test route_tests get_session_status_surfaces_subagent_result_audit_summary -- --nocapture