### PR TITLE
feat: add event priority classification (#418)

### DIFF
--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -43,6 +43,10 @@ Rune commands:
 /// Maps channel routing key → session_id.
 type SessionIndex = HashMap<String, Uuid>;
 
+type EventPriority = u8;
+const PRIORITY_USER_MESSAGE: EventPriority = 0;
+const PRIORITY_BACKGROUND: EventPriority = 4;
+
 /// The main session loop that ties channels to the runtime.
 pub struct SessionLoop {
     engine: Arc<SessionEngine>,
@@ -171,6 +175,22 @@ impl SessionLoop {
                 error!(error = %e, "failed to handle inbound event");
             }
         }
+    }
+
+    fn classify_event_priority(event: &InboundEvent) -> EventPriority {
+        match event {
+            InboundEvent::Message(_) => PRIORITY_USER_MESSAGE,
+            InboundEvent::Reaction { .. }
+            | InboundEvent::Edit { .. }
+            | InboundEvent::Delete { .. }
+            | InboundEvent::MemberJoin { .. }
+            | InboundEvent::MemberLeave { .. } => PRIORITY_BACKGROUND,
+        }
+    }
+
+    #[must_use]
+    pub fn event_priority_for_test(event: &InboundEvent) -> EventPriority {
+        Self::classify_event_priority(event)
     }
 
     async fn handle_event(&self, event: InboundEvent) -> Result<(), RuntimeError> {

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2897,3 +2897,28 @@ async fn create_subagent_session_with_context_persists_delegation_slice_and_scra
         "agents/acme/scratchpads/subagent-1.md"
     );
 }
+
+#[test]
+fn session_loop_prioritizes_user_messages_above_background_events() {
+    let message = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "chat-1".to_string(),
+        sender: "hamza".to_string(),
+        content: "urgent".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-1".to_string(),
+    });
+    let reaction = rune_channels::InboundEvent::Reaction {
+        channel_id: rune_core::ChannelId::new(),
+        message_id: "msg-2".to_string(),
+        emoji: "🔥".to_string(),
+        user: "peer".to_string(),
+    };
+
+    let user_priority = crate::session_loop::SessionLoop::event_priority_for_test(&message);
+    let background_priority = crate::session_loop::SessionLoop::event_priority_for_test(&reaction);
+
+    assert!(user_priority < background_priority);
+    assert_eq!(user_priority, 0);
+}


### PR DESCRIPTION
## Summary
- add runtime event priority classification for inbound events
- prioritize user messages above non-message background events
- add a regression test proving message priority outranks reaction events

## Validation
- cargo test -p rune-runtime session_loop_prioritizes_user_messages_above_background_events -- --nocapture
- cargo check