### PR TITLE
feat(gateway): surface subagent artifacts in session status

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -71,7 +71,7 @@ pub struct InstanceHealthResponse {
     pub peers: Vec<PeerHealthResponse>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationArtifactResponse {
     pub name: String,
     pub kind: String,
@@ -2447,6 +2447,8 @@ pub struct SessionAuditSummary {
 pub struct ParentSubagentResultSummary {
     pub session_id: String,
     pub summary: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub artifacts: Vec<DelegationArtifactResponse>,
 }
 
 #[derive(Serialize)]
@@ -3475,7 +3477,20 @@ fn latest_subagent_result(
             .and_then(Value::as_str)
             .map(ToOwned::to_owned)
             .unwrap_or_default();
-        Some(ParentSubagentResultSummary { session_id, summary })
+        let artifacts = item
+            .payload
+            .get("artifacts")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        Some(ParentSubagentResultSummary {
+            session_id,
+            summary,
+            artifacts,
+        })
     })
 }
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -8469,7 +8469,16 @@ async fn get_session_status_surfaces_subagent_metadata() {
             kind: "subagent_result".into(),
             payload: json!({
                 "session_id": "99999999-9999-9999-9999-999999999999",
-                "summary": "Tests tightened and lifecycle audit trail captured"
+                "summary": "Tests tightened and lifecycle audit trail captured",
+                "artifacts": [
+                    {
+                        "name": "review-notes.md",
+                        "kind": "markdown",
+                        "uri": "memory://subagents/99999999-9999-9999-9999-999999999999/review-notes.md",
+                        "content_type": "text/markdown",
+                        "description": "Follow-up notes from the delegated review pass"
+                    }
+                ]
             }),
             created_at: now + chrono::TimeDelta::milliseconds(1),
         })
@@ -8523,7 +8532,16 @@ async fn get_session_status_surfaces_subagent_metadata() {
         json["latest_subagent_result"],
         json!({
             "session_id": "99999999-9999-9999-9999-999999999999",
-            "summary": "Tests tightened and lifecycle audit trail captured"
+            "summary": "Tests tightened and lifecycle audit trail captured",
+            "artifacts": [
+                {
+                    "name": "review-notes.md",
+                    "kind": "markdown",
+                    "uri": "memory://subagents/99999999-9999-9999-9999-999999999999/review-notes.md",
+                    "content_type": "text/markdown",
+                    "description": "Follow-up notes from the delegated review pass"
+                }
+            ]
         })
     );
     let unresolved = json["unresolved"].as_array().unwrap();


### PR DESCRIPTION
## Summary\n- include delegated artifact metadata in the latest subagent result returned by session status\n- deserialize artifacts from session audit entries instead of dropping them\n- extend gateway route coverage for artifact-bearing delegated results\n\n## Testing\n- cargo test -p rune-gateway get_session_status_surfaces_subagent_metadata\n- cargo check\n\nRefs #658