### PR TITLE
feat(runtime): classify source priorities for routing (#418)

### DIFF
--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -13,7 +13,15 @@ use tokio::sync::{Mutex, RwLock};
 use tower::ServiceExt;
 use uuid::Uuid;
 
-use chrono::Timelike;
+use chrono::{Timelike, Utc};
+
+use std::str::FromStr;
+
+use rune_channels::{ChannelMessage, InboundEvent};
+use rune_runtime::session_loop::{
+    PRIORITY_BACKGROUND, PRIORITY_COMMS_DIRECTIVE, PRIORITY_CRON, PRIORITY_HEARTBEAT,
+    PRIORITY_USER_MESSAGE, SessionLoop,
+};
 
 use rune_config::{
     AppConfig, Capabilities, ConfiguredModel, InstanceIdentity, LaneQueueConfig,
@@ -14897,4 +14905,70 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
         json["audit"]["last_operator_note"],
         "Operator asked for a tighter review pass"
     );
+}
+fn test_inbound_message(raw_chat_id: &str) -> ChannelMessage {
+    ChannelMessage {
+        channel_id: rune_core::ChannelId::from_str("11111111-1111-1111-1111-111111111111").unwrap(),
+        raw_chat_id: raw_chat_id.to_string(),
+        sender: "tester".to_string(),
+        content: "payload".to_string(),
+        attachments: vec![],
+        timestamp: Utc::now(),
+        provider_message_id: format!("provider-{raw_chat_id}"),
+    }
+}
+
+#[tokio::test]
+async fn user_messages_outrank_heartbeat_comms_cron_and_background_work() {
+    let user = InboundEvent::Message(test_inbound_message("telegram:dm:hamza"));
+    let heartbeat = InboundEvent::Message(test_inbound_message("system:heartbeat"));
+    let comms = InboundEvent::Message(test_inbound_message("comms:directive"));
+    let cron = InboundEvent::Message(test_inbound_message("cron:daily"));
+    let reaction = InboundEvent::Reaction {
+        channel_id: rune_core::ChannelId::from_str("22222222-2222-2222-2222-222222222222").unwrap(),
+        message_id: "msg-1".to_string(),
+        emoji: "✅".to_string(),
+        user: "user-1".to_string(),
+    };
+
+    assert_eq!(SessionLoop::event_priority_for_test(&user), PRIORITY_USER_MESSAGE);
+    assert_eq!(SessionLoop::event_priority_for_test(&comms), PRIORITY_COMMS_DIRECTIVE);
+    assert_eq!(SessionLoop::event_priority_for_test(&heartbeat), PRIORITY_HEARTBEAT);
+    assert_eq!(SessionLoop::event_priority_for_test(&cron), PRIORITY_CRON);
+    assert_eq!(SessionLoop::event_priority_for_test(&reaction), PRIORITY_BACKGROUND);
+
+    assert!(SessionLoop::event_priority_for_test(&user) < SessionLoop::event_priority_for_test(&comms));
+    assert!(SessionLoop::event_priority_for_test(&comms) < SessionLoop::event_priority_for_test(&heartbeat));
+    assert!(SessionLoop::event_priority_for_test(&heartbeat) < SessionLoop::event_priority_for_test(&cron));
+    assert!(SessionLoop::event_priority_for_test(&cron) < SessionLoop::event_priority_for_test(&reaction));
+}
+
+#[test]
+fn source_priority_detects_internal_message_classes() {
+    assert_eq!(SessionLoop::source_priority_for_test("telegram:dm:hamza"), PRIORITY_USER_MESSAGE);
+    assert_eq!(SessionLoop::source_priority_for_test("COMMS:queue"), PRIORITY_COMMS_DIRECTIVE);
+    assert_eq!(SessionLoop::source_priority_for_test(" system:heartbeat "), PRIORITY_HEARTBEAT);
+    assert_eq!(SessionLoop::source_priority_for_test("cron:nightly"), PRIORITY_CRON);
+    assert_eq!(SessionLoop::source_priority_for_test("system:scheduled:heartbeat"), PRIORITY_CRON);
+}
+
+#[test]
+fn source_priority_treats_subagent_and_agent_sources_as_background_work() {
+    assert_eq!(SessionLoop::source_priority_for_test("subagent:worker-1"), PRIORITY_BACKGROUND);
+    assert_eq!(SessionLoop::source_priority_for_test(" agent:planner "), PRIORITY_BACKGROUND);
+}
+
+#[test]
+fn event_priority_treats_subagent_messages_as_background_work() {
+    let subagent = InboundEvent::Message(ChannelMessage {
+        channel_id: rune_core::ChannelId::from_str("33333333-3333-3333-3333-333333333333").unwrap(),
+        raw_chat_id: "subagent:worker-1".to_string(),
+        sender: "delegate".to_string(),
+        content: "subagent status update".to_string(),
+        attachments: vec![],
+        timestamp: Utc::now(),
+        provider_message_id: "provider-1".to_string(),
+    });
+
+    assert_eq!(SessionLoop::event_priority_for_test(&subagent), PRIORITY_BACKGROUND);
 }

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -43,9 +43,12 @@ Rune commands:
 /// Maps channel routing key → session_id.
 type SessionIndex = HashMap<String, Uuid>;
 
-type EventPriority = u8;
-const PRIORITY_USER_MESSAGE: EventPriority = 0;
-const PRIORITY_BACKGROUND: EventPriority = 4;
+pub type EventPriority = u8;
+pub const PRIORITY_USER_MESSAGE: EventPriority = 0;
+pub const PRIORITY_COMMS_DIRECTIVE: EventPriority = 1;
+pub const PRIORITY_HEARTBEAT: EventPriority = 2;
+pub const PRIORITY_CRON: EventPriority = 3;
+pub const PRIORITY_BACKGROUND: EventPriority = 4;
 
 /// The main session loop that ties channels to the runtime.
 pub struct SessionLoop {
@@ -61,6 +64,21 @@ pub struct SessionLoop {
     stt_engine: Option<Arc<RwLock<SttEngine>>>,
     file_downloader: Option<Arc<dyn TelegramFileDownloader>>,
     command_registry: Option<Arc<crate::command_registry::CommandRegistry>>,
+}
+
+fn classify_message_priority(raw_chat_id: &str) -> EventPriority {
+    let normalized = raw_chat_id.trim().to_ascii_lowercase();
+    if normalized == "system:heartbeat" {
+        PRIORITY_HEARTBEAT
+    } else if normalized.starts_with("comms:") || normalized == "system:comms" {
+        PRIORITY_COMMS_DIRECTIVE
+    } else if normalized.starts_with("cron:") || normalized.starts_with("system:scheduled") {
+        PRIORITY_CRON
+    } else if normalized.starts_with("subagent:") || normalized.starts_with("agent:") {
+        PRIORITY_BACKGROUND
+    } else {
+        PRIORITY_USER_MESSAGE
+    }
 }
 
 /// MIME types considered audio for transcription purposes.
@@ -179,7 +197,7 @@ impl SessionLoop {
 
     fn classify_event_priority(event: &InboundEvent) -> EventPriority {
         match event {
-            InboundEvent::Message(_) => PRIORITY_USER_MESSAGE,
+            InboundEvent::Message(msg) => classify_message_priority(&msg.raw_chat_id),
             InboundEvent::Reaction { .. }
             | InboundEvent::Edit { .. }
             | InboundEvent::Delete { .. }
@@ -191,6 +209,11 @@ impl SessionLoop {
     #[must_use]
     pub fn event_priority_for_test(event: &InboundEvent) -> EventPriority {
         Self::classify_event_priority(event)
+    }
+
+    #[must_use]
+    pub fn source_priority_for_test(raw_chat_id: &str) -> EventPriority {
+        classify_message_priority(raw_chat_id)
     }
 
     async fn handle_event(&self, event: InboundEvent) -> Result<(), RuntimeError> {


### PR DESCRIPTION
## Summary
- classify message priorities from raw channel source identifiers so user messages outrank comms, heartbeat, cron, and background agent traffic
- expose test-only helpers/constants for priority verification
- add regression coverage in gateway route tests for source and event priority ordering

## Testing
- cargo test -p rune-gateway source_priority -- --nocapture
- cargo test -p rune-runtime user_messages_outrank_heartbeat_comms_cron_and_background_work -- --nocapture
- cargo check