### PR TITLE
feat: add stop routing controls

### DIFF
--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -61,6 +61,11 @@ async fn abort_reason(session_id: Uuid) -> Option<String> {
     SESSION_ABORTS.lock().await.get(&session_id).cloned()
 }
 
+#[cfg(test)]
+pub(crate) async fn execute_for_abort_test(session_id: Uuid) -> Option<String> {
+    abort_reason(session_id).await
+}
+
 /// Executes a single turn: load context → prompt → model → tool loop → persist.
 ///
 /// When a `LaneQueue` is attached, each turn acquires a lane permit before

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -21,7 +21,7 @@ use rune_stt::SttEngine;
 use crate::engine::SessionEngine;
 use crate::error::RuntimeError;
 use crate::executor::TurnExecutor;
-use crate::session_metadata::{selected_model, set_selected_model};
+use crate::session_metadata::{selected_model, set_channel_source_priority, set_selected_model};
 
 /// Trait for downloading files from Telegram (or any provider using `telegram-file:` URLs).
 ///
@@ -350,7 +350,7 @@ impl SessionLoop {
         }
     }
 
-    async fn handle_event(&self, event: InboundEvent) -> Result<(), RuntimeError> {
+    pub(crate) async fn handle_event(&self, event: InboundEvent) -> Result<(), RuntimeError> {
         match event {
             InboundEvent::Message(msg) => {
                 if self.handle_command(&msg).await? {
@@ -358,9 +358,23 @@ impl SessionLoop {
                 }
 
                 let routing_key = format!("{}:{}", msg.raw_chat_id, msg.sender);
-                debug!(routing_key = %routing_key, "received inbound message");
+                let source = msg
+                    .raw_chat_id
+                    .split([':', '/'])
+                    .next()
+                    .filter(|segment| !segment.is_empty())
+                    .unwrap_or(msg.sender.as_str())
+                    .to_ascii_lowercase();
+                let source_priority = Self::classify_source_priority(&source);
+                debug!(routing_key = %routing_key, source = %source, priority = source_priority, "received inbound message");
 
                 let session = self.find_or_create_session(&routing_key).await?;
+                let metadata = set_channel_source_priority(&session.metadata, &source, source_priority);
+                if metadata != session.metadata {
+                    self.session_repo
+                        .update_metadata(session.id, metadata, chrono::Utc::now())
+                        .await?;
+                }
                 self.maybe_send_resumed_session_notice(&msg, &routing_key, &session)
                     .await;
 
@@ -545,7 +559,7 @@ impl SessionLoop {
         Ok(())
     }
 
-    async fn handle_command(
+    pub(crate) async fn handle_command(
         &self,
         msg: &rune_channels::ChannelMessage,
     ) -> Result<bool, RuntimeError> {
@@ -583,6 +597,10 @@ impl SessionLoop {
             }
             "/reset" => {
                 self.handle_reset_command(msg).await?;
+                Ok(true)
+            }
+            "/stop" => {
+                self.handle_stop_command(msg, args).await?;
                 Ok(true)
             }
             "/commands" => {
@@ -670,6 +688,39 @@ impl SessionLoop {
             )
             .await;
         }
+        Ok(())
+    }
+
+    async fn handle_stop_command(
+        &self,
+        msg: &rune_channels::ChannelMessage,
+        args: &str,
+    ) -> Result<(), RuntimeError> {
+        let routing_key = format!("{}:{}", msg.raw_chat_id, msg.sender);
+        let session = match self.find_or_create_session(&routing_key).await {
+            Ok(session) => session,
+            Err(error) => {
+                self.send_command_reply(
+                    msg,
+                    &format!("No active session to stop: {error}"),
+                )
+                .await;
+                return Ok(());
+            }
+        };
+
+        let reason = if args.trim().is_empty() {
+            format!("stop requested from channel {}", msg.raw_chat_id)
+        } else {
+            format!("stop requested from channel {}: {}", msg.raw_chat_id, args.trim())
+        };
+        crate::request_session_abort(session.id, reason.clone()).await;
+
+        self.send_command_reply(
+            msg,
+            &format!("Stopping active work for session {}. Reason: {}", session.id, reason),
+        )
+        .await;
         Ok(())
     }
 
@@ -780,7 +831,7 @@ impl SessionLoop {
         ))
     }
 
-    async fn find_or_create_session(&self, routing_key: &str) -> Result<SessionRow, RuntimeError> {
+    pub(crate) async fn find_or_create_session(&self, routing_key: &str) -> Result<SessionRow, RuntimeError> {
         // 1. Check in-memory cache
         {
             let index = self.sessions.lock().await;

--- a/crates/rune-runtime/src/session_metadata.rs
+++ b/crates/rune-runtime/src/session_metadata.rs
@@ -8,6 +8,7 @@ pub(crate) const SESSION_MODE_KEY: &str = "mode";
 pub(crate) const PROJECT_ID_KEY: &str = "project_id";
 pub(crate) const CONTEXT_TIERS_KEY: &str = "context_tiers";
 pub(crate) const CONTEXT_TOKEN_USAGE_KEY: &str = "context_token_usage";
+pub(crate) const CHANNEL_SOURCE_PRIORITY_KEY: &str = "channel_source_priority";
 
 pub(crate) fn selected_model(session: &SessionRow) -> Option<&str> {
     session
@@ -52,5 +53,17 @@ pub(crate) fn set_context_tiers(metadata: &Value, report: &ContextAssemblyReport
             "compaction_required": report.compaction_required,
         }),
     );
+    Value::Object(next)
+}
+
+
+pub(crate) fn set_channel_source_priority(metadata: &Value, source: &str, priority: u8) -> Value {
+    let mut next = metadata.as_object().cloned().unwrap_or_default();
+    let mut map = next
+        .remove(CHANNEL_SOURCE_PRIORITY_KEY)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    map.insert(source.to_string(), json!(priority));
+    next.insert(CHANNEL_SOURCE_PRIORITY_KEY.to_string(), Value::Object(map));
     Value::Object(next)
 }

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -3070,3 +3070,84 @@ async fn next_event_prefers_higher_priority_items_already_waiting() {
         other => panic!("expected message, got {other:?}"),
     }
 }
+
+
+#[tokio::test]
+async fn stop_command_registers_abort_for_active_channel_session() {
+    let h = TestHarness::new();
+    let engine = Arc::new(h.session_engine());
+    let adapter = SequenceChannelAdapter {
+        events: Arc::new(Mutex::new(Vec::new())),
+    };
+    let session_loop = crate::session_loop::SessionLoop::new(
+        engine,
+        Arc::new(h.turn_executor(
+            Arc::new(FakeModelProvider::new(vec![])),
+            Arc::new(FakeToolExecutor::new(vec![])),
+            ToolRegistry::new(),
+        )),
+        h.session_repo.clone(),
+        Box::new(adapter),
+        rune_config::AgentsConfig::default(),
+        rune_config::ModelsConfig::default(),
+    );
+
+    let routing_key = "telegram:dm:hamza:hamza";
+    let session = session_loop.find_or_create_session(routing_key).await.unwrap();
+    let stop = rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "telegram:dm:hamza".to_string(),
+        sender: "hamza".to_string(),
+        content: "/stop switch to issue #418".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "stop-1".to_string(),
+    };
+
+    assert!(session_loop.handle_command(&stop).await.unwrap());
+
+    let abort = crate::executor::execute_for_abort_test(session.id).await;
+    assert_eq!(abort.as_deref(), Some("stop requested from channel telegram:dm:hamza: switch to issue #418"));
+    crate::clear_session_abort(session.id).await;
+}
+
+#[tokio::test]
+async fn message_handling_persists_channel_source_priority_metadata() {
+    let h = TestHarness::new();
+    let engine = Arc::new(h.session_engine());
+    let adapter = SequenceChannelAdapter {
+        events: Arc::new(Mutex::new(Vec::new())),
+    };
+    let session_loop = crate::session_loop::SessionLoop::new(
+        engine,
+        Arc::new(h.turn_executor(
+            Arc::new(FakeModelProvider::new(vec![FakeModelProvider::text_response("done")])),
+            Arc::new(FakeToolExecutor::new(vec![])),
+            ToolRegistry::new(),
+        )),
+        h.session_repo.clone(),
+        Box::new(adapter),
+        rune_config::AgentsConfig::default(),
+        rune_config::ModelsConfig::default(),
+    );
+
+    let event = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "telegram:dm:hamza".to_string(),
+        sender: "hamza".to_string(),
+        content: "hello".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-meta-1".to_string(),
+    });
+
+    session_loop.handle_event(event).await.unwrap();
+
+    let session = h
+        .session_repo
+        .find_by_channel_ref("telegram:dm:hamza:hamza")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.metadata["channel_source_priority"]["telegram"], serde_json::json!(crate::session_loop::PRIORITY_USER_MESSAGE));
+}


### PR DESCRIPTION
## Summary
- add /stop command handling that registers an abort reason for the active channel session
- persist detected source priority metadata for inbound channel messages
- cover stop command and channel priority metadata persistence with runtime tests

## Validation
- cargo check
- cargo test -p rune-runtime stop_command_registers_abort_for_active_channel_session -- --nocapture *(timed out after 1200s in sandbox)*
- cargo test -p rune-runtime message_handling_persists_channel_source_priority_metadata -- --nocapture *(timed out after 1200s in sandbox)*
