### PR TITLE
fix(runtime): preserve trigger kind lane routing

### DIFF
--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use rune_channels::{ChannelAdapter, InboundEvent, OutboundAction};
 use rune_config::{AgentsConfig, ModelsConfig};
-use rune_core::SessionKind;
+use rune_core::{SessionKind, TriggerKind};
 use rune_store::models::SessionRow;
 use rune_store::repos::SessionRepo;
 use rune_stt::SttEngine;
@@ -255,12 +255,31 @@ impl SessionLoop {
 
     fn classify_event_priority(event: &InboundEvent) -> EventPriority {
         match event {
-            InboundEvent::Message(msg) => classify_message_priority(&msg.raw_chat_id, &msg.sender, &msg.content),
+            InboundEvent::Message(msg) => {
+                classify_message_priority(&msg.raw_chat_id, &msg.sender, &msg.content)
+            }
             InboundEvent::Reaction { .. }
             | InboundEvent::Edit { .. }
             | InboundEvent::Delete { .. }
             | InboundEvent::MemberJoin { .. }
             | InboundEvent::MemberLeave { .. } => PRIORITY_BACKGROUND,
+        }
+    }
+
+    fn trigger_kind_for_event(event: &InboundEvent) -> TriggerKind {
+        match event {
+            InboundEvent::Message(msg) => {
+                match Self::classify_event_priority(&InboundEvent::Message(msg.clone())) {
+                    PRIORITY_IMMEDIATE => TriggerKind::Heartbeat,
+                    PRIORITY_CRON => TriggerKind::CronJob,
+                    _ => TriggerKind::UserMessage,
+                }
+            }
+            InboundEvent::Reaction { .. }
+            | InboundEvent::Edit { .. }
+            | InboundEvent::Delete { .. }
+            | InboundEvent::MemberJoin { .. }
+            | InboundEvent::MemberLeave { .. } => TriggerKind::SystemWake,
         }
     }
 
@@ -286,6 +305,11 @@ impl SessionLoop {
     #[must_use]
     pub fn source_priority_for_test(source: &str) -> EventPriority {
         Self::classify_source_priority(source)
+    }
+
+    #[must_use]
+    pub fn trigger_kind_for_test(event: &InboundEvent) -> TriggerKind {
+        Self::trigger_kind_for_event(event)
     }
 
     async fn enqueue_event(&self, event: InboundEvent) {
@@ -451,14 +475,16 @@ impl SessionLoop {
                     Some(tokio::spawn(drain_chunks(chunk_rx)))
                 };
 
+                let trigger_kind = Self::trigger_kind_for_event(&InboundEvent::Message(msg.clone()));
                 let result = self
                     .turn_executor
-                    .execute_streaming_with_attachments(
+                    .execute_triggered(
                         session.id,
                         &final_text,
                         msg.attachments.clone(),
                         None,
-                        chunk_tx,
+                        trigger_kind,
+                        Some(chunk_tx),
                     )
                     .await;
 

--- a/crates/rune-runtime/src/tests.rs
+++ b/crates/rune-runtime/src/tests.rs
@@ -2956,6 +2956,50 @@ fn session_loop_prioritizes_user_messages_above_background_events() {
 }
 
 #[test]
+fn session_loop_maps_event_priority_to_trigger_kind() {
+    let heartbeat = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "heartbeat:agent".to_string(),
+        sender: "health".to_string(),
+        content: "ok".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-heartbeat".to_string(),
+    });
+    let cron = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "cron:daily".to_string(),
+        sender: "scheduler".to_string(),
+        content: "cron: run".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-cron".to_string(),
+    });
+    let user = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
+        channel_id: rune_core::ChannelId::new(),
+        raw_chat_id: "telegram:dm:hamza".to_string(),
+        sender: "hamza".to_string(),
+        content: "urgent".to_string(),
+        attachments: vec![],
+        timestamp: chrono::Utc::now(),
+        provider_message_id: "msg-user".to_string(),
+    });
+
+    assert_eq!(
+        crate::session_loop::SessionLoop::trigger_kind_for_test(&heartbeat),
+        rune_core::TriggerKind::Heartbeat
+    );
+    assert_eq!(
+        crate::session_loop::SessionLoop::trigger_kind_for_test(&cron),
+        rune_core::TriggerKind::CronJob
+    );
+    assert_eq!(
+        crate::session_loop::SessionLoop::trigger_kind_for_test(&user),
+        rune_core::TriggerKind::UserMessage
+    );
+}
+
+#[test]
 fn session_loop_assigns_comms_directives_between_user_and_cron_priority() {
     let directive = rune_channels::InboundEvent::Message(rune_channels::ChannelMessage {
         channel_id: rune_core::ChannelId::new(),


### PR DESCRIPTION
## Summary
- preserve inbound trigger kind classification when channel messages execute turns
- route heartbeat and cron-originated messages through execute_triggered so lane selection matches the priority queue
- add regression coverage for event priority -> trigger kind mapping

## Testing
- cargo test -p rune-runtime session_loop_ -- --nocapture
- cargo check

Closes #418