### PR TITLE
feat: expose project cache usage metrics

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -41,7 +41,9 @@ use crate::ms365::{
     UpdateTodoTaskRequest, UserProfile, UserSummary,
 };
 use crate::pairing::{DeviceRole, PairingError, PairingRequest, StoredPairedDevice};
-use crate::state::{AppState, SessionEvent, TokenMetricsSnapshot, TokenMetricsStore};
+use crate::state::{
+    AppState, ProjectTokenMetricsSnapshot, SessionEvent, TokenMetricsSnapshot, TokenMetricsStore,
+};
 use crate::ws::active_ws_connections;
 use crate::{SupervisorDeps, run_job_lifecycle};
 
@@ -5159,9 +5161,31 @@ pub struct UsageProjectSummaryResponse {
 }
 
 #[derive(Serialize)]
+pub struct UsageProjectCacheSummaryResponse {
+    pub project_id: String,
+    pub total_input_tokens: u64,
+    pub cached_tokens: u64,
+    pub uncached_tokens: u64,
+    pub cache_hit_ratio_percent: f64,
+}
+
+impl From<ProjectTokenMetricsSnapshot> for UsageProjectCacheSummaryResponse {
+    fn from(value: ProjectTokenMetricsSnapshot) -> Self {
+        Self {
+            project_id: value.project_id,
+            total_input_tokens: value.total_input_tokens,
+            cached_tokens: value.cached_tokens,
+            uncached_tokens: value.uncached_tokens,
+            cache_hit_ratio_percent: value.cache_hit_ratio_percent,
+        }
+    }
+}
+
+#[derive(Serialize)]
 pub struct UsageSummaryResponse {
     pub entries: Vec<UsageEntryResponse>,
     pub projects: Vec<UsageProjectSummaryResponse>,
+    pub project_cache: Vec<UsageProjectCacheSummaryResponse>,
     pub total_prompt_tokens: u64,
     pub total_completion_tokens: u64,
     pub total_tokens: u64,
@@ -5265,6 +5289,13 @@ pub async fn get_dashboard_usage(
         .list_usage(from, params.to, limit)
         .await
         .map_err(|e| GatewayError::Internal(e.to_string()))?;
+    let project_cache = state
+        .token_metrics
+        .project_snapshot()
+        .await
+        .into_iter()
+        .map(UsageProjectCacheSummaryResponse::from)
+        .collect::<Vec<_>>();
 
     let sessions = state
         .session_repo
@@ -5389,6 +5420,7 @@ pub async fn get_dashboard_usage(
     Ok(Json(UsageSummaryResponse {
         entries,
         projects,
+        project_cache,
         total_prompt_tokens,
         total_completion_tokens,
         total_tokens: total_prompt_tokens + total_completion_tokens,

--- a/crates/rune-gateway/src/state.rs
+++ b/crates/rune-gateway/src/state.rs
@@ -68,6 +68,15 @@ pub struct TokenMetricsSnapshot {
     pub cache_hit_ratio_percent: f64,
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ProjectTokenMetricsSnapshot {
+    pub project_id: String,
+    pub total_input_tokens: u64,
+    pub cached_tokens: u64,
+    pub uncached_tokens: u64,
+    pub cache_hit_ratio_percent: f64,
+}
+
 #[derive(Clone, Debug, Default)]
 struct TokenMetricsEntry {
     total_input_tokens: u64,
@@ -76,8 +85,16 @@ struct TokenMetricsEntry {
 }
 
 #[derive(Clone, Debug, Default)]
+struct ProjectTokenMetricsEntry {
+    total_input_tokens: u64,
+    cached_tokens: u64,
+    uncached_tokens: u64,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct TokenMetricsStore {
     inner: Arc<Mutex<HashMap<(String, String), TokenMetricsEntry>>>,
+    project_inner: Arc<Mutex<HashMap<String, ProjectTokenMetricsEntry>>>,
 }
 
 impl TokenMetricsStore {
@@ -89,30 +106,43 @@ impl TokenMetricsStore {
         &self,
         provider: impl Into<String>,
         model: impl Into<String>,
+        project_id: Option<&str>,
         total_input_tokens: u32,
-        cached_tokens: Option<u32>,
-        uncached_tokens: Option<u32>,
+        cached_tokens: u32,
     ) {
         let provider = provider.into();
         let model = model.into();
-        let mut inner = self.inner.lock().await;
-        let entry = inner.entry((provider, model)).or_default();
-
         let total_input_tokens = u64::from(total_input_tokens);
-        let cached_tokens = u64::from(cached_tokens.unwrap_or(0));
-        let uncached_tokens = uncached_tokens
-            .map(u64::from)
-            .unwrap_or_else(|| total_input_tokens.saturating_sub(cached_tokens));
+        let cached_tokens = u64::from(cached_tokens);
+        let uncached_tokens = total_input_tokens.saturating_sub(cached_tokens);
 
-        entry.total_input_tokens = entry.total_input_tokens.saturating_add(total_input_tokens);
-        entry.cached_tokens = entry.cached_tokens.saturating_add(cached_tokens);
-        entry.uncached_tokens = entry.uncached_tokens.saturating_add(uncached_tokens);
+        {
+            let mut inner = self.inner.lock().await;
+            let entry = inner.entry((provider, model)).or_default();
+            entry.total_input_tokens = entry.total_input_tokens.saturating_add(total_input_tokens);
+            entry.cached_tokens = entry.cached_tokens.saturating_add(cached_tokens);
+            entry.uncached_tokens = entry.uncached_tokens.saturating_add(uncached_tokens);
+        }
+
+        if let Some(project_id) = project_id.filter(|value| !value.is_empty()) {
+            let mut inner = self.project_inner.lock().await;
+            let entry = inner.entry(project_id.to_string()).or_default();
+            entry.total_input_tokens = entry.total_input_tokens.saturating_add(total_input_tokens);
+            entry.cached_tokens = entry.cached_tokens.saturating_add(cached_tokens);
+            entry.uncached_tokens = entry.uncached_tokens.saturating_add(uncached_tokens);
+        }
     }
 
     pub async fn snapshot(&self) -> Vec<TokenMetricsSnapshot> {
         let inner = self.inner.lock().await;
         Self::rows_from_inner(&inner)
     }
+
+    pub async fn project_snapshot(&self) -> Vec<ProjectTokenMetricsSnapshot> {
+        let inner = self.project_inner.lock().await;
+        Self::project_rows_from_inner(&inner)
+    }
+
     fn rows_from_inner(
         inner: &HashMap<(String, String), TokenMetricsEntry>,
     ) -> Vec<TokenMetricsSnapshot> {
@@ -139,6 +169,30 @@ impl TokenMetricsStore {
                 .cmp(&b.provider)
                 .then_with(|| a.model.cmp(&b.model))
         });
+        rows
+    }
+
+    fn project_rows_from_inner(
+        inner: &HashMap<String, ProjectTokenMetricsEntry>,
+    ) -> Vec<ProjectTokenMetricsSnapshot> {
+        let mut rows = inner
+            .iter()
+            .map(|(project_id, entry)| {
+                let ratio = if entry.total_input_tokens == 0 {
+                    0.0
+                } else {
+                    (entry.cached_tokens as f64 / entry.total_input_tokens as f64) * 100.0
+                };
+                ProjectTokenMetricsSnapshot {
+                    project_id: project_id.clone(),
+                    total_input_tokens: entry.total_input_tokens,
+                    cached_tokens: entry.cached_tokens,
+                    uncached_tokens: entry.uncached_tokens,
+                    cache_hit_ratio_percent: ratio,
+                }
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|a, b| a.project_id.cmp(&b.project_id));
         rows
     }
 }

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1566,9 +1566,9 @@ fn build_test_app_parts_with_ms365_services(
                         .record(
                             provider,
                             model,
+                            None,
                             usage.prompt_tokens,
-                            usage.cached_prompt_tokens,
-                            usage.uncached_prompt_tokens,
+                            usage.cached_prompt_tokens.unwrap_or(0),
                         )
                         .await;
                 }
@@ -8862,6 +8862,133 @@ async fn get_dashboard_usage_reports_cached_tokens_and_cache_hit_ratio() {
     assert_eq!(project["prompt_tokens"], 1500);
     assert_eq!(project["completion_tokens"], 700);
     assert_eq!(project["request_count"], 2);
+
+    assert_eq!(json["project_cache"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn dashboard_usage_includes_project_cache_metrics() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+    let token_metrics = TokenMetricsStore::new();
+    token_metrics
+        .record("openai", "gpt-4.1", Some("phoenix"), 1_000, 400)
+        .await;
+    token_metrics
+        .record("anthropic", "claude-sonnet-4", Some("phoenix"), 500, 100)
+        .await;
+    token_metrics
+        .record("openai", "gpt-4.1", Some("festivity"), 600, 300)
+        .await;
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo.clone() as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo.clone() as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics,
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/dashboard/usage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let project_cache = json["project_cache"].as_array().unwrap();
+    assert_eq!(project_cache.len(), 2);
+
+    let festivity = project_cache
+        .iter()
+        .find(|entry| entry["project_id"] == "festivity")
+        .unwrap();
+    assert_eq!(festivity["total_input_tokens"], 600);
+    assert_eq!(festivity["cached_tokens"], 300);
+    assert_eq!(festivity["uncached_tokens"], 300);
+    assert_eq!(festivity["cache_hit_ratio_percent"], 50.0);
+
+    let phoenix = project_cache
+        .iter()
+        .find(|entry| entry["project_id"] == "phoenix")
+        .unwrap();
+    assert_eq!(phoenix["total_input_tokens"], 1500);
+    assert_eq!(phoenix["cached_tokens"], 500);
+    assert_eq!(phoenix["uncached_tokens"], 1000);
+    assert_eq!(phoenix["cache_hit_ratio_percent"], serde_json::json!((500.0 / 1500.0) * 100.0));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add project-level cache token snapshots to gateway usage responses
- track cache token metrics by project in TokenMetricsStore
- cover project cache aggregation in dashboard usage tests

## Validation
- cargo check
- cargo test -p rune-gateway dashboard_usage_includes_project_cache_metrics -- --nocapture
- cargo test -p rune-gateway get_dashboard_usage_reports_cached_tokens_and_cache_hit_ratio -- --nocapture

Closes #419