### PR TITLE
feat: federated memory privacy controls (#422)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -6290,6 +6290,10 @@ pub struct MemorySearchQuery {
     pub q: Option<String>,
     #[serde(rename = "limit")]
     pub _limit: Option<usize>,
+    #[serde(default)]
+    pub include_remote: Option<bool>,
+    #[serde(default)]
+    pub include_private: Option<bool>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -6349,10 +6353,17 @@ struct RemoteMemorySearchResponse {
     pub message: String,
 }
 
+fn memory_result_is_private(result: &MemorySearchResult) -> bool {
+    let path = result.file_path.to_ascii_lowercase();
+    path.starts_with("memory/private/") || path.contains("/private/")
+}
+
 async fn federated_memory_search(
     state: &AppState,
     query: &str,
     limit: usize,
+    include_remote: bool,
+    include_private: bool,
     local_results: Vec<MemorySearchResult>,
 ) -> (Vec<MemorySearchResult>, usize) {
     let peers = {
@@ -6360,8 +6371,16 @@ async fn federated_memory_search(
         config.instance.peers.clone()
     };
 
-    if peers.is_empty() {
-        return (local_results, 0);
+    if !include_remote || peers.is_empty() {
+        let filtered = if include_private {
+            local_results
+        } else {
+            local_results
+                .into_iter()
+                .filter(|result| !memory_result_is_private(result))
+                .collect()
+        };
+        return (filtered, 0);
     }
 
     let client = match reqwest::Client::builder()
@@ -6381,8 +6400,9 @@ async fn federated_memory_search(
             .trim_end_matches("/api/v1/instance/health")
             .trim_end_matches('/');
         let endpoint = format!(
-            "{base}/api/memory/search?q={}&limit={limit}",
+            "{base}/api/memory/search?q={}&limit={limit}&include_remote=false&include_private={}",
             urlencoding::encode(query),
+            include_private,
         );
 
         let response = match client.get(&endpoint).send().await {
@@ -6423,8 +6443,15 @@ async fn federated_memory_search(
         merged.append(&mut peer_results);
     }
 
-    let local_count = local_results.len();
-    let mut combined = local_results;
+    let mut combined = if include_private {
+        local_results
+    } else {
+        local_results
+            .into_iter()
+            .filter(|result| !memory_result_is_private(result))
+            .collect()
+    };
+    let local_count = combined.len();
     combined.extend(merged);
     combined.truncate(limit.max(local_count));
     (combined, remote_pending)
@@ -6465,6 +6492,8 @@ pub async fn memory_search(
     }
 
     let limit = query._limit.unwrap_or(10).clamp(1, 50);
+    let include_remote = query.include_remote.unwrap_or(true);
+    let include_private = query.include_private.unwrap_or(false);
     let workspace_root = {
         let config = state.config.read().await;
         config
@@ -6490,8 +6519,16 @@ pub async fn memory_search(
         .await
         .map_err(|error| GatewayError::Internal(error.to_string()))?;
     let local_results = parse_memory_search_output(&result.output);
-    let local_count = local_results.len();
-    let (results, remote_pending) = federated_memory_search(&state, &q, limit, local_results).await;
+    let (results, remote_pending) = federated_memory_search(
+        &state,
+        &q,
+        limit,
+        include_remote,
+        include_private,
+        local_results,
+    )
+    .await;
+    let local_count = results.iter().filter(|result| !result.remote).count();
     let remote_results = results.iter().filter(|result| result.remote).count();
     let message = if results.is_empty() {
         format!("No results found for query: {q}")

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -8988,7 +8988,10 @@ async fn dashboard_usage_includes_project_cache_metrics() {
     assert_eq!(phoenix["total_input_tokens"], 1500);
     assert_eq!(phoenix["cached_tokens"], 500);
     assert_eq!(phoenix["uncached_tokens"], 1000);
-    assert_eq!(phoenix["cache_hit_ratio_percent"], serde_json::json!((500.0 / 1500.0) * 100.0));
+    assert_eq!(
+        phoenix["cache_hit_ratio_percent"],
+        serde_json::json!((500.0 / 1500.0) * 100.0)
+    );
 }
 
 #[tokio::test]
@@ -11652,6 +11655,148 @@ Met Hamza at Horizon Tech
     assert_eq!(body["remote_pending"], 1);
     assert_eq!(body["results"].as_array().unwrap().len(), 1);
     assert_eq!(body["results"][0]["remote"], false);
+}
+
+#[tokio::test]
+async fn memory_search_route_excludes_private_results_by_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("MEMORY.md"),
+        "# Memory
+Met Hamza at Horizon Tech
+",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("memory/private")).unwrap();
+    std::fs::write(
+        tmp.path().join("memory/private/secret.md"),
+        "# Private
+borrow checker patterns from private notes
+",
+    )
+    .unwrap();
+
+    let mut config = AppConfig::default();
+    config.agents.defaults.workspace = Some(tmp.path().display().to_string());
+
+    let app = build_test_app_with_config(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/memory/search?q=borrow&limit=5")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let results = body["results"].as_array().unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn memory_search_route_can_include_private_results_explicitly() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("MEMORY.md"),
+        "# Memory
+Met Hamza at Horizon Tech
+",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("memory/private")).unwrap();
+    std::fs::write(
+        tmp.path().join("memory/private/secret.md"),
+        "# Private
+borrow checker patterns from private notes
+",
+    )
+    .unwrap();
+
+    let mut config = AppConfig::default();
+    config.agents.defaults.workspace = Some(tmp.path().display().to_string());
+
+    let app = build_test_app_with_config(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/memory/search?q=borrow&limit=5&include_private=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["file_path"], "memory/private/secret.md");
+}
+
+#[tokio::test]
+async fn memory_search_route_disables_remote_fanout_when_requested() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("MEMORY.md"),
+        "# Memory
+Met Hamza at Horizon Tech
+",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("memory")).unwrap();
+
+    let peer_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let payload = serde_json::json!({
+            "query": "Hamza",
+            "results": [
+                {
+                    "source": "memory/2026-03-27.md#4",
+                    "file_path": "memory/2026-03-27.md",
+                    "line": 4,
+                    "snippet": "Learned shared borrow checker pattern from remote peer",
+                    "instance_id": "peer-a",
+                    "instance_name": "Peer A",
+                    "remote": true
+                }
+            ],
+            "message": "Found 1 memory result(s)"
+        });
+        let app = axum::Router::new().route(
+            "/api/memory/search",
+            axum::routing::get(move || {
+                let payload = payload.clone();
+                async move { axum::Json(payload) }
+            }),
+        );
+        axum::serve(peer_listener, app).await.unwrap();
+    });
+
+    let mut config = AppConfig::default();
+    config.agents.defaults.workspace = Some(tmp.path().display().to_string());
+    config.instance.peers = vec![rune_config::PeerConfig {
+        id: "peer-a".to_string(),
+        health_url: format!("http://{peer_addr}/api/v1/instance/health"),
+    }];
+
+    let app = build_test_app_with_config(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/memory/search?q=Hamza&limit=5&include_remote=false")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["local_results"], 1);
+    assert_eq!(body["remote_results"], 0);
+    assert_eq!(body["remote_pending"], 0);
+    assert_eq!(body["results"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/rune-tools/src/memory_tool.rs
+++ b/crates/rune-tools/src/memory_tool.rs
@@ -238,11 +238,16 @@ impl MemoryToolExecutor {
 
         let memory_dir = self.workspace_root.join("memory");
         if memory_dir.is_dir() {
-            if let Ok(mut entries) = tokio::fs::read_dir(&memory_dir).await {
-                while let Ok(Some(entry)) = entries.next_entry().await {
-                    let path = entry.path();
-                    if path.extension().is_some_and(|e| e == "md") {
-                        files.push(path);
+            let mut stack = vec![memory_dir];
+            while let Some(dir) = stack.pop() {
+                if let Ok(mut entries) = tokio::fs::read_dir(&dir).await {
+                    while let Ok(Some(entry)) = entries.next_entry().await {
+                        let path = entry.path();
+                        if path.is_dir() {
+                            stack.push(path);
+                        } else if path.extension().is_some_and(|e| e == "md") {
+                            files.push(path);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add include_remote/include_private controls to gateway memory search
- prevent recursive remote fanout and exclude private memory paths from federation by default
- make local memory search recurse into nested memory/ subdirectories and cover the behavior with tests

## Testing
- cargo test -p rune-gateway memory_search_route_ -- --nocapture
- cargo test -p rune-tools memory_search -- --nocapture
- cargo check