### PR TITLE
docs(memory-bank): clarify current shipped surface (#755)

### DIFF
--- a/docs/reference/memory-bank-current-state.md
+++ b/docs/reference/memory-bank-current-state.md
@@ -1,0 +1,48 @@
+# Memory Bank: current shipped surface
+
+Status: current implementation reference.
+
+This document describes the Memory Bank functionality that is actually shipped in Rune today.
+It exists to prevent confusion with broader planned Memory Bank work described in the Phase 25 spec.
+
+## Current implementation
+
+Rune currently exposes two Memory Bank tools in `crates/rune-tools/src/memory_tool.rs`:
+
+- `memory_bank_list`
+- `memory_bank_get`
+
+Current behavior:
+
+- data source is the workspace `memory-bank/` directory
+- only Markdown files are discoverable/readable
+- `memory_bank_list` lists Markdown documents under `memory-bank/`
+- `memory_bank_get` reads a specific Markdown file under `memory-bank/`
+- path traversal is explicitly rejected
+
+## Not yet implemented from the Phase 25 spec
+
+The Phase 25 specification in `docs/specs/phases-25-27.md` describes a larger future subsystem that is not fully shipped today, including:
+
+- `.rune/knowledge/` as the canonical storage location
+- a unified `memory_bank` tool with read/update/search operations
+- persistence via `knowledge_docs` store models and migrations
+- staleness detection/reporting
+- `/onboard` project briefing generation
+- automatic memory-bank context injection from that subsystem
+
+Treat that Phase 25 document as the target design, not as proof of current parity.
+
+## Contributor guidance
+
+When reasoning about current behavior, use the implementation in:
+
+- `crates/rune-tools/src/memory_tool.rs`
+- tool registration in `crates/rune-tools/src/stubs.rs`
+- related tests in `crates/rune-tools/src/tests.rs`
+
+When planning future work, use the Phase 25 spec as the intended end state.
+
+## Source-of-truth rule
+
+If implementation and planning docs diverge, current shipped behavior is defined by the code and tests, not by the future-phase design doc.

--- a/docs/specs/phases-25-27.md
+++ b/docs/specs/phases-25-27.md
@@ -3,6 +3,7 @@
 > Generated 2026-03-15. Authoritative reference for implementing phases 25 through 27.
 > Every type, endpoint, wire example, error case, and acceptance criterion is defined
 > here so that implementation can proceed without guessing.
+> Note: this file is the target implementation spec. For the currently shipped Memory Bank surface, see `docs/reference/memory-bank-current-state.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a reference doc describing the Memory Bank surface actually shipped today
- clarify that the Phase 25 document is a target implementation spec, not proof of current parity
- give contributors explicit source-of-truth guidance for current behavior

## Verification
- cargo test -p rune-tools memory_bank -- --nocapture
- cargo check
