### PR TITLE
feat: surface subagent result summaries in session tree

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2817,8 +2817,11 @@ pub async fn get_session_status(
     }))
 }
 
-
-pub(crate) fn session_status_reason(status: &str, metadata: &serde_json::Value, approval_mode: &str) -> Option<String> {
+pub(crate) fn session_status_reason(
+    status: &str,
+    metadata: &serde_json::Value,
+    approval_mode: &str,
+) -> Option<String> {
     match status {
         "waiting_for_approval" => Some(format!(
             "blocked on operator approval ({approval_mode}); resume after an approval decision is recorded"
@@ -2836,7 +2839,10 @@ pub(crate) fn session_status_reason(status: &str, metadata: &serde_json::Value, 
     }
 }
 
-pub(crate) fn session_next_task_reason(status: &str, metadata: &serde_json::Value) -> Option<String> {
+pub(crate) fn session_next_task_reason(
+    status: &str,
+    metadata: &serde_json::Value,
+) -> Option<String> {
     let lifecycle = metadata_string(metadata, "subagent_lifecycle");
     let operator_note = metadata_string(metadata, "subagent_last_note");
 
@@ -2925,6 +2931,7 @@ pub struct SessionTreeNode {
     pub subagent_status_updated_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subagent_last_note: Option<String>,
+    pub latest_subagent_result: Option<ParentSubagentResultSummary>,
     pub created_at: String,
     pub turn_count: u32,
     pub children: Vec<SessionTreeNode>,
@@ -2988,15 +2995,15 @@ pub async fn get_session_tree(
         row: &rune_store::models::SessionRow,
         children_map: &std::collections::HashMap<Uuid, Vec<&rune_store::models::SessionRow>>,
         turn_counts: &std::collections::HashMap<Uuid, u32>,
+        latest_results: &std::collections::HashMap<Uuid, ParentSubagentResultSummary>,
     ) -> SessionTreeNode {
-        let children = children_map
-            .get(&row.id)
-            .map(|kids| {
-                kids.iter()
-                    .map(|child| build_node(child, children_map, turn_counts))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let mut children = Vec::new();
+        if let Some(kids) = children_map.get(&row.id) {
+            for child in kids {
+                children.push(build_node(child, children_map, turn_counts, latest_results));
+            }
+        }
+        let latest_subagent_result = latest_results.get(&row.id).cloned();
         let orchestration_status = metadata_string(&row.metadata, "orchestration_status")
             .or_else(|| metadata_string(&row.metadata, "subagent_lifecycle"));
         let delegation_roles = row
@@ -3042,13 +3049,31 @@ pub async fn get_session_tree(
                 "subagent_status_updated_at",
             ),
             subagent_last_note: metadata_string(&row.metadata, "subagent_last_note"),
+            latest_subagent_result,
             created_at: row.created_at.to_rfc3339(),
             turn_count: turn_counts.get(&row.id).copied().unwrap_or(0),
             children,
         }
     }
 
-    let tree = build_node(&root, &children_map, &turn_counts);
+    let mut latest_results = std::collections::HashMap::new();
+    for sid in &subtree_ids {
+        if let Some(row) = all_rows
+            .iter()
+            .find(|row| &row.id == sid && row.kind == "subagent")
+        {
+            let transcript_items = state
+                .transcript_repo
+                .list_by_session(row.id)
+                .await
+                .map_err(|e| GatewayError::Internal(e.to_string()))?;
+            if let Some(summary) = latest_subagent_result(&transcript_items) {
+                latest_results.insert(row.id, summary);
+            }
+        }
+    }
+
+    let tree = build_node(&root, &children_map, &turn_counts, &latest_results);
     Ok(Json(tree))
 }
 
@@ -3357,7 +3382,12 @@ pub async fn agent_kill(
     let current_status = session
         .status
         .parse::<rune_core::SessionStatus>()
-        .map_err(|_| GatewayError::Internal(format!("invalid persisted session status: {}", session.status)))?;
+        .map_err(|_| {
+            GatewayError::Internal(format!(
+                "invalid persisted session status: {}",
+                session.status
+            ))
+        })?;
     current_status
         .transition(rune_core::SessionStatus::Cancelled)
         .map_err(|e| GatewayError::BadRequest(e.to_string()))?;

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -11169,10 +11169,12 @@ async fn agent_kill_rejects_invalid_terminal_transition() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let json = body_json(response).await;
     assert_eq!(json["code"], "bad_request");
-    assert!(json["message"]
-        .as_str()
-        .unwrap()
-        .contains("invalid session transition"));
+    assert!(
+        json["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid session transition")
+    );
 
     let session = session_repo.find_by_id(agent_id).await.unwrap();
     assert_eq!(session.status, "completed");
@@ -15086,6 +15088,30 @@ async fn get_session_tree_surfaces_subagent_audit_metadata() {
         })
         .await
         .unwrap();
+    transcript_repo
+        .append(NewTranscriptItem {
+            id: Uuid::now_v7(),
+            session_id: child_id,
+            turn_id: None,
+            seq: 1,
+            kind: "subagent_result".into(),
+            payload: serde_json::json!({
+                "session_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "summary": "Delegated review completed with reroute notes",
+                "artifacts": [
+                    {
+                        "name": "handoff.md",
+                        "kind": "markdown",
+                        "uri": "memory://subagents/cccccccc-cccc-cccc-cccc-cccccccccccc/handoff.md",
+                        "content_type": "text/markdown",
+                        "description": "Reroute summary for the parent operator"
+                    }
+                ]
+            }),
+            created_at: now + chrono::TimeDelta::milliseconds(1),
+        })
+        .await
+        .unwrap();
 
     let state = AppState {
         config: Arc::new(RwLock::new(AppConfig::default())),
@@ -15161,8 +15187,20 @@ async fn get_session_tree_surfaces_subagent_audit_metadata() {
     assert_eq!(child["subagent_runtime_attached"], false);
     assert_eq!(child["subagent_status_updated_at"], "2026-03-29T12:00:00Z");
     assert_eq!(
-        child["subagent_last_note"],
-        "Review result routing before resuming"
+        child["latest_subagent_result"],
+        serde_json::json!({
+            "session_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "summary": "Delegated review completed with reroute notes",
+            "artifacts": [
+                {
+                    "name": "handoff.md",
+                    "kind": "markdown",
+                    "uri": "memory://subagents/cccccccc-cccc-cccc-cccc-cccccccccccc/handoff.md",
+                    "content_type": "text/markdown",
+                    "description": "Reroute summary for the parent operator"
+                }
+            ]
+        })
     );
 }
 
@@ -16019,7 +16057,10 @@ async fn session_status_route_surfaces_next_task_reason_for_preempted_work() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = body_json(response).await;
-    assert_eq!(json["next_task_reason"], "higher-priority operator request took over");
+    assert_eq!(
+        json["next_task_reason"],
+        "higher-priority operator request took over"
+    );
 }
 
 #[tokio::test]
@@ -16140,7 +16181,16 @@ async fn ws_rpc_session_status_surfaces_next_task_reason_and_resume_fields() {
         .await
         .unwrap();
 
-    assert_eq!(result["status_reason"], "waiting for delegated work to progress (queued)");
-    assert_eq!(result["next_task_reason"], "next action follows delegated session lifecycle: queued");
-    assert_eq!(result["resume_hint"], "check child session status; current delegated lifecycle is queued");
+    assert_eq!(
+        result["status_reason"],
+        "waiting for delegated work to progress (queued)"
+    );
+    assert_eq!(
+        result["next_task_reason"],
+        "next action follows delegated session lifecycle: queued"
+    );
+    assert_eq!(
+        result["resume_hint"],
+        "check child session status; current delegated lifecycle is queued"
+    );
 }


### PR DESCRIPTION
## Summary
- expose the latest delegated `subagent_result` summary and artifacts from session tree nodes
- derive the newest child result during tree assembly so parent inspection does not need extra transcript polling
- cover the delegated result-routing visibility in route tests

## Testing
- cargo test -p rune-gateway --test route_tests get_session_tree_surfaces_subagent_audit_metadata -- --nocapture
- cargo check

Closes #658