### PR TITLE
feat(gateway): timestamp latest subagent results

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2077,6 +2077,11 @@ pub async fn cron_add(
     let next_run_at = compute_initial_next_run(&schedule);
     let mut job = Job {
         id,
+        max_retries: None,
+        retry_count: 0,
+        suppression_reason: None,
+        suppressed_at: None,
+        last_error: None,
         name: body.name,
         schedule,
         payload,
@@ -2127,6 +2132,11 @@ pub async fn cron_update(
 
     let update = JobUpdate {
         name: body.name,
+        max_retries: None,
+        retry_count: None,
+        suppression_reason: None,
+        suppressed_at: None,
+        last_error: None,
         enabled: body.enabled,
         schedule: new_schedule,
         payload: new_payload,
@@ -2552,6 +2562,7 @@ pub struct SessionAuditSummary {
 pub struct ParentSubagentResultSummary {
     pub session_id: String,
     pub summary: String,
+    pub recorded_at: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub artifacts: Vec<DelegationArtifactResponse>,
 }
@@ -3750,6 +3761,7 @@ fn latest_subagent_result(
         Some(ParentSubagentResultSummary {
             session_id,
             summary,
+            recorded_at: item.created_at.to_rfc3339(),
             artifacts,
         })
     })

--- a/crates/rune-gateway/src/supervisor.rs
+++ b/crates/rune-gateway/src/supervisor.rs
@@ -874,6 +874,11 @@ mod tests {
     fn make_test_job(delivery_mode: SchedulerDeliveryMode, webhook_url: Option<String>) -> Job {
         Job {
             id: JobId::new(),
+            max_retries: None,
+            retry_count: 0,
+            suppression_reason: None,
+            suppressed_at: None,
+            last_error: None,
             name: Some("test-job".into()),
             schedule: Schedule::Every {
                 every_ms: 60_000,

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -2944,6 +2944,11 @@ async fn ws_rpc_cron_list_and_get_surface_delivery_mode() {
     let job_id = scheduler
         .add_job(rune_runtime::scheduler::Job {
             id: rune_core::JobId::new(),
+            max_retries: None,
+            retry_count: 0,
+            suppression_reason: None,
+            suppressed_at: None,
+            last_error: None,
             name: Some("daily-check".into()),
             schedule: rune_runtime::scheduler::Schedule::Cron {
                 expr: "0 0 9 * * *".into(),
@@ -8568,6 +8573,7 @@ async fn get_session_status_surfaces_subagent_metadata() {
         json!({
             "session_id": "99999999-9999-9999-9999-999999999999",
             "summary": "Tests tightened and lifecycle audit trail captured",
+            "recorded_at": (now + chrono::TimeDelta::milliseconds(1)).to_rfc3339(),
             "artifacts": [
                 {
                     "name": "review-notes.md",
@@ -15500,6 +15506,153 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
     assert_eq!(
         json["audit"]["last_operator_note"],
         "Operator asked for a tighter review pass"
+    );
+}
+
+#[tokio::test]
+async fn session_status_route_surfaces_latest_subagent_result_timestamp() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("test");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let session_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let now = chrono::DateTime::parse_from_rfc3339("2026-03-29T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let result_recorded_at = chrono::DateTime::parse_from_rfc3339("2026-03-29T12:04:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    session_repo
+        .create(NewSession {
+            id: session_id,
+            kind: "subagent".into(),
+            status: "running".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: Some(
+                Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap(),
+            ),
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "subagent_lifecycle": "steered",
+                "subagent_runtime_status": "running",
+                "subagent_runtime_attached": true
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    transcript_repo
+        .append(NewTranscriptItem {
+            id: Uuid::now_v7(),
+            session_id,
+            turn_id: None,
+            seq: 0,
+            kind: "subagent_result".into(),
+            payload: json!({
+                "session_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "summary": "Delegated work completed with a clean verification pass"
+            }),
+            created_at: result_recorded_at,
+        })
+        .await
+        .unwrap();
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics: TokenMetricsStore::new(),
+        peer_health_alert_cache: PeerHealthAlertCache::new(),
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["latest_subagent_result"]["recorded_at"],
+        result_recorded_at.to_rfc3339()
     );
 }
 


### PR DESCRIPTION
## Summary\n- add  to latest subagent result summaries surfaced by session status and delegation tree APIs\n- add focused route coverage for the latest-result timestamp\n- fix gateway scheduler job initializers to match the current retry/suppression fields so cargo check stays green\n\n## Testing\n- cargo test -p rune-gateway session_status_route_surfaces_subagent_audit_summary -- --nocapture\n- cargo test -p rune-gateway session_status_route_surfaces_latest_subagent_result_timestamp -- --nocapture\n- cargo test -p rune-gateway session_status_route_surfaces_subagent_metadata -- --nocapture\n- cargo check\n\nCloses #811