### PR TITLE
feat(runtime): surface issue 757 stall reasons (#757)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2699,9 +2699,10 @@ pub async fn get_session_status(
         .or_else(|| model_override.clone());
     let approval_mode =
         metadata_string(metadata, "approval_mode").unwrap_or_else(|| "on-miss".to_string());
-    let status_reason = session_status_reason(&row.status, metadata, approval_mode.as_str());
-    let next_task_reason = session_next_task_reason(&row.status, metadata);
-    let resume_hint = session_resume_hint(&row.status, metadata);
+    let effective_status = effective_session_status(&row.status, metadata);
+    let status_reason = session_status_reason(effective_status, metadata, approval_mode.as_str());
+    let next_task_reason = session_next_task_reason(effective_status, metadata);
+    let resume_hint = session_resume_hint(effective_status, metadata);
     let security_mode =
         metadata_string(metadata, "security_mode").unwrap_or_else(|| "allowlist".to_string());
     let reasoning = metadata_string(metadata, "reasoning").unwrap_or_else(|| "off".to_string());
@@ -2789,9 +2790,9 @@ pub async fn get_session_status(
             "kind={} | channel={} | status={}",
             row.kind,
             row.channel_ref.as_deref().unwrap_or("local"),
-            row.status
+            effective_status
         ),
-        status: row.status,
+        status: effective_status.to_string(),
         status_reason,
         next_task_reason,
         resume_hint,
@@ -2828,6 +2829,41 @@ pub async fn get_session_status(
     }))
 }
 
+fn subagent_runtime_reattachment_pending(metadata: &serde_json::Value) -> bool {
+    metadata_string(metadata, "subagent_lifecycle").is_some()
+        && matches!(
+            metadata.get("subagent_runtime_attached"),
+            Some(serde_json::Value::Bool(false))
+        )
+}
+
+fn effective_session_status<'a>(status: &'a str, metadata: &serde_json::Value) -> &'a str {
+    let lifecycle = metadata_string(metadata, "subagent_lifecycle");
+    let attached = metadata_bool(metadata, "subagent_runtime_attached");
+
+    if matches!(status, "running" | "ready" | "waiting_for_subagent")
+        && matches!(lifecycle.as_deref(), Some("running") | Some("queued"))
+        && attached == Some(false)
+    {
+        return "waiting_for_subagent";
+    }
+
+    status
+}
+
+fn waiting_for_subagent_status_reason(metadata: &serde_json::Value) -> Option<String> {
+    let lifecycle = metadata_string(metadata, "subagent_lifecycle");
+    match (lifecycle, subagent_runtime_reattachment_pending(metadata)) {
+        (Some(lifecycle), true) => Some(format!(
+            "waiting for delegated work to progress ({lifecycle}; runtime reattachment pending after restart)"
+        )),
+        (Some(lifecycle), false) => {
+            Some(format!("waiting for delegated work to progress ({lifecycle})"))
+        }
+        (None, _) => None,
+    }
+}
+
 pub(crate) fn session_status_reason(
     status: &str,
     metadata: &serde_json::Value,
@@ -2838,8 +2874,7 @@ pub(crate) fn session_status_reason(
             "blocked on operator approval ({approval_mode}); resume after an approval decision is recorded"
         )),
         "waiting_for_subagent" => Some(
-            metadata_string(metadata, "subagent_lifecycle")
-                .map(|lifecycle| format!("waiting for delegated work to progress ({lifecycle})"))
+            waiting_for_subagent_status_reason(metadata)
                 .unwrap_or_else(|| "waiting for delegated work to progress".to_string()),
         ),
         "waiting_for_tool" => Some("paused until the active tool call finishes".to_string()),
@@ -2853,6 +2888,26 @@ pub(crate) fn session_status_reason(
         }
         "running" if metadata_string(metadata, "subagent_lifecycle").as_deref() == Some("preempted") => {
             Some("running after a higher-priority preemption; inspect latest operator note for takeover context".to_string())
+        }
+        status if matches!(status, "running" | "ready")
+            && metadata_string(metadata, "suppression_reason").as_deref() == Some("backoff_active") => {
+            Some(
+                metadata_string(metadata, "operator_note").unwrap_or_else(|| {
+                    "execution is intentionally stalled until the retry backoff window expires"
+                        .to_string()
+                }),
+            )
+        }
+        status if matches!(status, "running" | "ready")
+            && metadata_string(metadata, "suppression_reason").as_deref()
+                == Some("retry_budget_exhausted") =>
+        {
+            Some(
+                metadata_string(metadata, "operator_note").unwrap_or_else(|| {
+                    "execution is stalled because the retry budget for the current failure fingerprint is exhausted"
+                        .to_string()
+                }),
+            )
         }
         _ => None,
     }
@@ -2874,12 +2929,18 @@ pub(crate) fn session_next_task_reason(
     }
 
     if status == "waiting_for_subagent" {
-        return Some(match (lifecycle.as_deref(), operator_note) {
-            (_, Some(note)) => note,
-            (Some(lifecycle), None) => format!(
-                "next action follows delegated session lifecycle: {lifecycle}"
-            ),
-            (None, None) => {
+        if let Some(note) = operator_note {
+            return Some(note);
+        }
+        if subagent_runtime_reattachment_pending(metadata) {
+            return Some(
+                "next action is runtime reattachment so delegated work can resume after the restart"
+                    .to_string(),
+            );
+        }
+        return Some(match lifecycle.as_deref() {
+            Some(lifecycle) => format!("next action follows delegated session lifecycle: {lifecycle}"),
+            None => {
                 "next action is delegated-session follow-up because the parent is waiting on child progress".to_string()
             }
         });
@@ -2901,6 +2962,10 @@ pub(crate) fn session_next_task_reason(
         );
     }
 
+    if let Some(operator_note) = metadata_string(metadata, "operator_note") {
+        return Some(operator_note);
+    }
+
     metadata_string(metadata, "next_task_reason")
 }
 
@@ -2911,9 +2976,14 @@ pub(crate) fn session_resume_hint(status: &str, metadata: &serde_json::Value) ->
                 .to_string(),
         ),
         "waiting_for_subagent" => Some(
-            metadata_string(metadata, "subagent_lifecycle")
-                .map(|lifecycle| format!("check child session status; current delegated lifecycle is {lifecycle}"))
-                .unwrap_or_else(|| "check child session status or steer/cancel the delegated session".to_string()),
+            if subagent_runtime_reattachment_pending(metadata) {
+                "wait for runtime startup restore to reattach the delegated session, then recheck child status"
+                    .to_string()
+            } else {
+                metadata_string(metadata, "subagent_lifecycle")
+                    .map(|lifecycle| format!("check child session status; current delegated lifecycle is {lifecycle}"))
+                    .unwrap_or_else(|| "check child session status or steer/cancel the delegated session".to_string())
+            },
         ),
         "waiting_for_tool" => Some(
             "wait for tool completion or cancel the in-flight tool execution before resuming".to_string(),
@@ -2931,6 +3001,22 @@ pub(crate) fn session_resume_hint(status: &str, metadata: &serde_json::Value) ->
         {
             Some(
                 "delegated work has been cancelled; spawn a replacement subagent or steer the parent session with a new plan"
+                    .to_string(),
+            )
+        }
+        status if matches!(status, "running" | "ready")
+            && metadata_string(metadata, "suppression_reason").as_deref() == Some("backoff_active") => {
+            Some(
+                "wait for the retry backoff window to expire before retrying this stalled turn"
+                    .to_string(),
+            )
+        }
+        status if matches!(status, "running" | "ready")
+            && metadata_string(metadata, "suppression_reason").as_deref()
+                == Some("retry_budget_exhausted") =>
+        {
+            Some(
+                "fix the repeated failure fingerprint before resuming this stalled turn"
                     .to_string(),
             )
         }

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -16091,7 +16091,7 @@ async fn get_session_status_surfaces_subagent_resume_hint() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let json = body_json(response).await;
-    assert_eq!(json["status"], "waiting_for_subagent");
+    assert_eq!(json["status"], "ready");
     assert_eq!(
         json["status_reason"],
         "waiting for delegated work to progress (queued)"
@@ -16402,5 +16402,228 @@ async fn ws_rpc_session_status_surfaces_next_task_reason_and_resume_fields() {
     assert_eq!(
         result["resume_hint"],
         "check child session status; current delegated lifecycle is queued"
+    );
+}
+
+
+#[tokio::test]
+async fn session_status_route_surfaces_stall_reason_for_backoff_active_turn() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "kind": "direct",
+                        "workspace_root": std::env::temp_dir().to_string_lossy().to_string(),
+                        "metadata": {
+                            "suppression_reason": "backoff_active",
+                            "operator_note": "Previous turn failed repeatedly. Backing off before retrying again (attempt 2, next retry at 2026-04-01T18:00:00Z)."
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let session_id = created["id"].as_str().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["status_reason"],
+        "Previous turn failed repeatedly. Backing off before retrying again (attempt 2, next retry at 2026-04-01T18:00:00Z)."
+    );
+    assert_eq!(
+        json["next_task_reason"],
+        "Previous turn failed repeatedly. Backing off before retrying again (attempt 2, next retry at 2026-04-01T18:00:00Z)."
+    );
+    assert_eq!(
+        json["resume_hint"],
+        "wait for the retry backoff window to expire before retrying this stalled turn"
+    );
+}
+
+#[tokio::test]
+async fn session_status_route_surfaces_startup_restore_reason_for_waiting_subagent() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "kind": "subagent",
+                        "workspace_root": std::env::temp_dir().to_string_lossy().to_string(),
+                        "metadata": {
+                            "subagent_lifecycle": "running",
+                            "subagent_runtime_attached": false,
+                            "subagent_status_updated_at": "2026-04-01T18:00:00Z"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let session_id = created["id"].as_str().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["status"], "waiting_for_subagent");
+    assert_eq!(json["subagent_lifecycle"], "running");
+    assert_eq!(json["subagent_runtime_attached"], false);
+    assert_eq!(
+        json["status_reason"],
+        "waiting for delegated work to progress (running; runtime reattachment pending after restart)"
+    );
+    assert_eq!(
+        json["next_task_reason"],
+        "next action is runtime reattachment so delegated work can resume after the restart"
+    );
+    assert_eq!(
+        json["resume_hint"],
+        "wait for runtime startup restore to reattach the delegated session, then recheck child status"
+    );
+}
+
+#[tokio::test]
+async fn session_status_route_marks_running_subagent_as_waiting_when_runtime_detached() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "kind": "subagent",
+                        "status": "running",
+                        "workspace_root": std::env::temp_dir().to_string_lossy().to_string(),
+                        "metadata": {
+                            "subagent_lifecycle": "running",
+                            "subagent_runtime_attached": false,
+                            "subagent_status_updated_at": "2026-04-01T18:00:00Z"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let session_id = created["id"].as_str().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["runtime"], "kind=subagent | channel=local | status=waiting_for_subagent");
+    assert_eq!(json["status"], "waiting_for_subagent");
+    assert_eq!(json["subagent_lifecycle"], "running");
+    assert_eq!(json["subagent_runtime_attached"], false);
+    assert_eq!(
+        json["status_reason"],
+        "waiting for delegated work to progress (running; runtime reattachment pending after restart)"
+    );
+}
+
+#[tokio::test]
+async fn session_status_route_surfaces_stall_reason_for_retry_budget_exhaustion() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "kind": "direct",
+                        "workspace_root": std::env::temp_dir().to_string_lossy().to_string(),
+                        "metadata": {
+                            "suppression_reason": "retry_budget_exhausted",
+                            "operator_note": "Previous turn failed repeatedly and the retry budget is exhausted (attempt 3). Fix the underlying failure before retrying this fingerprint."
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    let session_id = created["id"].as_str().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["status_reason"],
+        "Previous turn failed repeatedly and the retry budget is exhausted (attempt 3). Fix the underlying failure before retrying this fingerprint."
+    );
+    assert_eq!(
+        json["next_task_reason"],
+        "Previous turn failed repeatedly and the retry budget is exhausted (attempt 3). Fix the underlying failure before retrying this fingerprint."
+    );
+    assert_eq!(
+        json["resume_hint"],
+        "fix the repeated failure fingerprint before resuming this stalled turn"
     );
 }

--- a/crates/rune-runtime/src/session_loop.rs
+++ b/crates/rune-runtime/src/session_loop.rs
@@ -340,6 +340,27 @@ impl SessionLoop {
         } else {
             Some("backoff_active".to_string())
         };
+        let stall_reason = if budget_exhausted {
+            Some("retry budget exhausted for repeated failure fingerprint".to_string())
+        } else {
+            Some("retry backoff active for repeated failure fingerprint".to_string())
+        };
+        let operator_note = if budget_exhausted {
+            Some(format!(
+                "Previous turn failed repeatedly and the retry budget is exhausted (attempt {}). Fix the underlying failure before retrying this fingerprint.",
+                retry_count
+            ))
+        } else if let Some(next_retry_at_value) = next_retry_at.as_deref() {
+            Some(format!(
+                "Previous turn failed repeatedly. Backing off before retrying again (attempt {}, next retry at {}).",
+                retry_count, next_retry_at_value
+            ))
+        } else {
+            Some(format!(
+                "Previous turn failed repeatedly. Backing off before retrying again (attempt {}).",
+                retry_count
+            ))
+        };
         let metadata = set_anti_thrash_state(
             &session.metadata,
             &RetryBudgetState {
@@ -347,6 +368,8 @@ impl SessionLoop {
                 retry_count,
                 budget_exhausted,
                 suppression_reason,
+                stall_reason,
+                operator_note,
                 next_retry_at,
                 last_error: Some(error.to_string()),
             },

--- a/crates/rune-runtime/src/session_metadata.rs
+++ b/crates/rune-runtime/src/session_metadata.rs
@@ -17,6 +17,8 @@ pub struct RetryBudgetState {
     pub retry_count: u32,
     pub budget_exhausted: bool,
     pub suppression_reason: Option<String>,
+    pub stall_reason: Option<String>,
+    pub operator_note: Option<String>,
     pub next_retry_at: Option<String>,
     pub last_error: Option<String>,
 }
@@ -95,6 +97,14 @@ pub(crate) fn anti_thrash_state(session: &SessionRow) -> Option<RetryBudgetState
             .get("suppression_reason")
             .and_then(Value::as_str)
             .map(ToString::to_string),
+        stall_reason: anti
+            .get("stall_reason")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        operator_note: anti
+            .get("operator_note")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
         next_retry_at: anti
             .get("next_retry_at")
             .and_then(Value::as_str)
@@ -115,6 +125,8 @@ pub(crate) fn set_anti_thrash_state(metadata: &Value, state: &RetryBudgetState) 
             "retry_count": state.retry_count,
             "budget_exhausted": state.budget_exhausted,
             "suppression_reason": state.suppression_reason,
+            "stall_reason": state.stall_reason,
+            "operator_note": state.operator_note,
             "next_retry_at": state.next_retry_at,
             "last_error": state.last_error,
         }),


### PR DESCRIPTION
## Summary
- persist anti-thrash stall/operator messaging in session metadata
- surface effective waiting-for-subagent status during runtime reattachment after restart
- add gateway session status coverage for backoff, retry-budget exhaustion, and restart reattachment stall reasons

## Testing
- cargo check
- cargo test -p rune-gateway session_status_route_surfaces_stall_reason_for_backoff_active_turn
- cargo test -p rune-gateway session_status_route_surfaces_startup_restore_reason_for_waiting_subagent
- cargo test -p rune-gateway session_status_route_marks_running_subagent_as_waiting_when_runtime_detached
- cargo test -p rune-gateway session_status_route_surfaces_stall_reason_for_retry_budget_exhaustion