### PR TITLE
docs(contributor): make docs part of done (#784)

### DIFF
--- a/docs/contributor/DEVELOPMENT.md
+++ b/docs/contributor/DEVELOPMENT.md
@@ -88,7 +88,10 @@ systemctl --user daemon-reload
 
 ## Tests and quality checks
 
+Treat documentation as part of the same delivery slice as code and validation. If a change affects runtime behavior, configuration, troubleshooting, contributor workflow, or architecture, update the matching canonical docs in the same PR.
+
 ```bash
+cargo check
 cargo test --workspace
 cargo clippy --workspace -- -D warnings
 ```

--- a/docs/contributor/TESTING.md
+++ b/docs/contributor/TESTING.md
@@ -17,9 +17,19 @@ Rune work uses tiered validation:
 - [`DEVELOPMENT.md`](DEVELOPMENT.md)
 - [`../INDEX.md`](../INDEX.md)
 
+## Definition of done for validation
+
+Validation is part of the shipped slice, not a private local checkpoint. Before a PR is merged, the work should include:
+- code changes required by the issue
+- validation evidence proportionate to the risk and surface area
+- canonical documentation updates whenever the change affects operator behavior, contributor workflow, runtime semantics, configuration, troubleshooting, or architecture
+
+A change is not done if tests passed but the durable docs for the new behavior are still missing.
+
 ## Common checks
 
 ```bash
+cargo check
 cargo test --workspace
 cargo clippy --workspace -- -D warnings
 ```


### PR DESCRIPTION
## Summary
- reinforce in contributor development/testing docs that canonical documentation updates ship in the same PR as non-trivial code changes
- add a definition-of-done section to testing guidance so validation is not considered complete without matching durable docs when behavior/config/workflow changes
- add  to the common validation baseline documented for contributors

Closes #784

## Validation
- cargo check