### PR TITLE
feat(storage): reserve Azure SQL config surface

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -300,11 +300,19 @@ fn emit_startup_banner(config: &AppConfig, flags: &StartupFlags, resolved_mode: 
             }
         }
         StorageBackend::Cosmos => "cosmos",
+        StorageBackend::AzureSql => "azure-sql (unimplemented)",
         StorageBackend::Auto => {
             if config.database.database_url.is_some() {
                 "postgres (external)"
             } else if config.database.cosmos_endpoint.is_some() {
                 "cosmos"
+            } else if config.database.azure_sql_server.is_some()
+                || config.database.azure_sql_database.is_some()
+                || config.database.azure_sql_user.is_some()
+                || config.database.azure_sql_password.is_some()
+                || config.database.azure_sql_access_token.is_some()
+            {
+                "azure-sql (unimplemented)"
             } else {
                 "sqlite"
             }

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,13 @@ run_migrations = true
 # sqlite_path = "/data/db/rune.db"
 # cosmos_endpoint = "https://example.documents.azure.com:443/"
 # cosmos_key = "<cosmos-account-key>"
+# Azure SQL Database fields are reserved for future support tracked in issue #782.
+# backend = "azure_sql"
+# azure_sql_server = "server.database.windows.net"
+# azure_sql_database = "rune"
+# azure_sql_user = "rune-user"
+# azure_sql_password = "<password>"
+# azure_sql_access_token = "<optional-aad-access-token>"
 # Azure SQL Database is not supported yet; use Azure Database for PostgreSQL for Azure-hosted relational deployments today.
 
 [channels]

--- a/crates/rune-cli/src/doctor.rs
+++ b/crates/rune-cli/src/doctor.rs
@@ -265,15 +265,23 @@ async fn check_database_config(config: &AppConfig) -> Vec<CheckResult> {
     let mut results = Vec::new();
 
     let using_external_postgres = config.database.database_url.is_some();
+    let azure_sql_configured = config.database.azure_sql_server.is_some()
+        || config.database.azure_sql_database.is_some()
+        || config.database.azure_sql_user.is_some()
+        || config.database.azure_sql_password.is_some()
+        || config.database.azure_sql_access_token.is_some();
     let resolved_backend = match config.database.backend {
         rune_config::StorageBackend::Postgres => "postgres",
         rune_config::StorageBackend::Sqlite => "sqlite",
         rune_config::StorageBackend::Cosmos => "cosmos",
+        rune_config::StorageBackend::AzureSql => "azure_sql",
         rune_config::StorageBackend::Auto => {
             if using_external_postgres {
                 "postgres"
             } else if config.database.cosmos_endpoint.is_some() {
                 "cosmos"
+            } else if azure_sql_configured {
+                "azure_sql"
             } else {
                 "sqlite"
             }
@@ -289,7 +297,7 @@ async fn check_database_config(config: &AppConfig) -> Vec<CheckResult> {
             config.database.backend
         ),
         hint: if matches!(config.database.backend, rune_config::StorageBackend::Auto) {
-            Some("Auto resolves to PostgreSQL when database_url is set, otherwise Cosmos when cosmos_endpoint is set, otherwise SQLite".into())
+            Some("Auto resolves to PostgreSQL when database_url is set, otherwise Cosmos when cosmos_endpoint is set, otherwise flags unsupported Azure SQL config, otherwise SQLite".into())
         } else {
             None
         },
@@ -336,6 +344,43 @@ async fn check_database_config(config: &AppConfig) -> Vec<CheckResult> {
 
     if resolved_backend == "postgres" && !using_external_postgres {
         results.extend(check_embedded_postgres_layout(config));
+    }
+
+
+    if azure_sql_configured || matches!(config.database.backend, rune_config::StorageBackend::AzureSql) {
+        let missing_identity = config.database.azure_sql_server.is_none()
+            || config.database.azure_sql_database.is_none();
+        let auth_configured = config.database.azure_sql_access_token.is_some()
+            || (config.database.azure_sql_user.is_some() && config.database.azure_sql_password.is_some());
+        results.push(CheckResult {
+            name: "database.azure_sql".into(),
+            category: "database".into(),
+            status: CheckStatus::Warn,
+            message: "Azure SQL Database config detected, but Rune does not support Azure SQL yet".into(),
+            hint: Some("Track issue #782. Use Azure Database for PostgreSQL or SQLite today; do not expect Azure SQL startup to succeed yet".into()),
+        });
+        results.push(CheckResult {
+            name: "database.azure_sql.identity".into(),
+            category: "database".into(),
+            status: if missing_identity { CheckStatus::Fail } else { CheckStatus::Warn },
+            message: if missing_identity {
+                "Azure SQL config is missing azure_sql_server or azure_sql_database".into()
+            } else {
+                "Azure SQL server/database fields are present".into()
+            },
+            hint: Some("When Azure SQL support lands, server and database names will be required".into()),
+        });
+        results.push(CheckResult {
+            name: "database.azure_sql.auth".into(),
+            category: "database".into(),
+            status: if auth_configured { CheckStatus::Warn } else { CheckStatus::Fail },
+            message: if auth_configured {
+                "Azure SQL auth material is present, but the backend is still unsupported".into()
+            } else {
+                "Azure SQL auth material is incomplete (set access token or username/password pair)".into()
+            },
+            hint: Some("Current releases ignore these fields except to warn; they are reserved for future Azure SQL support in issue #782".into()),
+        });
     }
 
     results.push(CheckResult {
@@ -1181,15 +1226,24 @@ fn build_backend_matrix_raw(config: &AppConfig) -> Vec<BackendMatrixRawEntry> {
 }
 
 fn resolved_storage_backend(config: &AppConfig) -> &'static str {
+    let azure_sql_configured = config.database.azure_sql_server.is_some()
+        || config.database.azure_sql_database.is_some()
+        || config.database.azure_sql_user.is_some()
+        || config.database.azure_sql_password.is_some()
+        || config.database.azure_sql_access_token.is_some();
+
     match config.database.backend {
         rune_config::StorageBackend::Postgres => "postgres",
         rune_config::StorageBackend::Sqlite => "sqlite",
         rune_config::StorageBackend::Cosmos => "cosmos",
+        rune_config::StorageBackend::AzureSql => "azure_sql",
         rune_config::StorageBackend::Auto => {
             if config.database.database_url.is_some() {
                 "postgres"
             } else if config.database.cosmos_endpoint.is_some() {
                 "cosmos"
+            } else if azure_sql_configured {
+                "azure_sql"
             } else {
                 "sqlite"
             }
@@ -1742,6 +1796,58 @@ mod tests {
         }));
         assert!(warmed.iter().any(|r| {
             r.name == "database.embedded.password_file" && r.status == CheckStatus::Pass
+        }));
+    }
+
+    #[tokio::test]
+    async fn azure_sql_backend_checks_warn_as_unimplemented() {
+        let tmp = TempDir::new().unwrap();
+        create_path_layout(tmp.path()).await;
+        let mut config = test_config_with_paths(tmp.path());
+        config.database.backend = rune_config::StorageBackend::AzureSql;
+        config.database.azure_sql_server = Some("server.database.windows.net".into());
+        config.database.azure_sql_database = Some("rune".into());
+        config.database.azure_sql_user = Some("hamza".into());
+        config.database.azure_sql_password = Some("secret".into());
+
+        let results = check_database_config(&config).await;
+        assert!(results.iter().any(|r| {
+            r.name == "database.backend"
+                && r.status == CheckStatus::Pass
+                && r.message.contains("resolved runtime backend = azure_sql")
+        }));
+        assert!(results.iter().any(|r| {
+            r.name == "database.azure_sql"
+                && r.status == CheckStatus::Warn
+                && r.message.contains("does not support Azure SQL yet")
+        }));
+        assert!(results.iter().any(|r| {
+            r.name == "database.azure_sql.identity" && r.status == CheckStatus::Warn
+        }));
+        assert!(results.iter().any(|r| {
+            r.name == "database.azure_sql.auth" && r.status == CheckStatus::Warn
+        }));
+    }
+
+    #[tokio::test]
+    async fn azure_sql_auto_detection_surfaces_missing_fields() {
+        let tmp = TempDir::new().unwrap();
+        create_path_layout(tmp.path()).await;
+        let mut config = test_config_with_paths(tmp.path());
+        config.database.backend = rune_config::StorageBackend::Auto;
+        config.database.azure_sql_server = Some("server.database.windows.net".into());
+
+        let results = check_database_config(&config).await;
+        assert!(results.iter().any(|r| {
+            r.name == "database.backend"
+                && r.status == CheckStatus::Pass
+                && r.message.contains("resolved runtime backend = azure_sql")
+        }));
+        assert!(results.iter().any(|r| {
+            r.name == "database.azure_sql.identity" && r.status == CheckStatus::Fail
+        }));
+        assert!(results.iter().any(|r| {
+            r.name == "database.azure_sql.auth" && r.status == CheckStatus::Fail
         }));
     }
 

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -770,6 +770,8 @@ pub enum StorageBackend {
     Sqlite,
     Postgres,
     Cosmos,
+    #[serde(alias = "sqlserver", alias = "mssql")]
+    AzureSql,
 }
 
 /// Which backend to use for vector/semantic memory.
@@ -832,7 +834,23 @@ pub struct DatabaseConfig {
     /// Cosmos DB master key for auth.
     #[serde(default)]
     pub cosmos_key: Option<String>,
+    /// Azure SQL Database server hostname or fully qualified server name.
+    #[serde(default)]
+    pub azure_sql_server: Option<String>,
+    /// Azure SQL Database name.
+    #[serde(default)]
+    pub azure_sql_database: Option<String>,
+    /// Azure SQL Database SQL auth username or Microsoft Entra principal name.
+    #[serde(default)]
+    pub azure_sql_user: Option<String>,
+    /// Azure SQL Database SQL auth password.
+    #[serde(default)]
+    pub azure_sql_password: Option<String>,
+    /// Azure SQL Database access token for token-based auth flows.
+    #[serde(default)]
+    pub azure_sql_access_token: Option<String>,
 }
+
 
 impl Default for DatabaseConfig {
     fn default() -> Self {
@@ -844,6 +862,11 @@ impl Default for DatabaseConfig {
             sqlite_path: None,
             cosmos_endpoint: None,
             cosmos_key: None,
+            azure_sql_server: None,
+            azure_sql_database: None,
+            azure_sql_user: None,
+            azure_sql_password: None,
+            azure_sql_access_token: None,
         }
     }
 }

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -7155,11 +7155,19 @@ fn doctor_topology_summary(config: &rune_config::AppConfig) -> DoctorTopologySum
         }
         rune_config::StorageBackend::Sqlite => "sqlite-local",
         rune_config::StorageBackend::Cosmos => "azure-cosmos",
+        rune_config::StorageBackend::AzureSql => "azure-sql-unimplemented",
         rune_config::StorageBackend::Auto => {
             if config.database.database_url.is_some() {
                 "azure-or-external-postgres"
             } else if config.database.cosmos_endpoint.is_some() {
                 "azure-cosmos"
+            } else if config.database.azure_sql_server.is_some()
+                || config.database.azure_sql_database.is_some()
+                || config.database.azure_sql_user.is_some()
+                || config.database.azure_sql_password.is_some()
+                || config.database.azure_sql_access_token.is_some()
+            {
+                "azure-sql-unimplemented"
             } else {
                 "sqlite-local"
             }

--- a/crates/rune-store/src/factory.rs
+++ b/crates/rune-store/src/factory.rs
@@ -137,6 +137,11 @@ fn resolve_backend(db: &rune_config::DatabaseConfig) -> ResolvedBackend {
             #[cfg(not(feature = "cosmos"))]
             panic!("storage backend set to 'cosmos' but the 'cosmos' feature is not compiled in");
         }
+        StorageBackend::AzureSql => {
+            panic!(
+                "storage backend set to 'azure_sql' but Azure SQL Database support is not implemented yet; track issue #782 and use PostgreSQL or SQLite today"
+            );
+        }
         StorageBackend::Auto => {
             if db.database_url.is_some() {
                 #[cfg(feature = "postgres")]
@@ -149,6 +154,16 @@ fn resolve_backend(db: &rune_config::DatabaseConfig) -> ResolvedBackend {
                 return ResolvedBackend::Cosmos;
                 #[cfg(not(feature = "cosmos"))]
                 panic!("cosmos_endpoint is set but the 'cosmos' feature is not compiled in");
+            }
+            if db.azure_sql_server.is_some()
+                || db.azure_sql_database.is_some()
+                || db.azure_sql_user.is_some()
+                || db.azure_sql_password.is_some()
+                || db.azure_sql_access_token.is_some()
+            {
+                panic!(
+                    "Azure SQL Database configuration detected but support is not implemented yet; track issue #782 and use Azure Database for PostgreSQL or SQLite today"
+                );
             }
             #[cfg(feature = "sqlite")]
             return ResolvedBackend::Sqlite;

--- a/crates/rune-store/tests/factory_backend_matrix.rs
+++ b/crates/rune-store/tests/factory_backend_matrix.rs
@@ -1,4 +1,24 @@
 #![cfg(feature = "sqlite")]
+#[test]
+#[should_panic(expected = "Azure SQL Database support is not implemented yet")]
+fn explicit_azure_sql_backend_panics_with_actionable_message() {
+    let mut config = AppConfig::default();
+    config.database.backend = StorageBackend::AzureSql;
+    config.database.azure_sql_server = Some("server.database.windows.net".into());
+    config.database.azure_sql_database = Some("rune".into());
+
+    let _ = rune_store::build_repos(&config);
+}
+
+#[test]
+#[should_panic(expected = "Azure SQL Database configuration detected but support is not implemented yet")]
+fn auto_backend_panics_when_azure_sql_fields_are_present() {
+    let mut config = AppConfig::default();
+    config.database.backend = StorageBackend::Auto;
+    config.database.azure_sql_server = Some("server.database.windows.net".into());
+
+    let _ = rune_store::build_repos(&config);
+}
 
 use chrono::Utc;
 use rune_config::{AppConfig, StorageBackend, VectorBackend};


### PR DESCRIPTION
## Summary\n- reserve Azure SQL backend/config enum values and fields without pretending support exists\n- fail loudly when Azure SQL config is selected or auto-detected so it cannot be misread as Postgres\n- surface Azure SQL as unimplemented in doctor/startup metadata and cover it with tests\n\n## Testing\n- cargo check\n- cargo test -p rune-cli azure_sql -- --nocapture\n- cargo test -p rune-store factory_backend_matrix -- --nocapture