### PR TITLE
fix(gateway): default subagent lifecycle audit fields in session tree (#658)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2904,6 +2904,24 @@ pub async fn get_session_tree(
             .get(&row.id)
             .cloned()
             .unwrap_or((None, None));
+        let subagent_lifecycle = metadata_string(&row.metadata, "subagent_lifecycle")
+            .or_else(|| {
+                if row.kind == "subagent" {
+                    Some("created".to_string())
+                } else {
+                    None
+                }
+            });
+        let subagent_runtime_status = metadata_string(&row.metadata, "subagent_runtime_status")
+            .or_else(|| {
+                if row.kind == "subagent" {
+                    Some("pending".to_string())
+                } else {
+                    None
+                }
+            });
+        let subagent_runtime_attached = metadata_bool(&row.metadata, "subagent_runtime_attached")
+            .or(if row.kind == "subagent" { Some(false) } else { None });
         SessionTreeNode {
             id: row.id.to_string(),
             kind: row.kind.clone(),
@@ -2916,9 +2934,9 @@ pub async fn get_session_tree(
             orchestration_status,
             delegation_roles,
             delegation_depth,
-            subagent_lifecycle: metadata_string(&row.metadata, "subagent_lifecycle"),
-            subagent_runtime_status: metadata_string(&row.metadata, "subagent_runtime_status"),
-            subagent_runtime_attached: metadata_bool(&row.metadata, "subagent_runtime_attached"),
+            subagent_lifecycle,
+            subagent_runtime_status,
+            subagent_runtime_attached,
             subagent_status_updated_at: metadata_string(
                 &row.metadata,
                 "subagent_status_updated_at",

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -9913,6 +9913,59 @@ async fn create_subagent_session_accepts_shared_scratchpad_without_delegation_co
     );
 }
 #[tokio::test]
+async fn get_session_tree_defaults_subagent_lifecycle_when_runtime_metadata_missing() {
+    let app = build_test_app(None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"kind":"direct"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let parent_json = body_json(response).await;
+    let parent_id = parent_json["id"].as_str().unwrap().to_string();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/sessions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "kind": "subagent",
+                        "requester_session_id": parent_id
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/sessions/{parent_id}/tree"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let child = &json["children"][0];
+    assert_eq!(child["kind"], "subagent");
+    assert_eq!(child["subagent_lifecycle"], "created");
+    assert_eq!(child["subagent_runtime_status"], "pending");
+    assert_eq!(child["subagent_runtime_attached"], false);
+}
+
 async fn create_subagent_session_accepts_delegation_context_and_scratchpad() {
     let app = build_test_app(None);
 


### PR DESCRIPTION
## Summary
- default session-tree subagent lifecycle/runtime fields when runtime metadata is not attached yet
- preserve explicit metadata when present
- add regression coverage for newly created subagents without runtime metadata

## Validation
- cargo check -p rune-gateway
- cargo test -p rune-gateway --test route_tests get_session_tree_defaults_subagent_lifecycle_when_runtime_metadata_missing -- --exact *(currently blocked by unrelated pre-existing test compile failures in route_tests around AppState/usage tracker API drift)*