### PR TITLE
feat(gateway): surface goal lease status (#763)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -9,7 +9,7 @@ use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Map, Value, json};
 use std::collections::{BTreeSet, HashMap};
 use tracing::info;
 use uuid::Uuid;
@@ -26,7 +26,6 @@ use rune_store::models::{SessionRow, TurnRow};
 use rune_tools::memory_tool::MemoryToolExecutor;
 use rune_tools::process_tool::{PersistedProcessInfo, ProcessInfo};
 use rune_tools::{ToolCall, ToolExecutor};
-use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::events::{ApprovalEvent, RuntimeEvent, broadcast_runtime_event};
@@ -2464,6 +2463,8 @@ pub struct SessionStatusResponse {
     pub status_reason: String,
     pub next_task_reason: String,
     pub resume_hint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goal_lease: Option<Value>,
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_ref: Option<String>,
@@ -2703,6 +2704,7 @@ pub async fn get_session_status(
         status_reason: session_status_reason(&row.status, metadata, &approval_mode),
         next_task_reason: session_next_task_reason(&row.status, metadata),
         resume_hint: session_resume_hint(&row.status, metadata),
+        goal_lease: session_goal_lease(metadata),
         kind: row.kind,
         channel_ref: row.channel_ref,
         parent_session_id,
@@ -3630,6 +3632,39 @@ pub(crate) fn session_next_task_reason(status: &str, metadata: &Value) -> String
         "cancelled" => "restart the session only if the task is still relevant".to_string(),
         _ => "inspect session metadata and transcript for the next action".to_string(),
     }
+}
+
+fn session_goal_lease(metadata: &Value) -> Option<Value> {
+    let goal_key = metadata_string(metadata, "goal_key")?;
+    let owner_agent_id = metadata_string(metadata, "goal_owner_agent_id")?;
+
+    let mut lease = Map::new();
+    lease.insert("goal_key".to_string(), Value::String(goal_key));
+    lease.insert(
+        "owner_agent_id".to_string(),
+        Value::String(owner_agent_id),
+    );
+
+    if let Some(lease_expires_at) = metadata_string(metadata, "goal_lease_expires_at") {
+        lease.insert(
+            "lease_expires_at".to_string(),
+            Value::String(lease_expires_at),
+        );
+    }
+    if let Some(leased_at) = metadata_string(metadata, "goal_leased_at") {
+        lease.insert("leased_at".to_string(), Value::String(leased_at));
+    }
+    if let Some(recovered_at) = metadata_string(metadata, "goal_lease_recovered_at") {
+        lease.insert("recovered_at".to_string(), Value::String(recovered_at));
+    }
+    if let Some(recovered_from_agent_id) = metadata_string(metadata, "goal_lease_recovered_from_agent_id") {
+        lease.insert(
+            "recovered_from_agent_id".to_string(),
+            Value::String(recovered_from_agent_id),
+        );
+    }
+
+    Some(Value::Object(lease))
 }
 
 pub(crate) fn session_resume_hint(status: &str, metadata: &Value) -> String {

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -15098,3 +15098,138 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
         "Identified result routing gap: parent session lacks last delegated outcome summary when descendant completes."
     );
 }
+
+#[tokio::test]
+async fn get_session_status_surfaces_goal_lease_metadata() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+
+    let session_id = Uuid::parse_str("55555555-5555-5555-5555-555555555555").unwrap();
+    let now = chrono::Utc::now();
+    let lease_expires_at = (now + chrono::Duration::minutes(30)).to_rfc3339();
+    let leased_at = now.to_rfc3339();
+    session_repo
+        .create(NewSession {
+            id: session_id,
+            kind: "subagent".into(),
+            status: "running".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: None,
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "goal_key": "issue-763/explain-why-this-session-is-running",
+                "goal_owner_agent_id": "architect-1",
+                "goal_lease_expires_at": lease_expires_at,
+                "goal_leased_at": leased_at,
+                "goal_lease_recovered_at": "2026-03-29T11:59:00Z",
+                "goal_lease_recovered_from_agent_id": "architect-0"
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let state = AppState {
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics: TokenMetricsStore::new(),
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["goal_lease"],
+        serde_json::json!({
+            "goal_key": "issue-763/explain-why-this-session-is-running",
+            "owner_agent_id": "architect-1",
+            "lease_expires_at": lease_expires_at,
+            "leased_at": leased_at,
+            "recovered_at": "2026-03-29T11:59:00Z",
+            "recovered_from_agent_id": "architect-0"
+        })
+    );
+}


### PR DESCRIPTION
## Summary
- add goal_lease to session status responses when lease metadata exists
- map goal lease fields from session metadata into a stable JSON object
- cover the new response shape with a route test

## Verification
- cargo check -p rune-gateway
- cargo test -p rune-gateway get_session_status_surfaces_goal_lease_metadata --test route_tests *(blocked by pre-existing route_tests compile failures on main unrelated to this diff)*

Refs #763