### PR TITLE
fix(gateway): preserve approval resume hints and document goal leases (#763)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -3687,13 +3687,13 @@ fn session_goal_lease(metadata: &Value) -> Option<Value> {
 }
 
 pub(crate) fn session_resume_hint(status: &str, metadata: &Value) -> String {
-    if let Some(hint) = metadata_string(metadata, "resume_hint") {
-        return hint;
-    }
     if status.eq_ignore_ascii_case("waiting_approval")
         || metadata_bool(metadata, "approval_pending").unwrap_or(false)
     {
         return "decide the pending approval, then resume the stored tool call".to_string();
+    }
+    if let Some(hint) = metadata_string(metadata, "resume_hint") {
+        return hint;
     }
     if metadata
         .get("hook_blocked")

--- a/docs/operator/session-status.md
+++ b/docs/operator/session-status.md
@@ -26,6 +26,25 @@ Current behavior:
 This closes an operator-visibility gap for approval pauses, delegated waits, preempted work, and
 explicitly cancelled delegated work.
 
+
+## Goal lease visibility on session status
+
+`GET /sessions/{id}/status` and session-tree payloads now expose `goal_lease` when a session carries durable orchestration lease metadata. This gives operators a compact control-plane snapshot without reading raw session metadata.
+
+`goal_lease` currently includes:
+
+- `goal_key` — the durable objective identifier
+- `owner_agent_id` — the agent/session currently holding the lease
+- `state` — `active` or `expired`, derived from `goal_lease_expires_at`
+- `leased_at` and `lease_expires_at` — lease timing for takeover/debug decisions
+- `recovered_at` and `recovered_from_agent_id` — present when ownership was recovered from a stale worker
+
+Operational guidance:
+
+- treat `state=expired` as audit information, not current ownership truth
+- use `goal_lease` together with `status_reason` / `next_task_reason` to distinguish an actively owned objective from a stuck or abandoned one
+- when recovery fields are present, the current owner already replaced a stale worker; use that history before manually reassigning work
+
 ## Lane queue visibility and priority routing
 
 `GET /status` exposes `lane_stats` so operators can verify that high-priority work is isolated from normal background contention. The payload includes independent utilisation/capacity counters for `main`, `priority`, `subagent`, `cron`, and `heartbeat`, plus global/per-project tool concurrency.


### PR DESCRIPTION
## Summary
- ensure approval-blocked sessions always return the approval resume hint even when stale metadata exists
- document the new goal_lease session-status surface for operators
- keep goal lease visibility aligned with the autonomy control-plane work in #763

## Testing
- cargo test -p rune-gateway get_session_status_surfaces_control_plane_explainability
- cargo test -p rune-gateway get_session_status_marks_expired_goal_leases
- cargo check