### PR TITLE
feat(gateway): explain task-picking audit reasons (#763)

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -3627,7 +3627,7 @@ pub(crate) fn session_next_task_reason(status: &str, metadata: &Value) -> String
     {
         return "resolve or disable the blocking hook before retrying the event".to_string();
     }
-    if let Some(reason) = metadata_string(metadata, "next_task_reason") {
+    if let Some(reason) = session_task_picking_reason(status, metadata) {
         return reason;
     }
     match status {
@@ -3641,6 +3641,40 @@ pub(crate) fn session_next_task_reason(status: &str, metadata: &Value) -> String
         }
         "cancelled" => "restart the session only if the task is still relevant".to_string(),
         _ => "inspect session metadata and transcript for the next action".to_string(),
+    }
+}
+
+fn session_task_picking_reason(status: &str, metadata: &Value) -> Option<String> {
+    if let Some(reason) = metadata_string(metadata, "next_task_reason") {
+        return Some(reason);
+    }
+
+    let deferred = metadata_string(metadata, "deferred_task_reason");
+    let picked = metadata_string(metadata, "task_pick_reason");
+    let constraint = metadata_string(metadata, "task_pick_constraint");
+
+    if deferred.is_none() && picked.is_none() && constraint.is_none() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    if let Some(picked) = picked {
+        parts.push(format!("picked next slice: {picked}"));
+    }
+    if let Some(constraint) = constraint {
+        parts.push(format!("winning constraint: {constraint}"));
+    }
+    if let Some(deferred) = deferred {
+        parts.push(format!("deferred work: {deferred}"));
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(match status {
+            "running" => format!("{}", parts.join("; ")),
+            _ => format!("{}", parts.join("; ")),
+        })
     }
 }
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -8814,6 +8814,130 @@ async fn get_session_status_surfaces_control_plane_explainability() {
 }
 
 #[tokio::test]
+async fn get_session_status_derives_task_picking_reason_from_audit_metadata() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("You are a test assistant.");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+
+    let session_id = Uuid::parse_str("55555555-5555-5555-5555-555555555555").unwrap();
+    let now = chrono::Utc::now();
+    session_repo
+        .create(NewSession {
+            id: session_id,
+            kind: "subagent".into(),
+            status: "running".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: None,
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "task_pick_reason": "continue issue #763 auditability slice",
+                "task_pick_constraint": "priority lane preempted background queue",
+                "deferred_task_reason": "docs follow-up waits until the active gateway patch lands"
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let state = AppState {
+        peer_health_alert_cache: rune_gateway::PeerHealthAlertCache::new(),
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics: TokenMetricsStore::new(),
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["next_task_reason"],
+        "picked next slice: continue issue #763 auditability slice; winning constraint: priority lane preempted background queue; deferred work: docs follow-up waits until the active gateway patch lands"
+    );
+}
+
+#[tokio::test]
 async fn get_dashboard_usage_reports_cached_tokens_and_cache_hit_ratio() {
     let session_repo = Arc::new(MemSessionRepo::new());
     let turn_repo = Arc::new(MemTurnRepo::new());

--- a/docs/operator/session-status.md
+++ b/docs/operator/session-status.md
@@ -27,6 +27,17 @@ This closes an operator-visibility gap for approval pauses, delegated waits, pre
 explicitly cancelled delegated work.
 
 
+Rune also derives `next_task_reason` from task-picking audit metadata when explicit text is not already stored.
+If session metadata includes any of the following keys, the status surface composes them into one operator-facing reason:
+
+- `task_pick_reason` — the slice Rune chose next
+- `task_pick_constraint` — the constraint or higher-priority signal that won
+- `deferred_task_reason` — work Rune intentionally postponed
+
+This gives operators a compact explanation of why a session kept its current lane, what won preemption,
+and what was deferred, without opening the raw metadata blob or transcript.
+
+
 ## Goal lease visibility on session status
 
 `GET /sessions/{id}/status` and session-tree payloads now expose `goal_lease` when a session carries durable orchestration lease metadata. This gives operators a compact control-plane snapshot without reading raw session metadata.


### PR DESCRIPTION
## Summary
- derive session status next-task explainability from task-picking audit metadata
- add gateway coverage for composed picked/constraint/deferred reasons
- document the operator-facing status behavior

## Testing
- cargo test -p rune-gateway get_session_status_derives_task_picking_reason_from_audit_metadata -- --nocapture
- cargo check
