### PR TITLE
feat: summarize descendant subagent audit results

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2449,10 +2449,14 @@ pub struct SessionAuditSummary {
     pub transcript_items: u32,
     pub status_notes: u32,
     pub subagent_results: u32,
+    pub descendant_sessions: u32,
+    pub descendant_subagent_results: u32,
     pub last_transcript_at: Option<String>,
     pub last_operator_note: Option<String>,
     pub last_subagent_result_at: Option<String>,
     pub last_subagent_result_excerpt: Option<String>,
+    pub last_descendant_result_at: Option<String>,
+    pub last_descendant_result_excerpt: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -2631,6 +2635,18 @@ pub async fn get_session_status(
         .iter()
         .filter(|item| item.kind == "subagent_result")
         .count() as u32;
+    let descendant_rows = if row.kind == "subagent" {
+        state
+            .session_repo
+            .list(500, 0)
+            .await
+            .map_err(|e| GatewayError::Internal(e.to_string()))?
+            .into_iter()
+            .filter(|candidate| candidate.requester_session_id == Some(row.id))
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
     let last_transcript_at = transcript_items
         .last()
         .map(|item| item.created_at.to_rfc3339());
@@ -2662,15 +2678,57 @@ pub async fn get_session_status(
                 format!("{truncated}…")
             }
         });
+    let descendant_sessions = descendant_rows.len() as u32;
+    let mut descendant_subagent_results = 0u32;
+    let mut last_descendant_result_at = None;
+    let mut last_descendant_result_excerpt = None;
+    for descendant in &descendant_rows {
+        let descendant_transcript_items = state
+            .transcript_repo
+            .list_by_session(descendant.id)
+            .await
+            .map_err(|e| GatewayError::Internal(e.to_string()))?;
+        descendant_subagent_results += descendant_transcript_items
+            .iter()
+            .filter(|item| item.kind == "subagent_result")
+            .count() as u32;
+        if last_descendant_result_at.is_none() {
+            if let Some(item) = descendant_transcript_items
+                .iter()
+                .rev()
+                .find(|item| item.kind == "subagent_result")
+            {
+                last_descendant_result_at = Some(item.created_at.to_rfc3339());
+                last_descendant_result_excerpt = item
+                    .payload
+                    .get("content")
+                    .or_else(|| item.payload.get("summary"))
+                    .and_then(|value| value.as_str())
+                    .map(|text| {
+                        const MAX_CHARS: usize = 200;
+                        if text.chars().count() <= MAX_CHARS {
+                            text.to_string()
+                        } else {
+                            let truncated: String = text.chars().take(MAX_CHARS).collect();
+                            format!("{truncated}…")
+                        }
+                    });
+            }
+        }
+    }
     let audit = if row.kind == "subagent" {
         Some(SessionAuditSummary {
             transcript_items: transcript_items.len() as u32,
             status_notes,
             subagent_results,
+            descendant_sessions,
+            descendant_subagent_results,
             last_transcript_at,
             last_operator_note,
             last_subagent_result_at,
             last_subagent_result_excerpt,
+            last_descendant_result_at,
+            last_descendant_result_excerpt,
         })
     } else {
         None

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -8535,8 +8535,12 @@ async fn get_session_status_surfaces_subagent_metadata() {
     );
     assert_eq!(json["audit"]["transcript_items"], 0);
     assert_eq!(json["audit"]["status_notes"], 0);
+    assert_eq!(json["audit"]["descendant_sessions"], 0);
+    assert_eq!(json["audit"]["descendant_subagent_results"], 0);
     assert_eq!(json["audit"]["last_transcript_at"], Value::Null);
     assert_eq!(json["audit"]["last_operator_note"], Value::Null);
+    assert_eq!(json["audit"]["last_descendant_result_at"], Value::Null);
+    assert_eq!(json["audit"]["last_descendant_result_excerpt"], Value::Null);
     let unresolved = json["unresolved"].as_array().unwrap();
     assert!(unresolved.iter().any(|item| item.as_str()
         == Some("cost posture is estimate-only; provider pricing is not wired yet")));
@@ -15265,6 +15269,10 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
     assert_eq!(json["audit"]["transcript_items"], 3);
     assert_eq!(json["audit"]["status_notes"], 1);
     assert_eq!(json["audit"]["subagent_results"], 1);
+    assert_eq!(json["audit"]["descendant_sessions"], 0);
+    assert_eq!(json["audit"]["descendant_subagent_results"], 0);
+    assert_eq!(json["audit"]["last_descendant_result_at"], Value::Null);
+    assert_eq!(json["audit"]["last_descendant_result_excerpt"], Value::Null);
     assert_eq!(
         json["audit"]["last_transcript_at"],
         "2026-03-29T12:04:00+00:00"
@@ -15280,6 +15288,174 @@ async fn session_status_route_surfaces_subagent_audit_summary() {
     assert_eq!(
         json["audit"]["last_subagent_result_excerpt"],
         "Identified result routing gap: parent session lacks last delegated outcome summary when descendant completes."
+    );
+}
+
+#[tokio::test]
+async fn session_status_route_summarizes_descendant_subagent_results() {
+    let session_repo = Arc::new(MemSessionRepo::new());
+    let turn_repo = Arc::new(MemTurnRepo::new());
+    let transcript_repo = Arc::new(MemTranscriptRepo::new());
+    let model_provider: Arc<dyn ModelProvider> = Arc::new(FakeModelProvider);
+    let scheduler = Arc::new(Scheduler::new());
+    let session_engine = Arc::new(
+        SessionEngine::new(session_repo.clone()).with_transcript_repo(transcript_repo.clone()),
+    );
+    let context_assembler = ContextAssembler::new("test");
+    let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
+    let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let approval_repo = Arc::new(MemApprovalRepo::new());
+    let turn_executor = Arc::new(
+        TurnExecutor::new(
+            session_repo.clone() as Arc<dyn SessionRepo>,
+            turn_repo.clone() as Arc<dyn TurnRepo>,
+            transcript_repo.clone() as Arc<dyn TranscriptRepo>,
+            approval_repo.clone() as Arc<dyn ApprovalRepo>,
+            model_provider.clone(),
+            tool_executor,
+            tool_registry,
+            context_assembler,
+            compaction,
+        )
+        .with_default_model("fake-model"),
+    );
+    let event_tx = test_event_sender().clone();
+    let skill_registry = Arc::new(SkillRegistry::new());
+    let skill_loader = Arc::new(SkillLoader::new(
+        std::env::temp_dir(),
+        skill_registry.clone(),
+    ));
+    let device_repo = Arc::new(MemDeviceRepo::new());
+    let device_registry = Arc::new(DeviceRegistry::new(device_repo.clone()));
+    let (plugin_registry, plugin_loader, hook_registry) = test_plugins();
+
+    let parent_id = Uuid::parse_str("88888888-8888-8888-8888-888888888888").unwrap();
+    let child_id = Uuid::parse_str("99999999-9999-9999-9999-999999999999").unwrap();
+    let now = chrono::Utc::now();
+    session_repo
+        .create(NewSession {
+            id: parent_id,
+            kind: "subagent".into(),
+            status: "running".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: Some(
+                Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            ),
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "subagent_lifecycle": "running"
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    session_repo
+        .create(NewSession {
+            id: child_id,
+            kind: "subagent".into(),
+            status: "completed".into(),
+            workspace_root: None,
+            channel_ref: None,
+            requester_session_id: Some(parent_id),
+            latest_turn_id: None,
+            runtime_profile: None,
+            policy_profile: None,
+            metadata: serde_json::json!({
+                "subagent_lifecycle": "completed"
+            }),
+            created_at: now,
+            updated_at: now,
+            last_activity_at: now,
+        })
+        .await
+        .unwrap();
+    transcript_repo
+        .append(NewTranscriptItem {
+            id: Uuid::now_v7(),
+            session_id: child_id,
+            turn_id: None,
+            seq: 0,
+            kind: "subagent_result".into(),
+            payload: serde_json::json!({
+                "summary": "Child delegate completed the missing audit aggregation slice for the parent session status card."
+            }),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-03-29T12:10:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        })
+        .await
+        .unwrap();
+
+    let state = AppState {
+        peer_health_alert_cache: rune_gateway::PeerHealthAlertCache::new(),
+        config: Arc::new(RwLock::new(AppConfig::default())),
+        started_at: Arc::new(Instant::now()),
+        session_engine,
+        turn_executor,
+        session_repo: session_repo as Arc<dyn SessionRepo>,
+        transcript_repo: transcript_repo as Arc<dyn TranscriptRepo>,
+        turn_repo: turn_repo as Arc<dyn TurnRepo>,
+        model_provider,
+        scheduler,
+        heartbeat: Arc::new(HeartbeatRunner::new(std::env::temp_dir())),
+        reminder_store: Arc::new(ReminderStore::new()),
+        approval_repo: approval_repo as Arc<dyn ApprovalRepo>,
+        tool_approval_repo: Arc::new(MemToolApprovalPolicyRepo::new())
+            as Arc<dyn ToolApprovalPolicyRepo>,
+        tool_execution_repo: Arc::new(InMemoryToolExecutionRepo::new())
+            as Arc<dyn ToolExecutionRepo>,
+        process_manager: ProcessManager::new(),
+        log_store: LogStore::new(1000),
+        capabilities: test_capabilities(0),
+        device_repo: device_repo.clone() as Arc<dyn DeviceRepo>,
+        device_registry,
+        skill_registry,
+        skill_loader,
+        plugin_registry,
+        plugin_loader,
+        hook_registry,
+        plugin_manager: None,
+        event_tx,
+        webchat_rate_limiter: Arc::new(WebChatRateLimiter::new(Duration::from_secs(10), 4)),
+        tts_engine: None,
+        stt_engine: None,
+        ms365_calendar_service: test_ms365_calendar_service(),
+        ms365_planner_service: test_ms365_planner_service(),
+        ms365_todo_service: test_ms365_todo_service(),
+        ms365_mail_service: test_ms365_mail_service(),
+        ms365_files_service: test_ms365_files_service(),
+        ms365_users_service: test_ms365_users_service(),
+        comms_client: None,
+        token_metrics: TokenMetricsStore::new(),
+    };
+
+    let app = build_router(state, None);
+    let response = app
+        .oneshot(
+            Request::get(format!("/sessions/{parent_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["audit"]["descendant_sessions"], 1);
+    assert_eq!(json["audit"]["descendant_subagent_results"], 1);
+    assert_eq!(
+        json["audit"]["last_descendant_result_at"],
+        "2026-03-29T12:10:00+00:00"
+    );
+    assert_eq!(
+        json["audit"]["last_descendant_result_excerpt"],
+        "Child delegate completed the missing audit aggregation slice for the parent session status card."
     );
 }
 


### PR DESCRIPTION
## Summary
- extend session status audit summaries with descendant session/result counts and latest delegated result metadata
- aggregate direct child subagent result excerpts so parent subagent status cards expose routed descendant outcomes
- add gateway tests covering empty descendant state and populated descendant result summaries

## Testing
- cargo test -p rune-gateway session_status_route_surfaces_subagent_audit_summary -- --nocapture
- cargo test -p rune-gateway session_status_route_summarizes_descendant_subagent_results -- --nocapture
- cargo check

Closes #763