### PR TITLE
feat(gateway): stream logs and diagnostics over ws

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -32,7 +32,7 @@ use rune_gateway::ms365::{
     GraphMs365CalendarService, GraphMs365FilesService, GraphMs365MailService,
     GraphMs365PlannerService, GraphMs365TodoService, GraphMs365UsersService,
 };
-use rune_gateway::{Services, init_logging, start};
+use rune_gateway::{Services, init_logging_with_store, start, LogStore};
 use rune_mcp::discovery::McpServerConfig as RuntimeMcpServerConfig;
 use rune_mcp::{McpManager, McpToolExecutor};
 use rune_models::{
@@ -139,7 +139,8 @@ async fn main() -> Result<ExitCode> {
     let resolved_mode = config.mode.resolve(&config);
     config.adjust_paths_for_mode(&resolved_mode);
 
-    init_logging(&config.logging);
+    let log_store = LogStore::new(1000);
+    init_logging_with_store(&config.logging, log_store.clone());
     emit_startup_banner(&config, &flags, &resolved_mode);
 
     // Auto-create missing directories in Standalone mode so that `rune` boots
@@ -158,7 +159,7 @@ async fn main() -> Result<ExitCode> {
         }
     }
 
-    let (services, _embedded_pg, session_loop) = build_services(config).await?;
+    let (services, _embedded_pg, session_loop) = build_services(config, log_store).await?;
     let handle = start(services).await.context("failed to start gateway")?;
 
     // Start the session loop (channel listener) if a channel is configured.
@@ -572,6 +573,7 @@ fn emit_startup_model_resolution(
 /// must be kept alive for the lifetime of the process.
 async fn build_services(
     config: AppConfig,
+    log_store: LogStore,
 ) -> Result<(Services, Option<EmbeddedPg>, Option<SessionLoop>)> {
     let (repos, storage_info, embedded_pg) = build_repos(&config)
         .await
@@ -910,6 +912,7 @@ async fn build_services(
         ms365_files_service: Arc::new(GraphMs365FilesService::new()),
         ms365_users_service: Arc::new(GraphMs365UsersService::new()),
         command_registry: Some(shared_command_registry.clone()),
+        log_store,
     };
 
     Ok((services, embedded_pg, session_loop))

--- a/crates/rune-gateway/src/lib.rs
+++ b/crates/rune-gateway/src/lib.rs
@@ -21,7 +21,7 @@ pub use events::{
     ApprovalEvent, ProcessEvent, RuntimeEvent, ToolEvent, TurnEvent, UsageSummary,
     broadcast_runtime_event,
 };
-pub use logging::init_logging;
+pub use logging::{init_logging, init_logging_with_store, LogStore};
 pub use routes::{DoctorCheck, parse_memory_search_output, storage_path_checks_for_tests};
 pub use server::{GatewayHandle, Services, build_router, start};
 pub use state::{

--- a/crates/rune-gateway/src/logging.rs
+++ b/crates/rune-gateway/src/logging.rs
@@ -2,7 +2,10 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use tokio::sync::{RwLock, broadcast};
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{
+    EnvFilter, Layer, fmt, layer::Context, layer::SubscriberExt, registry::LookupSpan,
+    util::SubscriberInitExt,
+};
 
 use rune_config::LoggingConfig;
 
@@ -60,6 +63,112 @@ pub fn init_logging(config: &LoggingConfig) {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.level));
 
     let registry = tracing_subscriber::registry().with(filter);
+
+    if config.json {
+        registry.with(fmt::layer().json()).init();
+    } else {
+        registry.with(fmt::layer()).init();
+    }
+}
+
+#[derive(Clone)]
+struct LogStoreLayer {
+    store: LogStore,
+}
+
+impl<S> Layer<S> for LogStoreLayer
+where
+    S: tracing::Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        use tracing::field::{Field, Visit};
+
+        struct Visitor {
+            message: Option<String>,
+            fields: serde_json::Map<String, serde_json::Value>,
+        }
+
+        impl Visit for Visitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                let rendered = format!("{value:?}");
+                if field.name() == "message" {
+                    self.message = Some(rendered.trim_matches('\"').to_string());
+                } else {
+                    self.fields.insert(
+                        field.name().to_string(),
+                        serde_json::Value::String(rendered),
+                    );
+                }
+            }
+
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.message = Some(value.to_string());
+                } else {
+                    self.fields.insert(
+                        field.name().to_string(),
+                        serde_json::Value::String(value.to_string()),
+                    );
+                }
+            }
+
+            fn record_bool(&mut self, field: &Field, value: bool) {
+                self.fields
+                    .insert(field.name().to_string(), serde_json::Value::Bool(value));
+            }
+
+            fn record_i64(&mut self, field: &Field, value: i64) {
+                self.fields.insert(
+                    field.name().to_string(),
+                    serde_json::Value::Number(value.into()),
+                );
+            }
+
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                self.fields.insert(
+                    field.name().to_string(),
+                    serde_json::Value::Number(value.into()),
+                );
+            }
+
+            fn record_f64(&mut self, field: &Field, value: f64) {
+                if let Some(number) = serde_json::Number::from_f64(value) {
+                    self.fields
+                        .insert(field.name().to_string(), serde_json::Value::Number(number));
+                }
+            }
+        }
+
+        let mut visitor = Visitor {
+            message: None,
+            fields: serde_json::Map::new(),
+        };
+        event.record(&mut visitor);
+
+        let entry = LogEntry {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            level: event.metadata().level().to_string(),
+            target: event.metadata().target().to_string(),
+            message: visitor
+                .message
+                .unwrap_or_else(|| event.metadata().name().to_string()),
+            fields: (!visitor.fields.is_empty()).then_some(visitor.fields),
+        };
+
+        let store = self.store.clone();
+        tokio::spawn(async move {
+            store.push(entry).await;
+        });
+    }
+}
+
+pub fn init_logging_with_store(config: &LoggingConfig, log_store: LogStore) {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.level));
+
+    let registry = tracing_subscriber::registry()
+        .with(filter)
+        .with(LogStoreLayer { store: log_store });
 
     if config.json {
         registry.with(fmt::layer().json()).init();

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -2992,8 +2992,8 @@ pub async fn get_session_tree(
             .get(&row.id)
             .cloned()
             .unwrap_or((None, None));
-        let subagent_lifecycle = metadata_string(&row.metadata, "subagent_lifecycle")
-            .or_else(|| {
+        let subagent_lifecycle =
+            metadata_string(&row.metadata, "subagent_lifecycle").or_else(|| {
                 if row.kind == "subagent" {
                     Some("created".to_string())
                 } else {
@@ -3009,7 +3009,11 @@ pub async fn get_session_tree(
                 }
             });
         let subagent_runtime_attached = metadata_bool(&row.metadata, "subagent_runtime_attached")
-            .or(if row.kind == "subagent" { Some(false) } else { None });
+            .or(if row.kind == "subagent" {
+                Some(false)
+            } else {
+                None
+            });
         SessionTreeNode {
             id: row.id.to_string(),
             kind: row.kind.clone(),
@@ -3677,9 +3681,12 @@ pub(crate) fn session_status_reason(status: &str, metadata: &Value, approval_mod
     if let Some(reason) = metadata_string(metadata, "hook_block_reason") {
         return format!("blocked by hook policy: {reason}");
     }
-    if let Some(reason) = metadata_string(metadata, "status_reason")
-        .or_else(|| metadata.pointer("/anti_thrash/stall_reason").and_then(|v| v.as_str()).map(str::to_string))
-    {
+    if let Some(reason) = metadata_string(metadata, "status_reason").or_else(|| {
+        metadata
+            .pointer("/anti_thrash/stall_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }) {
         return reason;
     }
     match status {
@@ -3776,14 +3783,8 @@ fn session_goal_lease(metadata: &Value) -> Option<Value> {
 
     let mut lease = Map::new();
     lease.insert("goal_key".to_string(), Value::String(goal_key));
-    lease.insert(
-        "owner_agent_id".to_string(),
-        Value::String(owner_agent_id),
-    );
-    lease.insert(
-        "state".to_string(),
-        Value::String(lease_state.to_string()),
-    );
+    lease.insert("owner_agent_id".to_string(), Value::String(owner_agent_id));
+    lease.insert("state".to_string(), Value::String(lease_state.to_string()));
 
     if let Some(lease_expires_at) = lease_expires_at {
         lease.insert(
@@ -3835,8 +3836,8 @@ pub(crate) fn session_resume_hint(status: &str, metadata: &Value) -> String {
 }
 
 fn session_to_dashboard_item(row: SessionRow) -> DashboardSessionItem {
-    let approval_mode = metadata_string(&row.metadata, "approval_mode")
-        .unwrap_or_else(|| "on-failure".to_string());
+    let approval_mode =
+        metadata_string(&row.metadata, "approval_mode").unwrap_or_else(|| "on-failure".to_string());
     DashboardSessionItem {
         id: row.id.to_string(),
         kind: row.kind,
@@ -3844,16 +3845,50 @@ fn session_to_dashboard_item(row: SessionRow) -> DashboardSessionItem {
         status_reason: session_status_reason(&row.status, &row.metadata, &approval_mode),
         next_task_reason: session_next_task_reason(&row.status, &row.metadata),
         mode: metadata_string(&row.metadata, "mode"),
-        stall_reason: metadata_string(&row.metadata, "stall_reason")
-            .or_else(|| row.metadata.pointer("/anti_thrash/stall_reason").and_then(|v| v.as_str()).map(str::to_string)),
-        operator_note: row.metadata.pointer("/anti_thrash/operator_note").and_then(|v| v.as_str()).map(str::to_string),
-        next_retry_at: row.metadata.pointer("/anti_thrash/next_retry_at").and_then(|v| v.as_str()).map(str::to_string),
-        retry_budget_exhausted: row.metadata.pointer("/anti_thrash/budget_exhausted").and_then(|v| v.as_bool()),
-        suppression_reason: row.metadata.pointer("/anti_thrash/suppression_reason").and_then(|v| v.as_str()).map(str::to_string),
-        last_error: row.metadata.pointer("/anti_thrash/last_error").and_then(|v| v.as_str()).map(str::to_string),
-        failure_fingerprint: row.metadata.pointer("/anti_thrash/failure_fingerprint").and_then(|v| v.as_str()).map(str::to_string),
-        objective_fingerprint: row.metadata.pointer("/anti_thrash/objective_fingerprint").and_then(|v| v.as_str()).map(str::to_string),
-        objective_snapshot: row.metadata.pointer("/anti_thrash/objective_snapshot").cloned(),
+        stall_reason: metadata_string(&row.metadata, "stall_reason").or_else(|| {
+            row.metadata
+                .pointer("/anti_thrash/stall_reason")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        }),
+        operator_note: row
+            .metadata
+            .pointer("/anti_thrash/operator_note")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        next_retry_at: row
+            .metadata
+            .pointer("/anti_thrash/next_retry_at")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        retry_budget_exhausted: row
+            .metadata
+            .pointer("/anti_thrash/budget_exhausted")
+            .and_then(|v| v.as_bool()),
+        suppression_reason: row
+            .metadata
+            .pointer("/anti_thrash/suppression_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        last_error: row
+            .metadata
+            .pointer("/anti_thrash/last_error")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        failure_fingerprint: row
+            .metadata
+            .pointer("/anti_thrash/failure_fingerprint")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        objective_fingerprint: row
+            .metadata
+            .pointer("/anti_thrash/objective_fingerprint")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        objective_snapshot: row
+            .metadata
+            .pointer("/anti_thrash/objective_snapshot")
+            .cloned(),
         routing_ref: row.channel_ref.clone(),
         channel_ref: row.channel_ref,
         created_at: row.created_at.to_rfc3339(),

--- a/crates/rune-gateway/src/server.rs
+++ b/crates/rune-gateway/src/server.rs
@@ -39,6 +39,7 @@ use crate::ms365::{
 };
 use crate::pairing::DeviceRegistry;
 use crate::routes;
+use crate::logging::LogStore;
 use crate::state::{AppState, SessionEvent, TokenMetricsStore};
 use crate::supervisor::{BackgroundSupervisor, SupervisorDeps};
 use crate::webchat;
@@ -93,6 +94,7 @@ pub struct Services {
     pub ms365_files_service: Arc<dyn Ms365FilesService>,
     pub ms365_users_service: Arc<dyn Ms365UsersService>,
     pub command_registry: Option<Arc<CommandRegistry>>,
+    pub log_store: LogStore,
 }
 
 /// Start the gateway HTTP server.
@@ -306,7 +308,7 @@ pub async fn start(services: Services) -> Result<GatewayHandle, GatewayError> {
         hook_registry,
         plugin_manager: Some(plugin_manager),
         event_tx,
-        log_store: crate::logging::LogStore::new(1000),
+        log_store: services.log_store,
         webchat_rate_limiter: Arc::new(crate::state::WebChatRateLimiter::new(
             Duration::from_secs(webchat_send_window_seconds),
             webchat_send_max_requests,
@@ -675,6 +677,7 @@ pub fn build_router(state: AppState, auth_token: Option<String>) -> Router {
         .route("/api/peers/alerts", get(routes::peer_health_alerts))
         .route("/api/dashboard/usage", get(routes::get_dashboard_usage))
         .route("/ws", get(ws::ws_handler))
+        .route("/ws/logs", get(ws::logs_ws_handler))
         // Channel routes
         .route("/api/channels", get(routes::list_channels))
         .route("/api/channels/status", get(routes::channels_status))

--- a/crates/rune-gateway/src/ws.rs
+++ b/crates/rune-gateway/src/ws.rs
@@ -109,6 +109,63 @@ struct EventFrame {
     state_version: u64,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LogsWsQuery {
+    pub source: Option<String>,
+}
+
+/// `GET /ws/logs` -- upgrade to WebSocket for live log streaming.
+pub async fn logs_ws_handler(
+    ws: WebSocketUpgrade,
+    Query(params): Query<LogsWsQuery>,
+    State(state): State<AppState>,
+) -> Response {
+    let rx = state.log_store.subscribe();
+    ws.on_upgrade(move |socket| handle_logs_socket(socket, rx, params.source))
+}
+
+async fn handle_logs_socket(
+    mut socket: WebSocket,
+    mut rx: broadcast::Receiver<crate::logging::LogEntry>,
+    source_filter: Option<String>,
+) {
+    let _connection_guard = ActiveConnectionGuard::new();
+    let source_filter = source_filter
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty());
+
+    loop {
+        tokio::select! {
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) => break,
+                }
+            }
+            entry = rx.recv() => {
+                match entry {
+                    Ok(entry) => {
+                        if let Some(source) = source_filter.as_deref()
+                            && !entry.target.to_ascii_lowercase().contains(source) {
+                            continue;
+                        }
+                        let payload = match serde_json::to_string(&entry) {
+                            Ok(s) => s,
+                            Err(_) => continue,
+                        };
+                        if socket.send(Message::Text(payload.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }
+    }
+}
+
 // ── Handler ──────────────────────────────────────────────────────────────────
 
 /// `GET /ws` -- upgrade to WebSocket for RPC and live event streaming.

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -725,7 +725,7 @@ impl RpcDispatcher {
             .map_err(|_| RpcError::not_found(format!("agent session {session_id} not found")))?;
 
         let now = chrono::Utc::now();
-            let parent_session_id = session
+        let parent_session_id = session
             .requester_session_id
             .map(|parent| parent.to_string());
         let note = format!("[steer] operator instruction injected: {message}");

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -5850,7 +5850,10 @@ async fn dashboard_sessions_includes_kind_activity_and_status_fields() {
     assert_eq!(items[0]["kind"], "channel");
     assert_eq!(items[0]["channel_ref"], "telegram:ops");
     assert_eq!(items[0]["status_reason"], "session status: ready");
-    assert_eq!(items[0]["next_task_reason"], "inspect session metadata and transcript for the next action");
+    assert_eq!(
+        items[0]["next_task_reason"],
+        "inspect session metadata and transcript for the next action"
+    );
     assert!(items[0]["last_activity_at"].is_string());
 }
 
@@ -5859,11 +5862,8 @@ async fn dashboard_sessions_surface_anti_thrash_stall_reason() {
     let now = Utc::now();
     let session_id = Uuid::now_v7();
     let session_repo = Arc::new(MemSessionRepo::new());
-    let (app, _device_repo) = build_test_app_parts_with_session_repo(
-        AppConfig::default(),
-        None,
-        session_repo.clone(),
-    );
+    let (app, _device_repo) =
+        build_test_app_parts_with_session_repo(AppConfig::default(), None, session_repo.clone());
 
     let session_repo: Arc<dyn SessionRepo> = session_repo;
 
@@ -8631,8 +8631,14 @@ async fn get_session_status_surfaces_subagent_metadata() {
     );
     assert_eq!(json["status"], "running");
     assert_eq!(json["status_reason"], "session actively processing work");
-    assert_eq!(json["next_task_reason"], "allow the active run to finish or steer it with a higher-priority task");
-    assert_eq!(json["resume_hint"], "session is already active; send steering only if priorities changed");
+    assert_eq!(
+        json["next_task_reason"],
+        "allow the active run to finish or steer it with a higher-priority task"
+    );
+    assert_eq!(
+        json["resume_hint"],
+        "session is already active; send steering only if priorities changed"
+    );
     assert_eq!(json["kind"], "subagent");
     assert_eq!(json["channel_ref"], Value::Null);
     assert_eq!(
@@ -8804,10 +8810,15 @@ async fn get_session_status_surfaces_orchestration_metadata() {
     );
     assert_eq!(json["delegation_depth"], 2);
     assert_eq!(json["status_reason"], "session actively processing work");
-    assert_eq!(json["next_task_reason"], "allow the active run to finish or steer it with a higher-priority task");
-    assert_eq!(json["resume_hint"], "session is already active; send steering only if priorities changed");
+    assert_eq!(
+        json["next_task_reason"],
+        "allow the active run to finish or steer it with a higher-priority task"
+    );
+    assert_eq!(
+        json["resume_hint"],
+        "session is already active; send steering only if priorities changed"
+    );
 }
-
 
 #[tokio::test]
 async fn get_session_status_surfaces_control_plane_explainability() {
@@ -8928,7 +8939,10 @@ async fn get_session_status_surfaces_control_plane_explainability() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let json = body_json(response).await;
-    assert_eq!(json["status_reason"], "waiting for operator approval (on-miss)");
+    assert_eq!(
+        json["status_reason"],
+        "waiting for operator approval (on-miss)"
+    );
     assert_eq!(
         json["next_task_reason"],
         "operator approval decision required before execution can continue"


### PR DESCRIPTION
## Summary
- expose gateway log store initialization to the app entrypoint and wire a shared in-memory log buffer into HTTP + WS surfaces
- add  and  websocket RPC methods plus live  broadcasts when sessions subscribe to log events
- extend gateway route coverage for log querying and diagnostics fallback behavior

## Testing
- cargo check
- cargo test -p rune-gateway route_tests -- --nocapture
- cargo test -p rune-gateway logs_query -- --nocapture
- cargo test -p rune-gateway dashboard_diagnostics -- --nocapture

Refs #754