### PR TITLE
docs(runtime): document dashboard anti-thrash fields (#754)

### DIFF
--- a/docs/operator/HEALTH-AND-DOCTOR.md
+++ b/docs/operator/HEALTH-AND-DOCTOR.md
@@ -60,3 +60,15 @@ Current semantics:
 This is the first operator-visible M10 anti-thrash foundation rather than the full final status surface. For now, operators can inspect persisted session metadata to distinguish a degraded-but-alive lane from one that is still actively shipping.
 
 - Anti-thrash metadata now persists objective fingerprints and objective snapshots for repeated-failure diagnosis across reloads/restarts.
+- `GET /api/dashboard/sessions` now lifts the anti-thrash fields into top-level operator-visible session diagnostics so dashboards do not need to parse raw metadata blobs.
+
+Dashboard session anti-thrash fields:
+- `stall_reason` — machine-readable/current operator-visible reason the lane is stalled or suppressed
+- `operator_note` — human-facing remediation hint for exhausted budget or active backoff
+- `next_retry_at` — retry release timestamp when backoff is still active
+- `retry_budget_exhausted` — whether the repeated-failure budget is terminally exhausted
+- `suppression_reason` — normalized suppression code such as `backoff_active` or `retry_budget_exhausted`
+- `last_error` — latest recorded failure string associated with the fingerprint
+- `failure_fingerprint` — normalized repeated-failure key
+- `objective_fingerprint` — normalized objective key for the work that keeps failing
+- `objective_snapshot` — structured objective summary captured when suppression was recorded

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -132,3 +132,4 @@ Operator-facing inspection helpers now exist at the state layer too:
 - both helpers intentionally exclude expired leases so operators and future gateway routes do not misread stale ownership as active execution
 
 - Retry budget state now stores both failure fingerprint and objective fingerprint/snapshot so operators can inspect which objective keeps re-failing after restart.
+- Gateway dashboard session responses project the anti-thrash state into first-class fields (`stall_reason`, `operator_note`, `next_retry_at`, `retry_budget_exhausted`, `suppression_reason`, `last_error`, `failure_fingerprint`, `objective_fingerprint`, `objective_snapshot`) so operator surfaces can explain degraded-but-alive lanes without raw metadata parsing.


### PR DESCRIPTION
## Summary\n- document the operator-visible anti-thrash fields exposed by \n- record the gateway projection behavior in the architecture reference\n\n## Testing\n- cargo test -p rune-gateway dashboard_sessions_surface_anti_thrash_stall_reason -- --exact\n- cargo check\n