### PR TITLE
feat(cli): expose plugin hook metadata (#875)

### DIFF
--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -6718,6 +6718,34 @@ impl GatewayClient {
                 description: v["description"].as_str().unwrap_or("").to_string(),
                 source: v["source"].as_str().unwrap_or("unknown").to_string(),
                 manifest_valid: v["manifest_valid"].as_bool().unwrap_or(true),
+                registered_commands: v["registered_commands"]
+                    .as_array()
+                    .map(|commands| {
+                        commands
+                            .iter()
+                            .map(|command| crate::output::PluginCommandSummary {
+                                name: command["name"].as_str().unwrap_or("?").to_string(),
+                                description: command["description"].as_str().unwrap_or("").to_string(),
+                                prompt_body: command["prompt_body"]
+                                    .as_str()
+                                    .unwrap_or("")
+                                    .to_string(),
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                hook_registrations: v["hook_registrations"]
+                    .as_array()
+                    .map(|hooks| {
+                        hooks
+                            .iter()
+                            .map(|hook| crate::output::PluginHookRegistrationSummary {
+                                event: hook["event"].as_str().unwrap_or("?").to_string(),
+                                order: hook["order"].as_u64().unwrap_or_default() as usize,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
         } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
             bail!("Plugin '{name}' not found.");
@@ -7254,5 +7282,62 @@ mod delegation_plan_parse_tests {
             "started_at"
         );
         assert_eq!(parsed.result.as_ref().unwrap().task_id_field, "task_id");
+    }
+}
+
+#[cfg(test)]
+mod plugin_lifecycle_tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn plugins_info_parses_registered_commands_and_hook_registrations() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/plugins/alpha"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "alpha",
+                "version": "1.2.3",
+                "enabled": true,
+                "description": "Alpha plugin",
+                "source": "/plugins/alpha",
+                "manifest_valid": true,
+                "registered_commands": [
+                    {
+                        "name": "alpha:deploy",
+                        "description": "Deploy alpha",
+                        "prompt_body": "deploy now"
+                    }
+                ],
+                "hook_registrations": [
+                    {
+                        "event": "pre_tool_call",
+                        "plugin": "alpha",
+                        "order": 0
+                    },
+                    {
+                        "event": "post_tool_call",
+                        "plugin": "alpha",
+                        "order": 1
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GatewayClient::new(&server.uri());
+        let response = client.plugins_info("alpha").await.unwrap();
+
+        assert_eq!(response.registered_commands.len(), 1);
+        assert_eq!(response.registered_commands[0].name, "alpha:deploy");
+        assert_eq!(response.registered_commands[0].description, "Deploy alpha");
+        assert_eq!(response.registered_commands[0].prompt_body, "deploy now");
+        assert_eq!(response.hook_registrations.len(), 2);
+        assert_eq!(response.hook_registrations[0].event, "pre_tool_call");
+        assert_eq!(response.hook_registrations[0].order, 0);
+        assert_eq!(response.hook_registrations[1].event, "post_tool_call");
+        assert_eq!(response.hook_registrations[1].order, 1);
     }
 }

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -9498,6 +9498,46 @@ mod subagent_output_tests {
         };
         assert!(render(&r, OutputFormat::Human).contains("m1"));
     }
+
+    #[test]
+    fn render_plugin_info_with_registered_commands_and_hooks() {
+        let r = PluginInfoResponse {
+            name: "alpha".into(),
+            version: "1.2.3".into(),
+            enabled: true,
+            description: "Alpha plugin".into(),
+            source: "/plugins/alpha".into(),
+            manifest_valid: true,
+            registered_commands: vec![
+                PluginCommandSummary {
+                    name: "alpha:deploy".into(),
+                    description: "Deploy alpha".into(),
+                    prompt_body: "deploy".into(),
+                },
+                PluginCommandSummary {
+                    name: "alpha:status".into(),
+                    description: "Show alpha status".into(),
+                    prompt_body: "status".into(),
+                },
+            ],
+            hook_registrations: vec![
+                PluginHookRegistrationSummary {
+                    event: "pre_tool_call".into(),
+                    order: 0,
+                },
+                PluginHookRegistrationSummary {
+                    event: "post_tool_call".into(),
+                    order: 1,
+                },
+            ],
+        };
+        let out = render(&r, OutputFormat::Human);
+        assert!(out.contains("Registered commands (2):"));
+        assert!(out.contains("alpha:deploy — Deploy alpha"));
+        assert!(out.contains("Hook registrations (2):"));
+        assert!(out.contains("pre_tool_call @ order 0"));
+        assert!(out.contains("post_tool_call @ order 1"));
+    }
 }
 
 /// Response for `rune plugins list`.
@@ -9541,6 +9581,19 @@ impl fmt::Display for PluginListResponse {
 
 /// Response for `rune plugins info`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginCommandSummary {
+    pub name: String,
+    pub description: String,
+    pub prompt_body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginHookRegistrationSummary {
+    pub event: String,
+    pub order: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginInfoResponse {
     pub name: String,
     pub version: String,
@@ -9548,6 +9601,8 @@ pub struct PluginInfoResponse {
     pub description: String,
     pub source: String,
     pub manifest_valid: bool,
+    pub registered_commands: Vec<PluginCommandSummary>,
+    pub hook_registrations: Vec<PluginHookRegistrationSummary>,
 }
 
 impl fmt::Display for PluginInfoResponse {
@@ -9565,7 +9620,26 @@ impl fmt::Display for PluginInfoResponse {
                 "invalid"
             }
         )?;
-        write!(f, "  {}", self.description)
+        writeln!(f, "  Description: {}", self.description)?;
+
+        if self.registered_commands.is_empty() {
+            writeln!(f, "  Registered commands: none")?;
+        } else {
+            writeln!(f, "  Registered commands ({}):", self.registered_commands.len())?;
+            for command in &self.registered_commands {
+                writeln!(f, "    - {} — {}", command.name, command.description)?;
+            }
+        }
+
+        if self.hook_registrations.is_empty() {
+            write!(f, "  Hook registrations: none")
+        } else {
+            writeln!(f, "  Hook registrations ({}):", self.hook_registrations.len())?;
+            for hook in &self.hook_registrations {
+                writeln!(f, "    - {} @ order {}", hook.event, hook.order)?;
+            }
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- preserve plugin  and  in the CLI gateway client
- render plugin command and hook registration metadata in 
- add CLI tests for gateway parsing and human-readable output

## Testing
- cargo check
- cargo test -p rune-cli plugin_info
- cargo test -p rune-cli plugins_info_parses_registered_commands_and_hook_registrations