### PR TITLE
fix(cli): remove stale hook mutation commands

### DIFF
--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -1134,31 +1134,6 @@ pub enum HooksAction {
     },
     /// Validate hook configuration and report issues.
     Check,
-    /// Enable a configured hook.
-    Enable {
-        /// Hook name.
-        name: String,
-    },
-    /// Disable a configured hook.
-    Disable {
-        /// Hook name.
-        name: String,
-    },
-    /// Install a hook from a path or URL.
-    Install {
-        /// Hook source (local path or URL).
-        source: String,
-    },
-    /// Update an installed hook.
-    Update {
-        /// Hook name.
-        name: String,
-    },
-    /// Run diagnostic checks on a hook.
-    Doctor {
-        /// Hook name.
-        name: String,
-    },
 }
 
 #[derive(Debug, Clone, Args)]
@@ -2631,17 +2606,6 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
-    }
-
-    #[test]
-    fn parse_hooks_doctor() {
-        let cli = Cli::try_parse_from(["rune", "hooks", "doctor", "preflight"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Hooks {
-                action: HooksAction::Doctor { name }
-            } if name == "preflight"
-        ));
     }
 
     #[test]

--- a/crates/rune-cli/src/client.rs
+++ b/crates/rune-cli/src/client.rs
@@ -6892,34 +6892,6 @@ impl GatewayClient {
         }
     }
 
-    /// `POST /hooks/:action` — hook lifecycle mutation.
-    pub async fn hooks_mutate(
-        &self,
-        action: &str,
-        name_or_source: &str,
-    ) -> Result<crate::output::HookMutationResponse> {
-        let resp = self
-            .http
-            .post(self.url(&format!("/hooks/{action}")))
-            .json(&serde_json::json!({"name": name_or_source}))
-            .send()
-            .await
-            .context("failed to reach gateway")?;
-        if resp.status().is_success() {
-            let v: serde_json::Value = resp
-                .json()
-                .await
-                .context("invalid JSON from POST /hooks/:action")?;
-            Ok(crate::output::HookMutationResponse {
-                success: v["success"].as_bool().unwrap_or(true),
-                hook: v["hook"].as_str().unwrap_or(name_or_source).to_string(),
-                action: action.to_string(),
-                detail: v["detail"].as_str().unwrap_or("done").to_string(),
-            })
-        } else {
-            bail!("Gateway returned HTTP {}", resp.status());
-        }
-    }
 }
 
 fn parse_instance_load(value: &serde_json::Value) -> Option<InstanceLoadSummary> {
@@ -7323,27 +7295,6 @@ mod plugin_lifecycle_tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[tokio::test]
-    async fn hooks_doctor_posts_and_parses_response() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/hooks/doctor"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "success": true,
-                "hook": "preflight",
-                "detail": "hook manifest and handler wiring look healthy"
-            })))
-            .mount(&server)
-            .await;
-
-        let client = GatewayClient::new(&server.uri());
-        let response = client.hooks_mutate("doctor", "preflight").await.unwrap();
-
-        assert!(response.success);
-        assert_eq!(response.hook, "preflight");
-        assert_eq!(response.action, "doctor");
-        assert_eq!(response.detail, "hook manifest and handler wiring look healthy");
-    }
 
     #[tokio::test]
     async fn plugins_info_parses_registered_commands_and_hook_registrations() {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -3877,26 +3877,6 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let result = client.hooks_check().await?;
                 println!("{}", render(&result, format));
             }
-            HooksAction::Enable { name } => {
-                let result = client.hooks_mutate("enable", &name).await?;
-                println!("{}", render(&result, format));
-            }
-            HooksAction::Disable { name } => {
-                let result = client.hooks_mutate("disable", &name).await?;
-                println!("{}", render(&result, format));
-            }
-            HooksAction::Install { source } => {
-                let result = client.hooks_mutate("install", &source).await?;
-                println!("{}", render(&result, format));
-            }
-            HooksAction::Update { name } => {
-                let result = client.hooks_mutate("update", &name).await?;
-                println!("{}", render(&result, format));
-            }
-            HooksAction::Doctor { name } => {
-                let result = client.hooks_mutate("doctor", &name).await?;
-                println!("{}", render(&result, format));
-            }
         },
 
         Command::Backup { action } => match action {

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -9772,22 +9772,6 @@ impl fmt::Display for HookCheckResponse {
     }
 }
 
-/// Response for hook lifecycle mutations (enable/disable/install/update/doctor).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HookMutationResponse {
-    pub success: bool,
-    pub hook: String,
-    pub action: String,
-    pub detail: String,
-}
-
-impl fmt::Display for HookMutationResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let icon = if self.success { "✓" } else { "✗" };
-        writeln!(f, "{icon} Hook '{}' — {}", self.hook, self.action)?;
-        write!(f, "  {}", self.detail)
-    }
-}
 
 #[cfg(test)]
 mod plugin_reload_output_tests {


### PR DESCRIPTION
## Summary
- remove unsupported `rune hooks` mutation subcommands
- drop the unused hook mutation client/helper response types
- delete stale tests covering nonexistent hook lifecycle endpoints

## Testing
- cargo check

Closes #881