### PR TITLE
feat(cli): add rust-pattern validate command (#884)

### DIFF
--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -10,6 +10,7 @@ rune-core = { path = "../rune-core" }
 rune-config = { path = "../rune-config" }
 rune-mcp = { path = "../rune-mcp" }
 rune-runtime = { path = "../rune-runtime" }
+rune-spells-rust-patterns = { path = "../rune-spells/rust-patterns" }
 anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/crates/rune-cli/src/cli.rs
+++ b/crates/rune-cli/src/cli.rs
@@ -129,6 +129,11 @@ pub enum Command {
         #[command(subcommand)]
         action: MemoryAction,
     },
+    /// Query Rust patterns guidance and validate Rust code for common anti-patterns.
+    RustPattern {
+        #[command(subcommand)]
+        action: RustPatternAction,
+    },
     /// Emit system events and inspect heartbeat presence.
     System {
         #[command(subcommand)]
@@ -1726,6 +1731,16 @@ pub enum MemoryAction {
 }
 
 #[derive(Debug, Subcommand)]
+pub enum RustPatternAction {
+    /// Scan Rust files for common anti-patterns from the rust-patterns spell.
+    Validate {
+        /// Optional workspace-relative directory or Rust file path to validate.
+        #[arg(long)]
+        path: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 pub enum SystemAction {
     /// Inject, schedule, and list system events.
     Event {
@@ -3121,6 +3136,26 @@ mod tests {
                 assert_eq!(path, "memory/2026-03-13.md");
                 assert_eq!(from, 10);
                 assert_eq!(lines, Some(5));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rust_pattern_validate() {
+        let cli = Cli::try_parse_from([
+            "rune",
+            "rust-pattern",
+            "validate",
+            "--path",
+            "crates",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::RustPattern {
+                action: RustPatternAction::Validate { path },
+            } => {
+                assert_eq!(path.as_deref(), Some("crates"));
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -35,6 +35,7 @@ use cli::{
     CompletionAction, CompletionShell, ConfigAction, CronAction, CronDeliveryMode, DoctorAction,
     GatewayAction, GatewayConfigAction, GatewayRuntimeAction, GatewayRuntimeHeartbeatAction,
     HooksAction, LogsAction, LogsArgs, MemoryAction, MessageAction, MessageTagAction,
+    RustPatternAction,
     MessageThreadAction, MessageVoiceAction, ModelsAction, Ms365Action, Ms365AuthAction,
     Ms365CalendarAction, Ms365FilesAction, Ms365MailAction, Ms365PlannerAction, Ms365SitesAction,
     Ms365TeamsAction, Ms365TodoAction, Ms365UsersAction, PluginsAction, ProcessAction,
@@ -52,7 +53,8 @@ use output::{
     ModelAliasDetail, ModelAliasesResponse, ModelAuthProviderDetail, ModelAuthResponse,
     ModelFallbackChainDetail, ModelFallbacksResponse, ModelListResponse, ModelProviderDetail,
     ModelScanResponse, ModelSetImageResponse, ModelSetResponse, ModelStatusResponse, OutputFormat,
-    SpellSearchResponse, TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
+    RustPatternValidateFinding, RustPatternValidateResponse, SpellSearchResponse,
+    TemplateListResponse, TemplateStartResponse, TemplateSummary, render,
 };
 use service::{ServiceInstallOptions, install_service_definition, print_service_definition};
 
@@ -3249,6 +3251,29 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
             MemoryAction::Get { path, from, lines } => {
                 let result = memory::get(&path, from, lines).await?;
+                println!("{}", render(&result, format));
+            }
+        },
+        Command::RustPattern { action } => match action {
+            RustPatternAction::Validate { path } => {
+                let root = path
+                    .as_deref()
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
+                let report = rune_spells_rust_patterns::validate_rune_codebase(&root);
+                let result = RustPatternValidateResponse {
+                    scanned_files: report.scanned_files,
+                    findings: report
+                        .findings
+                        .into_iter()
+                        .map(|finding| RustPatternValidateFinding {
+                            file: finding.file,
+                            line: finding.line,
+                            issue: finding.issue,
+                            recommendation: finding.recommendation,
+                        })
+                        .collect(),
+                };
                 println!("{}", render(&result, format));
             }
         },

--- a/crates/rune-cli/src/output.rs
+++ b/crates/rune-cli/src/output.rs
@@ -2913,6 +2913,20 @@ pub struct MemoryGetResponse {
     pub content: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RustPatternValidateFinding {
+    pub file: String,
+    pub line: usize,
+    pub issue: String,
+    pub recommendation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RustPatternValidateResponse {
+    pub scanned_files: usize,
+    pub findings: Vec<RustPatternValidateFinding>,
+}
+
 impl fmt::Display for MemoryGetResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
@@ -2921,6 +2935,26 @@ impl fmt::Display for MemoryGetResponse {
             self.path, self.from, self.lines
         )?;
         write!(f, "{}", self.content)
+    }
+}
+
+impl fmt::Display for RustPatternValidateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Scanned Rust files: {}", self.scanned_files)?;
+        if self.findings.is_empty() {
+            write!(f, "No anti-pattern findings.")
+        } else {
+            writeln!(f, "Findings: {}", self.findings.len())?;
+            for (idx, finding) in self.findings.iter().enumerate() {
+                if idx > 0 {
+                    writeln!(f)?;
+                }
+                writeln!(f, "{}:{}", finding.file, finding.line)?;
+                writeln!(f, "Issue: {}", finding.issue)?;
+                write!(f, "Recommendation: {}", finding.recommendation)?;
+            }
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a top-level `rune rust-pattern validate` CLI command
- expose validation output in human/json formats
- add CLI parsing coverage for the new subcommand

## Verification
- `cargo test -p rune-cli parse_rust_pattern_validate -- --nocapture`
- `cargo test -p rune-cli parse_memory_get -- --nocapture`
- `cargo check`
- `cargo run -p rune-cli-app -- rust-pattern validate --path crates/rune-cli/src`
