### PR TITLE
fix(runtime): recover clippy failure after #885 (#884)

### DIFF
--- a/crates/rune-runtime/src/executor.rs
+++ b/crates/rune-runtime/src/executor.rs
@@ -919,7 +919,7 @@ impl TurnExecutor {
                 skill_prompt_fragment.into_iter().collect();
             extra_system_sections.extend(
                 self.context_assembler
-                    .session_metadata_sections(session_kind.clone(), &session.metadata),
+                    .session_metadata_sections(session_kind, &session.metadata),
             );
 
             // Inject recalled mem0 memories into the system prompt


### PR DESCRIPTION
## Summary
- recover the failed CI state introduced when #885 merged before checks were green
- fix the clippy failure in rune-runtime blocking the #884 lane
- keep recovery scoped to the minimal CI fallout only

## Verification
- cargo check
- cargo test -p rune-cli rust_pattern -- --nocapture
- cargo clippy --workspace --all-targets --all-features -- -D warnings *(currently still blocked by pre-existing warnings outside this recovery diff; see PR notes)*
