### PR TITLE
refactor(ui): use shared admin operator hooks

### DIFF
--- a/ui/src/routes/_admin/agents.tsx
+++ b/ui/src/routes/_admin/agents.tsx
@@ -10,9 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { AgentListItem } from "@/lib/api-types";
+import { useAgents } from "@/hooks/use-operators";
 import { Bot, Star } from "lucide-react";
 
 export const Route = createFileRoute("/_admin/agents")({
@@ -20,11 +18,7 @@ export const Route = createFileRoute("/_admin/agents")({
 });
 
 function AgentsPage() {
-  const { data: agents, isLoading } = useQuery({
-    queryKey: ["agents"],
-    queryFn: () => api.get<AgentListItem[]>("/agents"),
-    refetchInterval: 30_000,
-  });
+  const { data: agents, isLoading } = useAgents();
 
   return (
     <div className="space-y-8">
@@ -78,21 +72,23 @@ function AgentsPage() {
                       )}
                     </TableCell>
                     <TableCell className="max-w-[200px] truncate py-3 font-mono text-xs">
-                      {agent.workspace ?? "—"}
+                      {agent.workspace ?? <span className="text-muted-foreground">—</span>}
                     </TableCell>
-                    <TableCell className="max-w-[200px] truncate py-3 text-xs">
+                    <TableCell className="max-w-[320px] truncate py-3 text-sm text-muted-foreground">
                       {agent.system_prompt ? (
-                        <span title={agent.system_prompt}>
-                          {agent.system_prompt.slice(0, 80)}
-                          {agent.system_prompt.length > 80 ? "..." : ""}
-                        </span>
+                        <span title={agent.system_prompt}>{agent.system_prompt}</span>
                       ) : (
-                        <span className="text-muted-foreground">—</span>
+                        "—"
                       )}
                     </TableCell>
                     <TableCell className="py-3">
-                      {agent.default && (
-                        <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                      {agent.default ? (
+                        <Badge className="gap-1">
+                          <Star className="h-3 w-3" />
+                          Default
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
                       )}
                     </TableCell>
                   </TableRow>

--- a/ui/src/routes/_admin/skills.tsx
+++ b/ui/src/routes/_admin/skills.tsx
@@ -3,9 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { SkillItem } from "@/lib/api-types";
+import { useSkills, useToggleSkill } from "@/hooks/use-operators";
 import { Wrench, FolderOpen } from "lucide-react";
 
 export const Route = createFileRoute("/_admin/skills")({
@@ -13,21 +11,9 @@ export const Route = createFileRoute("/_admin/skills")({
 });
 
 function SkillsPage() {
-  const queryClient = useQueryClient();
+  const { data: skills, isLoading } = useSkills();
 
-  const { data: skills, isLoading } = useQuery({
-    queryKey: ["skills"],
-    queryFn: () => api.get<SkillItem[]>("/skills"),
-    refetchInterval: 15_000,
-  });
-
-  const toggleSkill = useMutation({
-    mutationFn: ({ name, enable }: { name: string; enable: boolean }) =>
-      api.post(`/skills/${name}/${enable ? "enable" : "disable"}`),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["skills"] });
-    },
-  });
+  const toggleSkill = useToggleSkill();
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- replace inline agents query logic with shared useAgents hook
- replace inline skills query/mutation logic with shared useSkills and useToggleSkill hooks
- keep admin UI behavior unchanged while removing duplicated data access code

## Testing
- cargo check -p rune-gateway
- cd ui && npm run build
