### PR TITLE
docs(contributor): clarify required merge gates (#889)

### DIFF
--- a/docs/contributor/EXECUTION-SPEED-POLICY.md
+++ b/docs/contributor/EXECUTION-SPEED-POLICY.md
@@ -70,15 +70,17 @@ Do not run the whole universe on every tiny local change if targeted validation 
 
 ## Merge rule
 
-If the active PR is:
-- green
-- mergeable
+If the active PR has:
+- all required CI jobs green
+- mergeable status
 
 then:
 1. merge immediately
 2. sync `main` immediately
 3. create the next batch immediately
 4. continue immediately
+
+For Rune, required means the enforced merge gates for that PR are actually passing. If both `check-and-lint` and `test` are required, do not merge on a partial green state.
 
 Do not stop at a status checkpoint when the next safe execution step is obvious.
 

--- a/docs/contributor/WORKFLOW.md
+++ b/docs/contributor/WORKFLOW.md
@@ -8,7 +8,7 @@ Rune currently uses a batch-branch workflow model:
 - one active coding branch
 - one active PR
 - one coherent milestone batch
-- immediate merge when green and mergeable
+- immediate merge only after the required CI gates are green and the PR is mergeable
 
 ## Current canonical references
 


### PR DESCRIPTION
## Summary
- clarify contributor workflow docs to require all enforced CI gates before merging
- spell out that Rune must wait for both check-and-lint and test when both are required

## Testing
- cargo check