### PR TITLE
docs(repo): codify enforced merge gates in agents guide (#889)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 4. Open a PR with clear title and body referencing the issue
 5. Ensure `cargo check` and `cargo clippy` pass
 6. Squash merge to main
+   - Merge only after all enforced CI jobs for that PR are green (for Rune: `check-and-lint` and `test`)
 7. Delete the branch after merge
 8. Update/close the GitHub issue
 


### PR DESCRIPTION
## Summary
- add the reset-lane merge gate rule to AGENTS.md
- require Rune PRs to wait for both enforced CI jobs before merge

Closes #889