### PR TITLE
fix(gateway): mark readiness evidence as pending

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -7818,7 +7818,7 @@ async fn doctor_memory_hierarchy(
             l3_cold_storage_enabled,
             last_checkpoint_at.as_deref().unwrap_or("never")
         ),
-        readiness_status: Some("blocked".to_string()),
+        readiness_status: Some("slo_defined_evidence_pending".to_string()),
         readiness_summary: Some(doctor_readiness_summary()),
         last_checkpoint_at,
         prompt_cache_rows: prompt_cache_rows.len() as u64,
@@ -8248,7 +8248,7 @@ pub async fn doctor_run(State(state): State<AppState>) -> Result<Json<DoctorRepo
 
     Ok(Json(DoctorReport {
         overall,
-        readiness_status: Some("blocked".to_string()),
+        readiness_status: Some("slo_defined_evidence_pending".to_string()),
         readiness_summary: Some(readiness_summary),
         checks,
         paths: paths_summary,

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -13614,7 +13614,7 @@ async fn doctor_run_reports_memory_hierarchy_summary() {
 }
 
 #[tokio::test]
-async fn doctor_run_surfaces_readiness_slos_and_blocker_status() {
+async fn doctor_run_surfaces_readiness_slos_and_pending_evidence_status() {
     let mut config = AppConfig::default();
     config.gateway.auth_token = Some("secret-token".into());
 
@@ -13632,7 +13632,7 @@ async fn doctor_run_surfaces_readiness_slos_and_blocker_status() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
 
-    assert_eq!(body["readiness_status"], "blocked");
+    assert_eq!(body["readiness_status"], "slo_defined_evidence_pending");
     assert!(body["readiness_summary"]
         .as_str()
         .unwrap()
@@ -13649,7 +13649,7 @@ async fn doctor_run_surfaces_readiness_slos_and_blocker_status() {
         .as_str()
         .unwrap()
         .contains("recovery_time<= 60s"));
-    assert_eq!(body["memory_hierarchy"]["readiness_status"], "blocked");
+    assert_eq!(body["memory_hierarchy"]["readiness_status"], "slo_defined_evidence_pending");
 
     let checks = body["checks"].as_array().unwrap();
     assert!(checks.iter().any(|check| {


### PR DESCRIPTION
## Summary
- replace generic readiness blocker status with an explicit pending-evidence status
- keep doctor/readiness summaries aligned with issue #905 SLO language
- rename the gateway test to match the new readiness semantics

## Testing
- cargo test -p rune-gateway doctor_run_surfaces_readiness_slos_and_pending_evidence_status -- --exact
- cargo check
