### PR TITLE
feat(runtime): expose per-project tool lane stats

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -21,7 +21,7 @@ use rune_runtime::scheduler::{
     Job, JobPayload, JobRun, JobRunStatus, JobUpdate, Reminder, ReminderStatus, Schedule,
     SessionTarget, compute_initial_next_run,
 };
-use rune_runtime::{LaneStats, Skill, SkillScanSummary};
+use rune_runtime::{LaneStats, ProjectToolStats, Skill, SkillScanSummary};
 use rune_store::models::{SessionRow, TurnRow};
 use rune_tools::memory_tool::MemoryToolExecutor;
 use rune_tools::process_tool::{PersistedProcessInfo, ProcessInfo};
@@ -993,6 +993,7 @@ pub struct StatusPaths {
 
 #[derive(Serialize)]
 pub struct LaneStatsResponse {
+    pub tool_projects: std::collections::BTreeMap<String, ProjectToolStatsResponse>,
     pub main_active: usize,
     pub main_available: usize,
     pub main_capacity: usize,
@@ -1018,6 +1019,14 @@ pub struct LaneStatsResponse {
     pub tool_capacity: usize,
     pub tool_queued: usize,
     pub project_tool_capacity: usize,
+}
+
+#[derive(Serialize)]
+pub struct ProjectToolStatsResponse {
+    pub active: usize,
+    pub available: usize,
+    pub capacity: usize,
+    pub queued: usize,
 }
 
 #[derive(Serialize)]
@@ -4148,6 +4157,11 @@ fn session_to_dashboard_item(row: SessionRow) -> DashboardSessionItem {
 
 fn lane_stats_response(stats: LaneStats) -> LaneStatsResponse {
     LaneStatsResponse {
+        tool_projects: stats
+            .tool_project_stats
+            .into_iter()
+            .map(|(project, stats)| (project, project_tool_stats_response(stats)))
+            .collect(),
         main_active: stats.main_active,
         main_available: stats.main_available,
         main_capacity: stats.main_capacity,
@@ -4173,6 +4187,15 @@ fn lane_stats_response(stats: LaneStats) -> LaneStatsResponse {
         tool_capacity: stats.tool_capacity,
         tool_queued: stats.tool_queued,
         project_tool_capacity: stats.project_tool_capacity,
+    }
+}
+
+fn project_tool_stats_response(stats: ProjectToolStats) -> ProjectToolStatsResponse {
+    ProjectToolStatsResponse {
+        active: stats.active,
+        available: stats.available,
+        capacity: stats.capacity,
+        queued: stats.queued,
     }
 }
 

--- a/crates/rune-gateway/src/ws_rpc.rs
+++ b/crates/rune-gateway/src/ws_rpc.rs
@@ -1014,6 +1014,7 @@ impl RpcDispatcher {
                     "capacity": stats.tool_capacity,
                     "queued": stats.tool_queued,
                     "per_project_capacity": stats.project_tool_capacity,
+                    "projects": stats.tool_project_stats,
                 },
             })
         });
@@ -1668,22 +1669,29 @@ impl RpcDispatcher {
                 "main_active": stats.main_active,
                 "main_available": stats.main_available,
                 "main_capacity": stats.main_capacity,
+                "main_queued": stats.main_queued,
                 "priority_active": stats.priority_active,
                 "priority_available": stats.priority_available,
                 "priority_capacity": stats.priority_capacity,
+                "priority_queued": stats.priority_queued,
                 "subagent_active": stats.subagent_active,
                 "subagent_available": stats.subagent_available,
                 "subagent_capacity": stats.subagent_capacity,
+                "subagent_queued": stats.subagent_queued,
                 "cron_active": stats.cron_active,
                 "cron_available": stats.cron_available,
                 "cron_capacity": stats.cron_capacity,
+                "cron_queued": stats.cron_queued,
                 "heartbeat_active": stats.heartbeat_active,
                 "heartbeat_available": stats.heartbeat_available,
                 "heartbeat_capacity": stats.heartbeat_capacity,
+                "heartbeat_queued": stats.heartbeat_queued,
                 "tool_active": stats.tool_active,
                 "tool_available": stats.tool_available,
                 "tool_capacity": stats.tool_capacity,
+                "tool_queued": stats.tool_queued,
                 "project_tool_capacity": stats.project_tool_capacity,
+                "tool_projects": stats.tool_project_stats,
             })
         });
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1929,10 +1929,10 @@ async fn ws_rpc_status_matches_http_status_basics() {
     assert_eq!(payload["lane_stats"]["heartbeat_queued"], 0);
     assert_eq!(payload["lane_stats"]["tool_active"], 0);
     assert_eq!(payload["lane_stats"]["tool_available"], 32);
-    assert_eq!(payload["lane_stats"]["tool_available"], 32);
     assert_eq!(payload["lane_stats"]["tool_capacity"], 32);
     assert_eq!(payload["lane_stats"]["tool_queued"], 0);
     assert_eq!(payload["lane_stats"]["project_tool_capacity"], 4);
+    assert!(payload["lane_stats"]["tool_projects"].as_object().unwrap().is_empty());
 
     drop(main_permit);
 }
@@ -2087,7 +2087,7 @@ async fn status_reports_configured_lane_capacities() {
     let compaction: Arc<dyn CompactionStrategy> = Arc::new(NoOpCompaction);
     let tool_executor: Arc<dyn ToolExecutor> = Arc::new(FakeToolExecutor);
     let tool_registry = Arc::new(ToolRegistry::new());
-    let lane_queue = Arc::new(rune_runtime::LaneQueue::with_capacities(6, 9, 128));
+    let lane_queue = Arc::new(rune_runtime::LaneQueue::with_all_limits(6, 3, 9, 128, 1024, 32, 4));
     let turn_executor = Arc::new(
         TurnExecutor::new(
             session_repo.clone() as Arc<dyn SessionRepo>,
@@ -2113,7 +2113,7 @@ async fn status_reports_configured_lane_capacities() {
     let mut config = AppConfig::default();
     config.runtime.lanes = LaneQueueConfig {
         main_capacity: 6,
-        priority_capacity: 16,
+        priority_capacity: 3,
         subagent_capacity: 9,
         cron_capacity: 128,
         heartbeat_capacity: 1024,
@@ -2323,6 +2323,10 @@ async fn ws_rpc_runtime_lanes_reports_lane_queue_stats() {
     assert_eq!(payload["lanes"]["tools"]["capacity"], 32);
     assert_eq!(payload["lanes"]["tools"]["queued"], 0);
     assert_eq!(payload["lanes"]["tools"]["per_project_capacity"], 4);
+    assert_eq!(payload["lanes"]["tools"]["projects"]["project-a"]["active"], 1);
+    assert_eq!(payload["lanes"]["tools"]["projects"]["project-a"]["available"], 3);
+    assert_eq!(payload["lanes"]["tools"]["projects"]["project-a"]["capacity"], 4);
+    assert_eq!(payload["lanes"]["tools"]["projects"]["project-a"]["queued"], 0);
 
     drop(main_permit);
     drop(subagent_permit);

--- a/crates/rune-runtime/src/lane_queue.rs
+++ b/crates/rune-runtime/src/lane_queue.rs
@@ -5,7 +5,7 @@
 //! ensuring that (for example) a burst of subagent work cannot starve
 //! interactive user sessions.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
 
@@ -276,8 +276,10 @@ impl LaneQueue {
         let tool_capacity = self.tool_limits.global_capacity();
         let tool_queued = self.tool_limits.queued();
         let project_tool_capacity = self.tool_limits.project_capacity();
+        let tool_project_stats = self.tool_limits.project_stats();
 
         LaneStats {
+            tool_project_stats,
             main_active: self.main.active(),
             main_available: self.main.semaphore.available_permits(),
             main_capacity: self.main.capacity,
@@ -376,6 +378,28 @@ impl ToolConcurrencyQueue {
         self.project_capacity
     }
 
+    fn project_stats(&self) -> BTreeMap<String, ProjectToolStats> {
+        self.projects
+            .try_lock()
+            .map(|projects| {
+                projects
+                    .iter()
+                    .map(|(project_key, semaphore)| {
+                        (
+                            project_key.clone(),
+                            ProjectToolStats {
+                                active: semaphore.active(),
+                                available: semaphore.semaphore.available_permits(),
+                                capacity: semaphore.capacity,
+                                queued: semaphore.queued(),
+                            },
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     async fn release(&self, project_key: &str) {
         let project = {
             let projects = self.projects.lock().await;
@@ -438,6 +462,7 @@ impl Drop for ToolPermit {
 /// Snapshot of lane utilisation returned by [`LaneQueue::stats`].
 #[derive(Clone, Debug)]
 pub struct LaneStats {
+    pub tool_project_stats: BTreeMap<String, ProjectToolStats>,
     pub main_available: usize,
     pub main_active: usize,
     pub main_capacity: usize,
@@ -463,6 +488,14 @@ pub struct LaneStats {
     pub tool_capacity: usize,
     pub tool_queued: usize,
     pub project_tool_capacity: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct ProjectToolStats {
+    pub active: usize,
+    pub available: usize,
+    pub capacity: usize,
+    pub queued: usize,
 }
 
 impl fmt::Display for LaneStats {
@@ -774,6 +807,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_project_stats_reflect_per_project_usage_and_queue_depth() {
+        let queue = Arc::new(LaneQueue::with_limits(1, 1, 1, 8, 1));
+
+        let blocker = queue.acquire_tool(Some("alpha")).await;
+
+        let queue_for_waiter = Arc::clone(&queue);
+        let waiter = tokio::spawn(async move {
+            let _permit = queue_for_waiter.acquire_tool(Some("alpha")).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let _beta = queue.acquire_tool(Some("beta")).await;
+
+        let stats = queue.stats();
+        let alpha = stats.tool_project_stats.get("alpha").expect("alpha project stats");
+        assert_eq!(alpha.active, 1);
+        assert_eq!(alpha.available, 0);
+        assert_eq!(alpha.capacity, 1);
+        assert_eq!(alpha.queued, 1);
+
+        let beta = stats.tool_project_stats.get("beta").expect("beta project stats");
+        assert_eq!(beta.active, 1);
+        assert_eq!(beta.available, 0);
+        assert_eq!(beta.capacity, 1);
+        assert_eq!(beta.queued, 0);
+
+        drop(blocker);
+        tokio::time::timeout(Duration::from_millis(200), waiter)
+            .await
+            .expect("same-project waiter should be released")
+            .expect("join should succeed");
+    }
+
+    #[tokio::test]
     async fn stats_reflect_utilisation() {
         let queue = Arc::new(LaneQueue::new());
         let stats = queue.stats();
@@ -802,6 +870,7 @@ mod tests {
         assert_eq!(stats.tool_available, 32);
         assert_eq!(stats.tool_queued, 0);
         assert_eq!(stats.project_tool_capacity, 4);
+        assert!(stats.tool_project_stats.is_empty());
     }
 
     #[test]
@@ -816,6 +885,7 @@ mod tests {
     #[test]
     fn stats_display() {
         let stats = LaneStats {
+            tool_project_stats: BTreeMap::new(),
             main_active: 2,
             main_available: 2,
             main_capacity: 4,

--- a/crates/rune-runtime/src/lib.rs
+++ b/crates/rune-runtime/src/lib.rs
@@ -56,7 +56,7 @@ pub use engine::SessionEngine;
 pub use error::RuntimeError;
 pub use executor::{TurnExecutor, clear_session_abort, request_session_abort};
 pub use hooks::{HookEvent, HookHandler, HookRegistrationRecord, HookRegistry};
-pub use lane_queue::{Lane, LanePermit, LaneQueue, LaneStats, ToolPermit};
+pub use lane_queue::{Lane, LanePermit, LaneQueue, LaneStats, ProjectToolStats, ToolPermit};
 pub use mem0::Mem0Engine;
 pub use plugin::{PluginLoader, PluginManifest, PluginRegistry, PluginScanSummary};
 pub use plugin_manager::PluginManager;


### PR DESCRIPTION
## Summary
- expose configured per-project tool lane capacity and live per-project tool usage in runtime lane stats
- surface the new fields through both HTTP status and ws_rpc runtime.lanes responses
- cover the new status payloads with gateway tests

## Testing
- cargo test -p rune-gateway ws_rpc_status_matches_http_status_basics -- --exact --nocapture
- cargo test -p rune-gateway ws_rpc_runtime_lanes_reports_lane_queue_stats -- --exact --nocapture
- cargo test -p rune-gateway status_reports_configured_lane_capacities -- --exact --nocapture
- cargo check