### PR TITLE
fix(gateway): break same-host peer recursion

### DIFF
--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -299,8 +299,14 @@ pub async fn health(State(state): State<AppState>) -> Result<Json<HealthResponse
     }))
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct InstanceHealthQuery {
+    pub include_peers: Option<bool>,
+}
+
 pub async fn instance_health(
     State(state): State<AppState>,
+    Query(query): Query<InstanceHealthQuery>,
 ) -> Result<Json<InstanceHealthResponse>, GatewayError> {
     let sessions = state
         .session_repo
@@ -308,7 +314,11 @@ pub async fn instance_health(
         .await
         .map_err(|e| GatewayError::Internal(e.to_string()))?;
 
-    let peers = collect_peer_health(state.capabilities.peers.clone()).await;
+    let peers = if query.include_peers.unwrap_or(true) {
+        collect_peer_health(state.capabilities.peers.clone()).await
+    } else {
+        Vec::new()
+    };
 
     Ok(Json(InstanceHealthResponse {
         status: "ok".to_string(),
@@ -760,26 +770,36 @@ async fn collect_peer_health(
     for peer in peers {
         let started = Instant::now();
         let checked_at = Utc::now().to_rfc3339();
-        let item = match client.get(&peer.health_url).send().await {
+        let separator = if peer.health_url.contains('?') { '&' } else { '?' };
+        let probe_url = format!("{}{}include_peers=false", peer.health_url, separator);
+        let item = match client.get(&probe_url).send().await {
             Ok(response) => {
                 let latency_ms = Some(started.elapsed().as_millis());
                 let status_code = response.status();
                 let payload = response.json::<InstanceHealthResponse>().await;
                 match payload {
-                    Ok(payload) => PeerHealthResponse {
+                    Ok(payload) => {
+                        let observed_status = payload.status.clone();
+                        PeerHealthResponse {
                         id: peer.id,
                         name: payload.capabilities.identity.name.clone(),
                         health_url: peer.health_url,
-                        status: if status_code.is_success() {
+                        status: if status_code.is_success() && observed_status == "ok" {
                             "healthy".to_string()
                         } else {
                             "degraded".to_string()
                         },
-                        detail: status_code.to_string(),
+                        detail: if status_code.is_success() && observed_status == "ok" {
+                            status_code.to_string()
+                        } else if status_code.is_success() {
+                            format!("{} (peer reported status={observed_status})", status_code)
+                        } else {
+                            status_code.to_string()
+                        },
                         checked_at: checked_at.clone(),
                         latency_ms,
                         last_seen_at: Some(checked_at.clone()),
-                        observed_status: payload.status.clone(),
+                        observed_status,
                         load: Some(payload.load),
                         advertised_addr: payload.capabilities.identity.advertised_addr,
                         roles: payload.capabilities.identity.roles,
@@ -790,6 +810,7 @@ async fn collect_peer_health(
                         comms_transport: Some(payload.capabilities.comms_transport),
                         configured_models: payload.capabilities.configured_models,
                         active_projects: payload.capabilities.active_projects,
+                    }
                     },
                     Err(error) => PeerHealthResponse {
                         id: peer.id.clone(),

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -4694,6 +4694,7 @@ async fn delegation_plan_selects_least_busy_healthy_peer() {
                     "ws_connections": ws_connections
                 },
                 "capabilities": {
+                    "schema_version": 2,
                     "mode": "standalone",
                     "updated_at": "2026-03-29T00:00:00Z",
                     "storage_backend": "sqlite",
@@ -4712,8 +4713,10 @@ async fn delegation_plan_selects_least_busy_healthy_peer() {
                         "advertised_addr": null,
                         "roles": ["gateway"],
                         "capabilities_version": 2,
-                    "capability_hash": "cap-peer-a"
+                        "capability_hash": format!("cap-{}", id)
                     },
+                    "roles": ["gateway"],
+                    "peer_ids": [],
                     "instance_id": id,
                     "instance_name": id,
                     "peer_count": 0,
@@ -4772,9 +4775,9 @@ async fn delegation_plan_selects_least_busy_healthy_peer() {
     assert_eq!(json["selected_peer"]["id"], "peer-b");
     assert_eq!(json["receiver"]["instance_id"], "peer-b");
     assert_eq!(json["receiver"]["instance_name"], "peer-b");
-    assert_eq!(json["receiver"]["transport"], "http");
-    assert_eq!(json["selected_peer"]["capabilities_version"], 1);
-    assert_eq!(json["selected_peer"]["capability_hash"], "cap-peer-a");
+    assert_eq!(json["receiver"]["transport"], "filesystem");
+    assert_eq!(json["selected_peer"]["capabilities_version"], 2);
+    assert_eq!(json["selected_peer"]["capability_hash"], "cap-peer-b");
     assert_eq!(json["selected_peer"]["comms_transport"], "filesystem");
     assert_eq!(
         json["receiver"]["submit_url"],
@@ -5383,7 +5386,7 @@ async fn instance_health_preserves_last_seen_and_observed_status_from_peer_paylo
             "/api/v1/instance/health",
             axum::routing::get(|| async {
                 axum::Json(serde_json::json!({
-                    "status": "healthy",
+                    "status": "ok",
                     "service": "rune-gateway",
                     "version": "0.1.0",
                     "uptime_seconds": 42,
@@ -5393,6 +5396,7 @@ async fn instance_health_preserves_last_seen_and_observed_status_from_peer_paylo
                         "ws_connections": 3
                     },
                     "capabilities": {
+                        "schema_version": 1,
                         "mode": "direct",
                         "updated_at": "2026-03-29T10:00:00Z",
                         "storage_backend": "sqlite",
@@ -5413,6 +5417,8 @@ async fn instance_health_preserves_last_seen_and_observed_status_from_peer_paylo
                             "capabilities_version": 1,
                             "capability_hash": "cap-peer-a"
                         },
+                        "roles": ["gateway"],
+                        "peer_ids": [],
                         "instance_id": "peer-a",
                         "instance_name": "Peer A",
                         "peer_count": 0,
@@ -5448,10 +5454,113 @@ async fn instance_health_preserves_last_seen_and_observed_status_from_peer_paylo
     let peer = json["peers"].as_array().unwrap().first().unwrap();
     assert_eq!(peer["id"], "peer-a");
     assert_eq!(peer["status"], "healthy");
-    assert_eq!(peer["observed_status"], "healthy");
+    assert_eq!(peer["observed_status"], "ok");
     assert!(peer["last_seen_at"].is_string());
     assert_eq!(peer["name"], "Peer A");
     assert_eq!(peer["capability_hash"], "cap-peer-a");
+}
+
+#[tokio::test]
+async fn instance_health_include_peers_false_breaks_same_host_recursion() {
+    async fn spawn_peer_with_target(id: &'static str, target_url: String) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut config = AppConfig::default();
+            config.instance.id = id.to_string();
+            config.instance.name = id.to_string();
+            config.instance.peers = vec![rune_config::PeerConfig {
+                id: format!("target-for-{id}"),
+                health_url: target_url,
+            }];
+            let (app, _state) = build_test_app_parts(config, None);
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/api/v1/instance/health")
+    }
+
+    let final_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let final_addr = final_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let payload = serde_json::json!({
+            "status": "ok",
+            "service": "rune-gateway",
+            "version": "0.1.0",
+            "uptime_seconds": 7,
+            "load": {
+                "session_count": 1,
+                "ws_subscribers": 0,
+                "ws_connections": 0
+            },
+            "capabilities": {
+                "schema_version": 2,
+                "mode": "standalone",
+                "updated_at": "2026-03-29T00:00:00Z",
+                "storage_backend": "sqlite",
+                "pgvector": false,
+                "memory_mode": "semantic",
+                "browser": false,
+                "mcp_servers": 0,
+                "tts": false,
+                "stt": false,
+                "channels": [],
+                "approval_mode": "manual",
+                "security_posture": "standard",
+                "identity": {
+                    "id": "terminal-peer",
+                    "name": "terminal-peer",
+                    "advertised_addr": null,
+                    "roles": ["gateway"],
+                    "capabilities_version": 2,
+                    "capability_hash": "cap-terminal-peer"
+                },
+                "roles": ["gateway"],
+                "peer_ids": [],
+                "instance_id": "terminal-peer",
+                "instance_name": "terminal-peer",
+                "peer_count": 0,
+                "configured_models": [],
+                "active_projects": [],
+                "comms_transport": "filesystem"
+            },
+            "peers": []
+        });
+        let app = axum::Router::new().route(
+            "/api/v1/instance/health",
+            axum::routing::get(move || {
+                let payload = payload.clone();
+                async move { axum::Json(payload) }
+            }),
+        );
+        axum::serve(final_listener, app).await.unwrap();
+    });
+
+    let final_url = format!("http://{final_addr}/api/v1/instance/health");
+    let middle_url = spawn_peer_with_target("middle-peer", final_url).await;
+
+    let mut config = AppConfig::default();
+    config.instance.peers = vec![rune_config::PeerConfig {
+        id: "middle-peer".to_string(),
+        health_url: middle_url,
+    }];
+
+    let (app, _state) = build_test_app_parts(config, None);
+    let response = app
+        .oneshot(
+            Request::get("/api/v1/instance/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = body_json(response).await;
+    let peer = json["peers"].as_array().unwrap().first().unwrap();
+    assert_eq!(peer["id"], "middle-peer");
+    assert_eq!(peer["status"], "healthy");
+    assert_eq!(peer["observed_status"], "ok");
+    assert!(peer["last_seen_at"].is_string());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add an include_peers query flag to instance health so peer-to-peer probes can avoid recursive fanout on the same host
- make peer health collection probe peers with include_peers=false and only mark them healthy when the peer reports status=ok
- cover same-host recursion and updated capability payload expectations in route tests

## Verification
- cargo check
- cargo test -p rune-gateway delegation_plan_selects_least_busy_healthy_peer -- --nocapture
- cargo test -p rune-gateway instance_health_include_peers_false_breaks_same_host_recursion -- --nocapture
- cargo test -p rune-gateway instance_health_preserves_last_seen_and_observed_status_from_peer_payload -- --nocapture