### PR TITLE
fix(memory-bank): align tool path with seeded knowledge dir

### DIFF
--- a/crates/rune-tools/src/memory_tool.rs
+++ b/crates/rune-tools/src/memory_tool.rs
@@ -3,6 +3,7 @@
 //! Memory in Rune is file-oriented: MEMORY.md and memory/*.md files in the workspace.
 //! Search prefers the persisted hybrid backend when one is configured, falling back
 //! to local keyword scanning when persistence or embeddings are unavailable.
+//! Memory Bank document tools operate on the runtime-seeded `.rune/knowledge/` tree.
 
 use std::path::{Component, Path, PathBuf};
 
@@ -379,7 +380,7 @@ impl MemoryToolExecutor {
     }
 
     async fn memory_bank_files(&self) -> Result<Vec<PathBuf>, ToolError> {
-        let root = self.workspace_root.join("memory-bank");
+        let root = self.workspace_root.join(".rune/knowledge");
         if !root.exists() {
             return Ok(Vec::new());
         }
@@ -424,9 +425,9 @@ impl MemoryToolExecutor {
             ));
         }
 
-        let full = self.workspace_root.join("memory-bank").join(rel);
+        let full = self.workspace_root.join(".rune/knowledge").join(rel);
         if let Ok(canonical) = full.canonicalize() {
-            if let Ok(root) = self.workspace_root.join("memory-bank").canonicalize() {
+            if let Ok(root) = self.workspace_root.join(".rune/knowledge").canonicalize() {
                 if !canonical.starts_with(&root) {
                     return Err(ToolError::InvalidArgument(
                         "resolved path escapes memory-bank boundary".into(),
@@ -492,12 +493,12 @@ impl MemoryToolExecutor {
 
         if full_path.extension().is_none_or(|ext| ext != "md") {
             return Err(ToolError::InvalidArgument(
-                "memory_bank_get only reads markdown files under memory-bank/".into(),
+                "memory_bank_get only reads markdown files under .rune/knowledge/".into(),
             ));
         }
 
         let content = tokio::fs::read_to_string(&full_path).await.map_err(|e| {
-            ToolError::ExecutionFailed(format!("failed to read memory-bank/{path_str}: {e}"))
+            ToolError::ExecutionFailed(format!("failed to read .rune/knowledge/{path_str}: {e}"))
         })?;
         let from = call
             .arguments
@@ -1138,13 +1139,13 @@ mod tests {
     #[tokio::test]
     async fn memory_bank_list_returns_seeded_documents() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::create_dir_all(tmp.path().join("memory-bank/adr"))
+        tokio::fs::create_dir_all(tmp.path().join(".rune/knowledge/adr"))
             .await
             .unwrap();
-        tokio::fs::write(tmp.path().join("memory-bank/README.md"), "# Memory Bank")
+        tokio::fs::write(tmp.path().join(".rune/knowledge/README.md"), "# Memory Bank")
             .await
             .unwrap();
-        tokio::fs::write(tmp.path().join("memory-bank/adr/ADR-0001.md"), "# ADR")
+        tokio::fs::write(tmp.path().join(".rune/knowledge/adr/ADR-0001.md"), "# ADR")
             .await
             .unwrap();
 
@@ -1152,18 +1153,18 @@ mod tests {
         let call = make_call("memory_bank_list", serde_json::json!({}));
         let result = exec.execute(call).await.unwrap();
 
-        assert!(result.output.contains("memory-bank/README.md"));
-        assert!(result.output.contains("memory-bank/adr/ADR-0001.md"));
+        assert!(result.output.contains(".rune/knowledge/README.md"));
+        assert!(result.output.contains(".rune/knowledge/adr/ADR-0001.md"));
     }
 
     #[tokio::test]
     async fn memory_bank_get_reads_seeded_document() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::create_dir_all(tmp.path().join("memory-bank/adr"))
+        tokio::fs::create_dir_all(tmp.path().join(".rune/knowledge/adr"))
             .await
             .unwrap();
         tokio::fs::write(
-            tmp.path().join("memory-bank/adr/ADR-0001.md"),
+            tmp.path().join(".rune/knowledge/adr/ADR-0001.md"),
             "# ADR\n\nDecision line\nSecond line",
         )
         .await
@@ -1182,7 +1183,7 @@ mod tests {
     #[tokio::test]
     async fn memory_bank_get_rejects_path_traversal() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::create_dir_all(tmp.path().join("memory-bank/adr"))
+        tokio::fs::create_dir_all(tmp.path().join(".rune/knowledge/adr"))
             .await
             .unwrap();
 

--- a/docs/reference/memory-bank-current-state.md
+++ b/docs/reference/memory-bank-current-state.md
@@ -14,10 +14,10 @@ Rune currently exposes two Memory Bank tools in `crates/rune-tools/src/memory_to
 
 Current behavior:
 
-- `memory_bank_list` and `memory_bank_get` currently operate on the workspace `memory-bank/` directory
+- `memory_bank_list` and `memory_bank_get` currently operate on the workspace `.rune/knowledge/` directory
 - only Markdown files are discoverable/readable through those two tools
-- `memory_bank_list` lists Markdown documents under `memory-bank/`
-- `memory_bank_get` reads a specific Markdown file under `memory-bank/`
+- `memory_bank_list` lists Markdown documents under `.rune/knowledge/`
+- `memory_bank_get` reads a specific Markdown file under `.rune/knowledge/`
 - path traversal is explicitly rejected for both tools
 - separate runtime prompt injection now also seeds and loads `.rune/knowledge/` via `MemoryBankLoader` in `crates/rune-runtime/src/memory_bank.rs`
 - that `.rune/knowledge/` scaffold currently contains `ARCHITECTURE.md`, `DECISIONS.md`, `CONVENTIONS.md`, and `DEPENDENCIES.md`
@@ -26,7 +26,7 @@ Current behavior:
 
 The Phase 25 specification in `docs/specs/phases-25-27.md` describes a larger future subsystem that is not fully shipped today, including:
 
-- `.rune/knowledge/` as the canonical storage location for the full operator-facing/tooling-backed subsystem
+- the currently shipped tools already use `.rune/knowledge/` as their on-disk source; the remaining future work is broader API/search/staleness/onboarding support
 - a unified `memory_bank` tool with read/update/search operations
 - persistence via `knowledge_docs` store models and migrations
 - staleness detection/reporting


### PR DESCRIPTION
## Summary
- point memory_bank_list and memory_bank_get at the runtime-seeded .rune/knowledge directory
- update tool strings/tests to match the shipped storage location
- refresh the current-state reference doc so it matches implementation

## Testing
- cargo test -p rune-tools memory_bank_ -- --nocapture
- cargo check