### PR TITLE
fix(gateway): accept comms target and clean warnings (#893)

### DIFF
--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -4575,27 +4575,17 @@ connection: close
                 let mut buf = [0u8; 1024];
                 let read = stream.read(&mut buf).unwrap();
                 let request = String::from_utf8_lossy(&buf[..read]);
-                let response = if request.starts_with("GET /ready ") {
-                    b"HTTP/1.1 404 Not Found
+                let missing = b"HTTP/1.1 404 Not Found
 content-length: 0
 connection: close
 
 "
-                    .as_slice()
-                } else if request.starts_with("GET /health ") {
-                    b"HTTP/1.1 404 Not Found
-content-length: 0
-connection: close
-
-"
-                    .as_slice()
-                } else if request.starts_with("GET /gateway/ready ") {
-                    b"HTTP/1.1 404 Not Found
-content-length: 0
-connection: close
-
-"
-                    .as_slice()
+                .as_slice();
+                let response = if request.starts_with("GET /ready ")
+                    || request.starts_with("GET /health ")
+                    || request.starts_with("GET /gateway/ready ")
+                {
+                    missing
                 } else if request.starts_with("GET /gateway/health ") {
                     b"HTTP/1.1 200 OK
 content-length: 2

--- a/crates/rune-gateway/src/routes.rs
+++ b/crates/rune-gateway/src/routes.rs
@@ -1026,6 +1026,7 @@ pub struct SkillStatusResponse {
 
 #[derive(Deserialize)]
 pub struct CommsSendRequest {
+    pub to: Option<String>,
     pub msg_type: String,
     pub subject: String,
     pub body: String,
@@ -1191,6 +1192,16 @@ pub async fn comms_send(
         .comms_client
         .clone()
         .ok_or_else(|| GatewayError::BadRequest("native comms is not enabled".to_string()))?;
+
+    let client = if let Some(to) = body.to.as_deref() {
+        Arc::new(rune_runtime::comms::CommsClient::with_transport(
+            client.transport().clone(),
+            client.agent_id().to_string(),
+            to.to_string(),
+        ))
+    } else {
+        client
+    };
 
     let id = client
         .send(&body.msg_type, &body.subject, &body.body, &body.priority)
@@ -3993,7 +4004,7 @@ pub(crate) fn session_next_task_reason(status: &str, metadata: &Value) -> String
     }
 }
 
-fn session_task_picking_reason(status: &str, metadata: &Value) -> Option<String> {
+fn session_task_picking_reason(_status: &str, metadata: &Value) -> Option<String> {
     if let Some(reason) = metadata_string(metadata, "next_task_reason") {
         return Some(reason);
     }
@@ -4020,10 +4031,7 @@ fn session_task_picking_reason(status: &str, metadata: &Value) -> Option<String>
     if parts.is_empty() {
         None
     } else {
-        Some(match status {
-            "running" => format!("{}", parts.join("; ")),
-            _ => format!("{}", parts.join("; ")),
-        })
+        Some(parts.join("; "))
     }
 }
 
@@ -5205,37 +5213,34 @@ pub async fn scan_models(
             provider_cfg.kind.as_str()
         };
 
-        match kind.to_lowercase().as_str() {
-            "ollama" => {
-                let provider = if provider_cfg.base_url.is_empty() {
-                    rune_models::OllamaProvider::new()
-                } else {
-                    rune_models::OllamaProvider::with_base_url(&provider_cfg.base_url)
-                };
-                let models = provider.list_models().await.map_err(|e| {
-                    GatewayError::Internal(format!(
-                        "failed to scan models for provider '{}': {e}",
-                        provider_cfg.name
-                    ))
-                })?;
+        if kind.eq_ignore_ascii_case("ollama") {
+            let provider = if provider_cfg.base_url.is_empty() {
+                rune_models::OllamaProvider::new()
+            } else {
+                rune_models::OllamaProvider::with_base_url(&provider_cfg.base_url)
+            };
+            let models = provider.list_models().await.map_err(|e| {
+                GatewayError::Internal(format!(
+                    "failed to scan models for provider '{}': {e}",
+                    provider_cfg.name
+                ))
+            })?;
 
-                results.push(ScanModelsResponse {
-                    provider: provider_cfg.name.clone(),
-                    models: models
-                        .into_iter()
-                        .map(|m| ScannedModel {
-                            name: m.name,
-                            size: if m.size > 0 { Some(m.size) } else { None },
-                            modified_at: if m.modified_at.is_empty() {
-                                None
-                            } else {
-                                Some(m.modified_at)
-                            },
-                        })
-                        .collect(),
-                });
-            }
-            _ => {}
+            results.push(ScanModelsResponse {
+                provider: provider_cfg.name.clone(),
+                models: models
+                    .into_iter()
+                    .map(|m| ScannedModel {
+                        name: m.name,
+                        size: if m.size > 0 { Some(m.size) } else { None },
+                        modified_at: if m.modified_at.is_empty() {
+                            None
+                        } else {
+                            Some(m.modified_at)
+                        },
+                    })
+                    .collect(),
+            });
         }
     }
 

--- a/crates/rune-gateway/tests/route_tests.rs
+++ b/crates/rune-gateway/tests/route_tests.rs
@@ -1548,6 +1548,7 @@ fn build_test_app_parts_with_ms365_services(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_test_app_parts_with_ms365_services_and_session_repo(
     mut config: AppConfig,
     auth_token: Option<String>,
@@ -10795,6 +10796,7 @@ async fn get_session_tree_defaults_subagent_lifecycle_when_runtime_metadata_miss
     assert_eq!(child["subagent_runtime_attached"], false);
 }
 
+#[tokio::test]
 async fn create_subagent_session_accepts_delegation_context_and_scratchpad() {
     let app = build_test_app(None);
 
@@ -14849,8 +14851,10 @@ async fn ws_rpc_tools_get_returns_persisted_execution() {
 
 #[tokio::test]
 async fn doctor_route_reports_custom_path_profile_and_server_mode() {
-    let mut config = AppConfig::default();
-    config.mode = RuntimeMode::Server;
+    let mut config = AppConfig {
+        mode: RuntimeMode::Server,
+        ..AppConfig::default()
+    };
     let root = std::env::temp_dir().join(format!("rune-doctor-custom-{}", Uuid::now_v7()));
     config.paths.db_dir = root.join("db");
     config.paths.sessions_dir = root.join("sessions");
@@ -14996,9 +15000,9 @@ async fn protected_http_routes_reject_session_token_query_auth_for_non_webchat_r
 fn storage_path_checks_mark_root_owned_optional_server_paths_as_warns_during_standalone_first_run()
 {
     let root = tempfile::tempdir().unwrap();
-    let mut config = rune_config::AppConfig::default();
-    config.mode = rune_config::RuntimeMode::Standalone;
-    config.paths = rune_config::PathsConfig {
+    let mut config = rune_config::AppConfig {
+        mode: rune_config::RuntimeMode::Standalone,
+        paths: rune_config::PathsConfig {
         db_dir: root.path().join("db"),
         sessions_dir: root.path().join("sessions"),
         memory_dir: root.path().join("memory"),
@@ -15013,6 +15017,8 @@ fn storage_path_checks_mark_root_owned_optional_server_paths_as_warns_during_sta
         workspace_dir: root.path().join("workspace"),
         cache_dir: root.path().join("cache"),
         data_dir: root.path().join("data"),
+    },
+        ..rune_config::AppConfig::default()
     };
     config.ensure_dirs().unwrap();
     config.paths = rune_config::PathsConfig::default();
@@ -15386,8 +15392,10 @@ async fn delegation_plan_exposes_sender_capability_identity_metadata() {
 
 #[tokio::test]
 async fn doctor_run_reports_instance_topology_summary() {
-    let mut config = AppConfig::default();
-    config.mode = RuntimeMode::Server;
+    let mut config = AppConfig {
+        mode: RuntimeMode::Server,
+        ..AppConfig::default()
+    };
     config.database.backend = rune_config::StorageBackend::Postgres;
     config.database.database_url = Some("postgresql://localhost/rune".into());
     config.models.providers = vec![rune_config::ModelProviderConfig {

--- a/crates/rune-models/src/lib.rs
+++ b/crates/rune-models/src/lib.rs
@@ -408,7 +408,7 @@ impl RoutedModelProvider {
         self.record_provider_result(
             &resolved.provider.name,
             model_ref,
-            &result.as_ref().map(|_| ()).map_err(|err| err),
+            &result.as_ref().map(|_| ()),
         );
         result
     }
@@ -555,7 +555,7 @@ impl RoutedModelProvider {
         self.record_provider_result(
             &resolved.provider.name,
             model_ref,
-            &result.as_ref().map(|_| ()).map_err(|err| err),
+            &result.as_ref().map(|_| ()),
         );
         result
     }


### PR DESCRIPTION
## Summary
- allow gateway comms_send requests to override the peer target while preserving existing transport settings
- clean small warning/code-style issues surfaced in CLI, gateway, tests, and model routing
- keep targeted route coverage green for delegation context and doctor reporting paths

## Testing
- cargo check
- cargo test -p rune-gateway create_subagent_session_accepts_delegation_context_and_scratchpad -- --nocapture
- cargo test -p rune-gateway doctor_route_reports_custom_path_profile_and_server_mode -- --nocapture
- cargo test -p rune-gateway doctor_run_reports_instance_topology_summary -- --nocapture