### PR TITLE
docs(repo): prepare OSS contributor baseline

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want Rune to be an open, respectful, and technically serious project. Contributors, maintainers, and community participants are expected to make participation harassment-free for everyone regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Expected Behavior
+
+- be respectful, direct, and constructive
+- assume good intent, but be clear about technical tradeoffs
+- welcome questions from new contributors
+- keep reviews focused on the work, not the person
+- document significant decisions and changes clearly
+
+## Unacceptable Behavior
+
+- harassment, intimidation, or discrimination
+- trolling, insulting, or derogatory comments
+- deliberate disruption of discussions or review flow
+- publishing private information without explicit permission
+- any conduct that would be inappropriate in a professional open-source community
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that violate this Code of Conduct.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, contact the maintainers through the repository issue/PR trail or a private maintainer contact channel when available.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project or its community.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a defect or regression in Rune
+labels: bug
+---
+
+## Summary
+
+Describe the bug clearly.
+
+## Environment
+
+- OS:
+- Rune version / commit:
+- Deployment mode:
+- Provider(s):
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected result
+
+## Actual result
+
+## Logs / evidence
+
+Paste relevant logs, screenshots, or command output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributor docs
+    url: https://github.com/ghostrider0470/rune/tree/main/docs/contributor
+    about: Start here for local setup, testing, and workflow guidance.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a feature or improvement for Rune
+labels: enhancement
+---
+
+## Problem
+
+What problem are you trying to solve?
+
+## Proposed change
+
+Describe the desired behavior or capability.
+
+## Why this matters
+
+Explain the operator, contributor, or product value.
+
+## Additional context
+
+Links, examples, prior art, or constraints.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hamza Abdagic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -171,15 +171,18 @@ That means local-first is the default experience, not a throwaway dev-only mode.
 - use [`rune-plan.md`](rune-plan.md) for the canonical product strategy and planning summary
 - use [`docs/OPENCLAW-COVERAGE-MAP.md`](docs/OPENCLAW-COVERAGE-MAP.md) if you need the OpenClaw-surface parity front door
 
-## For contributors
+## Contributing
 
-Start here:
+Rune is now being prepared for open-source contributors. If you want to help, start here:
+- read [`docs/contributor/README.md`](docs/contributor/README.md) for the contributor docs hub
 - use [`docs/contributor/DEVELOPMENT.md`](docs/contributor/DEVELOPMENT.md) for local setup and day-to-day build/run flow
-- use `rune gateway instance-health` via the CLI after configuring `[instance]` to inspect identity/capabilities/load, and `rune gateway delegation-plan --strategy least_busy` to preview the current cross-instance delegation contract
-- use [`docs/contributor/README.md`](docs/contributor/README.md) for the contributor docs hub and related execution references
-- use [`docs/AGENT-ORCHESTRATION.md`](docs/AGENT-ORCHESTRATION.md) for deeper runtime/repo execution context
-- use [`docs/reference/README.md`](docs/reference/README.md), [`docs/reference/ARCHITECTURE.md`](docs/reference/ARCHITECTURE.md), [`docs/reference/CRATE-LAYOUT.md`](docs/reference/CRATE-LAYOUT.md), and [`docs/reference/SUBSYSTEMS.md`](docs/reference/SUBSYSTEMS.md) for technical reference material
+- use [`docs/contributor/TESTING.md`](docs/contributor/TESTING.md) for validation expectations
+- use [`docs/contributor/CONTRIBUTING.md`](docs/contributor/CONTRIBUTING.md) and [`docs/contributor/WORKFLOW.md`](docs/contributor/WORKFLOW.md) for how issues, docs, PRs, and execution flow fit together
+- use `rune gateway instance-health` after configuring `[instance]` to inspect identity/capabilities/load, and `rune gateway delegation-plan --strategy least_busy` to preview the cross-instance delegation contract
+- use [`docs/reference/README.md`](docs/reference/README.md), [`docs/reference/ARCHITECTURE.md`](docs/reference/ARCHITECTURE.md), [`docs/reference/CRATE-LAYOUT.md`](docs/reference/CRATE-LAYOUT.md), and [`docs/reference/SUBSYSTEMS.md`](docs/reference/SUBSYSTEMS.md) for deeper technical reference material
+
+Community scaffolding now lives at [`LICENSE`](LICENSE), [`.github/CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md), and [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
 
 ## License
 
-Private — [Horizon Tech d.o.o.](https://horizontech.ba)
+MIT — see [`LICENSE`](LICENSE).

--- a/docs/contributor/CONTRIBUTING.md
+++ b/docs/contributor/CONTRIBUTING.md
@@ -6,6 +6,10 @@ This is the contributor-facing entry doc for how work should move through Rune.
 
 Contributors should use Rune's docs and issue trail in a way that keeps strategy, execution, and durable decisions separated.
 
+## Open-source baseline
+
+Rune is now being prepared for external contributors. Keep issues scoped, document user-visible changes, and prefer small PRs with clear validation evidence.
+
 ## Start here
 
 - [`DEVELOPMENT.md`](DEVELOPMENT.md)

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,6 +1,6 @@
 # Contributor Docs
 
-This folder is the contributor-facing hub for building, validating, and shipping changes to Rune.
+This folder is the contributor-facing hub for building, validating, and shipping changes to Rune. If you are new to the project, start here before opening a PR.
 
 Start here:
 - use [`CONTRIBUTING.md`](CONTRIBUTING.md) for the big-picture relationship between docs, issues, PRs, and ADRs
@@ -9,3 +9,12 @@ Start here:
 - use [`WORKFLOW.md`](WORKFLOW.md) and [`EXECUTION-SPEED-POLICY.md`](EXECUTION-SPEED-POLICY.md) for the accepted batch-branch execution model
 - use [`../AGENT-ORCHESTRATION.md`](../AGENT-ORCHESTRATION.md) and [`../reference/CRATE-LAYOUT.md`](../reference/CRATE-LAYOUT.md) for deeper repo/subsystem execution context
 - use [`../INDEX.md`](../INDEX.md) if you need the wider docs front door
+
+## First contribution path
+
+If you are new here, use this order:
+1. Read the top-level [`README.md`](../../README.md) for product/runtime context.
+2. Follow [`DEVELOPMENT.md`](DEVELOPMENT.md) to get Rune building locally.
+3. Run the checks in [`TESTING.md`](TESTING.md).
+4. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`WORKFLOW.md`](WORKFLOW.md) before opening a PR.
+5. Pick or open a scoped GitHub issue before starting non-trivial work.


### PR DESCRIPTION
## Summary
- add an explicit MIT license file for Rune
- replace private-license language in README with open-source contributor guidance
- add baseline community scaffolding with a code of conduct and issue templates
- strengthen contributor docs with a clearer first-contribution path

## Validation
- cargo check