### PR TITLE
docs(repo): add OSS community docs baseline (#985)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Validation
+
+- [ ] `cargo check`
+- [ ] relevant tests run
+
+## Issue
+
+Closes #

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Rune is now being prepared for open-source contributors. If you want to help, st
 - use `rune gateway instance-health` after configuring `[instance]` to inspect identity/capabilities/load, and `rune gateway delegation-plan --strategy least_busy` to preview the cross-instance delegation contract
 - use [`docs/reference/README.md`](docs/reference/README.md), [`docs/reference/ARCHITECTURE.md`](docs/reference/ARCHITECTURE.md), [`docs/reference/CRATE-LAYOUT.md`](docs/reference/CRATE-LAYOUT.md), and [`docs/reference/SUBSYSTEMS.md`](docs/reference/SUBSYSTEMS.md) for deeper technical reference material
 
-Community scaffolding now lives at [`LICENSE`](LICENSE), [`.github/CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md), and [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).
+Community scaffolding now lives at [`LICENSE`](LICENSE), [`SECURITY.md`](SECURITY.md), [`SUPPORT.md`](SUPPORT.md), [`.github/CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md), [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/), and [`.github/pull_request_template.md`](.github/pull_request_template.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+Rune is still evolving quickly. Security fixes are applied on the latest supported `main` branch.
+
+| Version | Supported |
+| --- | --- |
+| `main` | ✅ |
+| older branches / tags | ❌ |
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for suspected vulnerabilities.
+
+Instead, report security issues privately to the maintainer:
+- email: `hamza.abdagic@outlook.com`
+
+When reporting, include:
+- a clear description of the issue
+- affected component(s) or file paths
+- reproduction steps or proof of concept if available
+- impact assessment
+- any suggested mitigation
+
+You should receive an acknowledgement as soon as practical. After triage, the fix may be handled privately until a patch is ready.
+
+## Scope notes
+
+Use normal GitHub issues for non-sensitive bugs, feature requests, and documentation problems.
+Public issues are appropriate only when the report does not create additional risk for operators or users.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+## Getting help
+
+For now, Rune support is handled through the public repository workflow:
+- use GitHub issues for bug reports and feature requests
+- read the contributor docs under [`docs/contributor/`](docs/contributor/) before opening development PRs
+- use the top-level [`README.md`](README.md) and [`docs/INDEX.md`](docs/INDEX.md) to find the right documentation entry point
+
+## Before opening an issue
+
+Please include:
+- what you were trying to do
+- expected vs actual behavior
+- reproduction steps
+- relevant logs, error output, or screenshots
+- environment details (OS, Rust version, deployment mode, provider path)
+
+## Security issues
+
+Do **not** report vulnerabilities in public issues.
+Use [`SECURITY.md`](SECURITY.md) for private reporting instructions.
+
+## Project status
+
+Rune is actively developed. The issue tracker is the authoritative place to see what is planned, in progress, and recently shipped.


### PR DESCRIPTION
## Summary
- add SECURITY.md and SUPPORT.md for public repo community workflows
- add a default PR template for contributor pull requests
- update README community scaffolding references to point at the new files

## Validation
- cargo check

Closes #985