### PR TITLE
docs(roadmap): align closed readiness lane truth (#893)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
 # Rune Roadmap — Execution Snapshot
 
-Last updated: 2026-04-07
+Last updated: 2026-04-10
 
 ## Status
 - Legacy roadmap retained below for provenance.
 - Canonical product strategy lives in `rune-plan.md`.
 - Canonical parity-phase sequencing lives in `docs/IMPLEMENTATION-PHASES.md`.
-- GitHub Project 2 is the live execution control plane.
+- GitHub issues/PRs are the live execution control plane.
 - Open replacement-readiness epic #893 and child issues #896, #898, #899 are closed.
 - There is no active roadmap lane under #893 now; remaining replacement-truth gates are tracked directly in shipped readiness docs and doctor/status surfaces.
-- Next execution should come from currently open GitHub issues / Project 2 priorities, not from the closed #893 lane.
+- If `gh issue list --state open` is empty, there is no active coding lane to resume from this roadmap snapshot.
 
 ---
 

--- a/docs/parity/OPENCLAW-VS-RUNE-MATRIX.md
+++ b/docs/parity/OPENCLAW-VS-RUNE-MATRIX.md
@@ -1,6 +1,6 @@
 # OpenClaw vs Rune — Parity Matrix
 
-_Generated 2026-03-20 from code audit of both codebases._
+_Generated 2026-03-20 from code audit of both codebases. Updated 2026-04-10 for replacement-readiness truth._
 
 ## Summary
 
@@ -147,7 +147,7 @@ _Generated 2026-03-20 from code audit of both codebases._
 | Sandbox (filesystem) | Yes | Yes |
 | Process audit trail | No | Yes |
 | First-use bypass warning | No | Yes |
-| Channel allowlists | Yes | Partial — provider/webhook authenticity checks exist where applicable, but no sender/user/chat allowlist policy surface yet (#898) |
+| Channel allowlists | Yes | Partial — provider/webhook authenticity checks exist where applicable, but no sender/user/chat allowlist policy surface yet; this remains a documented replacement-readiness blocker even though issue #898 is closed as a truth/documentation pass |
 | Role-based access | Basic | No |
 
 **Rune advantage:** Significantly more sophisticated approval system.
@@ -172,9 +172,9 @@ _Generated 2026-03-20 from code audit of both codebases._
 
 ## Critical Path: Rune as OpenClaw Replacement
 
-### Must-Have (blocks daily use):
-1. **web-fetch tool** — agents can't browse URLs or call APIs without it
-2. **git tool** — coding agents need git operations
+### Must-Have (historical gap list; not the canonical readiness verdict):
+1. **web-fetch tool** — historical note; shipped in the current Horizon execution environment, so do not use this row as the operator truth source
+2. **git tool** — historical note; shipped in the current Horizon execution environment, so do not use this row as the operator truth source
 3. **WebChat channel** — operator needs browser-based interaction
 4. **TLS/HTTPS** — production deployment requirement
 5. **Plugin execution engine** — extensibility is core to the product
@@ -206,4 +206,4 @@ For Rune to maintain its own code (self-coding agent):
 6. **Subagent orchestration** — already working (spawn coder agents)
 7. **Approval system** — already working (operator reviews before destructive ops)
 
-**Gap to self-maintenance: 2 tools (git + web-fetch).** Everything else is in place.
+**Historical note:** this self-maintenance summary is stale if read outside its original generation context. For current operator truth about replacement claims, use `docs/operator/REPLACEMENT-READINESS.md` and `docs/operator/HEALTH-AND-DOCTOR.md` instead of this matrix.


### PR DESCRIPTION
## Summary\n- update ROADMAP status header so it stops pointing execution at the already-closed #893 lane\n- mark the parity matrix trust-boundary note as a documented readiness blocker rather than an open-issue gap\n- annotate stale historical gap rows so operators use the canonical readiness docs instead\n\n## Testing\n- cargo check