### PR TITLE
fix(doctor): align CLI readiness blockers with gateway truth (#991)

### DIFF
--- a/crates/rune-cli/src/doctor.rs
+++ b/crates/rune-cli/src/doctor.rs
@@ -1303,6 +1303,18 @@ fn replacement_readiness_report() -> ReplacementReadinessReport {
             detail: "readiness evidence is still reported as pending until the gateway publishes live queue-delay, stuck-turn-rate, and recovery-time signals directly in status/doctor surfaces".to_string(),
             issue: None,
         },
+        ReplacementReadinessBlocker {
+            category: "product-surface".to_string(),
+            status: "blocked".to_string(),
+            detail: "operator-facing readiness wording is now aligned to canonical docs, but full replacement claims remain blocked until the remaining readiness-proof surfaces are evidenced".to_string(),
+            issue: None,
+        },
+        ReplacementReadinessBlocker {
+            category: "runtime-resilience".to_string(),
+            status: "partial".to_string(),
+            detail: "circuit breakers are already shipped, but broader runtime-resilience proof for an honest replacement claim still needs tracked operational evidence and closure".to_string(),
+            issue: None,
+        },
     ];
     ReplacementReadinessReport {
         verdict: "not_ready".to_string(),


### PR DESCRIPTION
## Summary
- align CLI doctor replacement-readiness blockers with the gateway canonical blocker set
- keep offline doctor output truthful with operator docs and gateway responses
- preserve the existing readiness summary while surfacing all current blocker categories

## Testing
- cargo test -p rune-cli render_doctor_report -q
- cargo test -p rune-gateway doctor_run_surfaces_readiness_slos_and_pending_evidence_status -q
- cargo test -p rune-gateway session_status_unresolved_reuses_replacement_readiness_blockers -q
- cargo check -q