### PR TITLE
feat(mcp): add auth-header support for HTTP servers (#999)

### DIFF
--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -1007,6 +1007,8 @@ async fn build_mcp_tool_executor(
             env: srv.env.clone(),
             cwd: None,
             url: srv.url.clone(),
+            http_headers: srv.http_headers.clone(),
+            http_headers_env: srv.http_headers_env.clone(),
             enabled: true,
         });
     }
@@ -1085,6 +1087,8 @@ fn runtime_mcp_config(
         env: server.env.clone(),
         cwd,
         url: server.url.clone(),
+        http_headers: server.http_headers.clone(),
+        http_headers_env: server.http_headers_env.clone(),
         enabled: server.enabled,
     }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -126,6 +126,16 @@ global_tool_capacity = 32
 # Max concurrent tool executions per project lane
 project_tool_capacity = 4
 
+
+[[mcp_servers]]
+name = "github-remote"
+transport = "http"
+url = "https://example.com/mcp"
+# Inline headers are supported, but prefer env-backed secrets for auth.
+# http_headers = { X-Client = "rune" }
+http_headers_env = { Authorization = "GITHUB_MCP_AUTH_HEADER" }
+# Example env value: export GITHUB_MCP_AUTH_HEADER='Bearer ghp_xxx'
+
 [logging]
 level = "info"
 json = true

--- a/crates/rune-config/src/lib.rs
+++ b/crates/rune-config/src/lib.rs
@@ -108,6 +108,11 @@ impl AppConfig {
         out.channels.teams_app_password = mask(&self.channels.teams_app_password);
         out.mem0.embedding_api_key = mask(&self.mem0.embedding_api_key);
         out.mem0.postgres_url = mask(&self.mem0.postgres_url);
+        for server in &mut out.mcp_servers {
+            for value in server.http_headers.values_mut() {
+                *value = "***".to_string();
+            }
+        }
         out
     }
 
@@ -1249,6 +1254,10 @@ pub struct McpServerConfig {
     pub cwd: Option<String>,
     #[serde(default)]
     pub url: Option<String>,
+    #[serde(default)]
+    pub http_headers: HashMap<String, String>,
+    #[serde(default)]
+    pub http_headers_env: HashMap<String, String>,
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
@@ -3040,10 +3049,16 @@ enabled = true
 name = "remote"
 transport = "http"
 url = "http://127.0.0.1:8788/mcp"
+http_headers = { Authorization = "Bearer inline-token" }
+http_headers_env = { X_API_KEY = "RUNE_TEST_MCP_KEY" }
 enabled = false
 "#,
         )
         .unwrap();
+
+        unsafe {
+            std::env::set_var("RUNE_TEST_MCP_KEY", "env-token");
+        }
 
         let config = AppConfig::load(Some(&path)).unwrap();
         assert_eq!(config.mcp_servers.len(), 2);
@@ -3057,8 +3072,25 @@ enabled = false
             config.mcp_servers[1].url.as_deref(),
             Some("http://127.0.0.1:8788/mcp")
         );
+        assert_eq!(
+            config.mcp_servers[1]
+                .http_headers
+                .get("Authorization")
+                .map(String::as_str),
+            Some("Bearer inline-token")
+        );
+        assert_eq!(
+            config.mcp_servers[1]
+                .http_headers_env
+                .get("X_API_KEY")
+                .map(String::as_str),
+            Some("RUNE_TEST_MCP_KEY")
+        );
         assert!(!config.mcp_servers[1].enabled);
 
+        unsafe {
+            std::env::remove_var("RUNE_TEST_MCP_KEY");
+        }
         let _ = fs::remove_file(path);
     }
 

--- a/crates/rune-mcp/Cargo.toml
+++ b/crates/rune-mcp/Cargo.toml
@@ -16,3 +16,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["process"] }
 tracing.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+wiremock.workspace = true

--- a/crates/rune-mcp/src/discovery.rs
+++ b/crates/rune-mcp/src/discovery.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::McpError;
+
 /// Transport mechanism for reaching an MCP server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +48,14 @@ pub struct McpServerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
+    /// Static HTTP headers sent with every request.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub http_headers: HashMap<String, String>,
+
+    /// Header -> env-var map resolved at runtime for secrets.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub http_headers_env: HashMap<String, String>,
+
     /// Whether this server is enabled.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
@@ -78,6 +88,20 @@ impl McpServerConfig {
         }
         Ok(())
     }
+
+    pub fn resolved_http_headers(&self) -> Result<HashMap<String, String>, McpError> {
+        let mut headers = self.http_headers.clone();
+        for (header_name, env_name) in &self.http_headers_env {
+            let value = std::env::var(env_name).map_err(|_| {
+                McpError::init_failed(format!(
+                    "server '{}': missing env var '{}' for HTTP header '{}'",
+                    self.name, env_name, header_name
+                ))
+            })?;
+            headers.insert(header_name.clone(), value);
+        }
+        Ok(headers)
+    }
 }
 
 #[cfg(test)]
@@ -94,6 +118,8 @@ mod tests {
             env: HashMap::new(),
             cwd: None,
             url: None,
+            http_headers: HashMap::new(),
+            http_headers_env: HashMap::new(),
             enabled: true,
         };
         assert!(cfg.validate().is_ok());
@@ -109,6 +135,8 @@ mod tests {
             env: HashMap::new(),
             cwd: None,
             url: None,
+            http_headers: HashMap::new(),
+            http_headers_env: HashMap::new(),
             enabled: true,
         };
         assert!(cfg.validate().is_err());
@@ -124,6 +152,8 @@ mod tests {
             env: HashMap::new(),
             cwd: None,
             url: Some("http://localhost:3001".into()),
+            http_headers: HashMap::new(),
+            http_headers_env: HashMap::new(),
             enabled: true,
         };
         assert!(cfg.validate().is_ok());
@@ -139,9 +169,66 @@ mod tests {
             env: HashMap::new(),
             cwd: None,
             url: None,
+            http_headers: HashMap::new(),
+            http_headers_env: HashMap::new(),
             enabled: true,
         };
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn resolved_http_headers_merge_inline_and_env() {
+        let cfg = McpServerConfig {
+            name: "remote".into(),
+            transport: McpTransportKind::Http,
+            command: None,
+            args: None,
+            env: HashMap::new(),
+            cwd: None,
+            url: Some("http://localhost:3001".into()),
+            http_headers: HashMap::from([("Authorization".into(), "Bearer inline".into())]),
+            http_headers_env: HashMap::from([("X-API-Key".into(), "RUNE_TEST_MCP_HEADER".into())]),
+            enabled: true,
+        };
+        unsafe {
+            std::env::set_var("RUNE_TEST_MCP_HEADER", "secret-from-env");
+        }
+        let headers = cfg.resolved_http_headers().unwrap();
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer inline")
+        );
+        assert_eq!(
+            headers.get("X-API-Key").map(String::as_str),
+            Some("secret-from-env")
+        );
+        unsafe {
+            std::env::remove_var("RUNE_TEST_MCP_HEADER");
+        }
+    }
+
+    #[test]
+    fn resolved_http_headers_errors_when_env_missing() {
+        let cfg = McpServerConfig {
+            name: "remote".into(),
+            transport: McpTransportKind::Http,
+            command: None,
+            args: None,
+            env: HashMap::new(),
+            cwd: None,
+            url: Some("http://localhost:3001".into()),
+            http_headers: HashMap::new(),
+            http_headers_env: HashMap::from([(
+                "Authorization".into(),
+                "RUNE_TEST_MISSING_MCP_HEADER".into(),
+            )]),
+            enabled: true,
+        };
+        unsafe {
+            std::env::remove_var("RUNE_TEST_MISSING_MCP_HEADER");
+        }
+        let err = cfg.resolved_http_headers().unwrap_err();
+        assert!(err.to_string().contains("RUNE_TEST_MISSING_MCP_HEADER"));
     }
 
     #[test]
@@ -162,6 +249,8 @@ mod tests {
             env: HashMap::from([("API_KEY".into(), "secret".into())]),
             cwd: None,
             url: Some("http://localhost:8080".into()),
+            http_headers: HashMap::from([("Authorization".into(), "Bearer token".into())]),
+            http_headers_env: HashMap::from([("X-API-Key".into(), "MCP_API_KEY".into())]),
             enabled: false,
         };
         let json = serde_json::to_string(&cfg).unwrap();

--- a/crates/rune-mcp/src/lib.rs
+++ b/crates/rune-mcp/src/lib.rs
@@ -150,7 +150,8 @@ impl McpManager {
             }
             McpTransportKind::Http => {
                 let url = cfg.url.as_deref().unwrap_or_default();
-                let t = HttpTransport::connect(url).await?;
+                let headers = cfg.resolved_http_headers()?;
+                let t = HttpTransport::connect(url, headers).await?;
                 TransportHandle::Http(t)
             }
         };
@@ -550,6 +551,8 @@ for line in sys.stdin:
                 env: HashMap::new(),
                 cwd: None,
                 url: None,
+                http_headers: HashMap::new(),
+                http_headers_env: HashMap::new(),
                 enabled: true,
             }])
             .await
@@ -589,6 +592,8 @@ for line in sys.stdin:
                 env: HashMap::new(),
                 cwd: None,
                 url: None,
+                http_headers: HashMap::new(),
+                http_headers_env: HashMap::new(),
                 enabled: true,
             }])
             .await

--- a/crates/rune-mcp/src/transport_http.rs
+++ b/crates/rune-mcp/src/transport_http.rs
@@ -3,10 +3,12 @@
 //! Sends JSON-RPC requests as HTTP POST and optionally connects to an SSE
 //! endpoint for server-initiated events.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use reqwest::Client;
+use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use tracing::debug;
 
 use crate::error::McpError;
@@ -22,8 +24,24 @@ pub struct HttpTransport {
     url: String,
     /// Shared HTTP client (connection pooling, TLS config, etc.).
     client: Client,
+    /// Headers applied to every request.
+    headers: HeaderMap,
     /// Monotonically increasing request id counter.
     next_id: Arc<AtomicU64>,
+}
+
+fn build_headers(headers: HashMap<String, String>) -> Result<HeaderMap, McpError> {
+    let mut header_map = HeaderMap::new();
+    for (name, value) in headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+            McpError::init_failed(format!("invalid HTTP header name '{name}': {e}"))
+        })?;
+        let header_value = HeaderValue::from_str(&value).map_err(|e| {
+            McpError::init_failed(format!("invalid HTTP header value for '{name}': {e}"))
+        })?;
+        header_map.insert(header_name, header_value);
+    }
+    Ok(header_map)
 }
 
 impl HttpTransport {
@@ -32,18 +50,23 @@ impl HttpTransport {
     /// This constructor validates reachability by default but does **not**
     /// perform the MCP `initialize` handshake -- that is the caller's
     /// responsibility.
-    pub async fn connect(url: impl Into<String>) -> Result<Self, McpError> {
+    pub async fn connect(
+        url: impl Into<String>,
+        headers: HashMap<String, String>,
+    ) -> Result<Self, McpError> {
         let url = url.into();
+        let headers = build_headers(headers)?;
 
         let client = Client::builder()
             .build()
             .map_err(|e| McpError::transport(format!("failed to build HTTP client: {e}")))?;
 
-        debug!(url = %url, "HTTP transport created");
+        debug!(url = %url, header_count = headers.len(), "HTTP transport created");
 
         Ok(Self {
             url,
             client,
+            headers,
             next_id: Arc::new(AtomicU64::new(1)),
         })
     }
@@ -62,8 +85,9 @@ impl HttpTransport {
         let resp = self
             .client
             .post(&self.url)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json, text/event-stream")
+            .headers(self.headers.clone())
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
             .json(&request)
             .send()
             .await
@@ -146,7 +170,8 @@ impl HttpTransport {
         let resp = self
             .client
             .post(&self.url)
-            .header("Content-Type", "application/json")
+            .headers(self.headers.clone())
+            .header(CONTENT_TYPE, "application/json")
             .json(&serde_json::json!({
                 "jsonrpc": "2.0",
                 "method": method,
@@ -179,10 +204,12 @@ impl HttpTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_partial_json, header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
     async fn connect_builds_transport() {
-        let transport = HttpTransport::connect("http://localhost:9999").await;
+        let transport = HttpTransport::connect("http://localhost:9999", HashMap::new()).await;
         assert!(transport.is_ok());
         let t = transport.unwrap();
         assert_eq!(t.url(), "http://localhost:9999");
@@ -190,11 +217,67 @@ mod tests {
 
     #[tokio::test]
     async fn next_id_increments() {
-        let t = HttpTransport::connect("http://localhost:9999")
+        let t = HttpTransport::connect("http://localhost:9999", HashMap::new())
             .await
             .unwrap();
         let a = t.next_request_id();
         let b = t.next_request_id();
         assert_eq!(b, a + 1);
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_invalid_header_name() {
+        let result = HttpTransport::connect(
+            "http://localhost:9999",
+            HashMap::from([("Bad Header".into(), "value".into())]),
+        )
+        .await;
+        match result {
+            Ok(_) => panic!("invalid header name should fail"),
+            Err(err) => assert!(err.to_string().contains("invalid HTTP header name")),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_includes_configured_headers() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer secret-token"))
+            .and(header("x-api-key", "extra-secret"))
+            .and(body_partial_json(
+                serde_json::json!({"method":"initialize"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc":"2.0",
+                "id":1,
+                "result": {
+                    "protocolVersion":"2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name":"mock-mcp","version":"1.0.0"}
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let transport = HttpTransport::connect(
+            server.uri(),
+            HashMap::from([
+                ("Authorization".into(), "Bearer secret-token".into()),
+                ("X-API-Key".into(), "extra-secret".into()),
+            ]),
+        )
+        .await
+        .unwrap();
+
+        let response = transport
+            .send(JsonRpcRequest::new(
+                1,
+                "initialize",
+                Some(serde_json::json!({})),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
     }
 }

--- a/crates/rune-runtime/src/claude_plugin.rs
+++ b/crates/rune-runtime/src/claude_plugin.rs
@@ -97,6 +97,10 @@ pub struct ClaudeMcpServer {
     #[serde(default)]
     pub env: HashMap<String, String>,
     pub url: Option<String>,
+    #[serde(default)]
+    pub http_headers: HashMap<String, String>,
+    #[serde(default)]
+    pub http_headers_env: HashMap<String, String>,
 }
 
 /// The fully-parsed representation of a Claude Code plugin directory.
@@ -169,6 +173,10 @@ struct McpServerEntry {
     env: HashMap<String, String>,
     #[serde(default)]
     url: Option<String>,
+    #[serde(default, alias = "headers")]
+    http_headers: HashMap<String, String>,
+    #[serde(default, alias = "headersEnv")]
+    http_headers_env: HashMap<String, String>,
 }
 
 fn default_transport() -> String {
@@ -425,6 +433,8 @@ async fn parse_mcp_file(path: &Path, plugin_name: &str) -> Vec<ClaudeMcpServer> 
                 args: entry.args,
                 env: entry.env,
                 url: entry.url,
+                http_headers: entry.http_headers,
+                http_headers_env: entry.http_headers_env,
             })
             .collect();
     }
@@ -441,6 +451,8 @@ async fn parse_mcp_file(path: &Path, plugin_name: &str) -> Vec<ClaudeMcpServer> 
                 args: entry.args,
                 env: entry.env,
                 url: entry.url,
+                http_headers: entry.http_headers,
+                http_headers_env: entry.http_headers_env,
             })
             .collect();
     }
@@ -976,7 +988,9 @@ mod tests {
       "transport": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],
-      "env": {"NODE_ENV": "production"}
+      "env": {"NODE_ENV": "production"},
+      "headers": {"Authorization": "Bearer plugin-token"},
+      "headersEnv": {"X-API-Key": "PLUGIN_MCP_KEY"}
     }
   }
 }"#,
@@ -994,6 +1008,14 @@ mod tests {
         assert_eq!(
             s.env.get("NODE_ENV").map(|s| s.as_str()),
             Some("production")
+        );
+        assert_eq!(
+            s.http_headers.get("Authorization").map(|s| s.as_str()),
+            Some("Bearer plugin-token")
+        );
+        assert_eq!(
+            s.http_headers_env.get("X-API-Key").map(|s| s.as_str()),
+            Some("PLUGIN_MCP_KEY")
         );
     }
 }


### PR DESCRIPTION
## Summary
- add HTTP header and env-backed header support for MCP server config
- propagate auth/header fields through configured and plugin-discovered MCP servers
- send configured headers on HTTP MCP requests and cover with transport/parser tests

## Testing
- cargo test -p rune-config mcp_servers_load_from_file
- cargo test -p rune-mcp
- cargo test -p rune-runtime mcp -- --nocapture
- cargo test -p rune-gateway-app --quiet